### PR TITLE
docs: remove stale claims for AI-context clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ frontend) and **Spring Boot 3** (backend). The design resolution is 417x614 (por
 ### Backend
 
 - **Spring Boot 3 (Java 17+)** — REST + WebSocket (STOMP)
-- **Spring Data JPA + MySQL/PostgreSQL** — persistence
+- **Spring Data JPA + PostgreSQL** — persistence (Flyway migrations)
 - **Spring Security + JWT** — stateless auth (nickname-based for MVP)
 - **spring-boot-starter-websocket** — built-in STOMP broker
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,13 @@ All endpoints require `Authorization: Bearer <token>` except `/api/auth/dev`.
 - `/topic/game/{gameId}` — public events
 - `/user/queue/private` — your private events (role, seer result)
 
-**Key action types:** `CONFIRM_ROLE`, `WOLF_KILL`, `SEER_CHECK`, `SEER_CONFIRM`, `WITCH_ACT`, `GUARD_PROTECT`,
-`GUARD_SKIP`, `REVEAL_NIGHT_RESULT`, `DAY_ADVANCE`, `SUBMIT_VOTE`, `VOTING_REVEAL_TALLY`, `VOTING_CONTINUE`,
-`HUNTER_SHOOT`, `HUNTER_SKIP`, `BADGE_PASS`, `BADGE_DESTROY`
+**Key action types:** `CONFIRM_ROLE`, `START_NIGHT`, `WOLF_SELECT`, `WOLF_KILL`, `SEER_CHECK`, `SEER_CONFIRM`,
+`WITCH_ACT`, `GUARD_PROTECT`, `GUARD_SKIP`, `REVEAL_NIGHT_RESULT`, `DAY_ADVANCE`, `SUBMIT_VOTE`, `VOTING_UNVOTE`,
+`VOTING_REVEAL_TALLY`, `VOTING_CONTINUE`, `HUNTER_SHOOT`, `HUNTER_PASS`, `IDIOT_REVEAL`, `BADGE_PASS`, `BADGE_DESTROY`,
+`SHERIFF_CAMPAIGN`, `SHERIFF_QUIT_CAMPAIGN`, `SHERIFF_START_SPEECH`, `SHERIFF_ADVANCE_SPEECH`, `SHERIFF_VOTE`,
+`SHERIFF_ABSTAIN`, `SHERIFF_REVEAL_RESULT`, `SHERIFF_APPOINT`
+
+Full enum: `backend/src/main/kotlin/com/werewolf/model/Enums.kt`.
 
 ---
 

--- a/docs/adr/ADR-002-single-action-endpoint.md
+++ b/docs/adr/ADR-002-single-action-endpoint.md
@@ -6,7 +6,7 @@ status: accepted
 
 ## Context
 
-The game has ~20 distinct player actions spread across multiple phases (role reveal, sheriff election, day, voting,
+The game has ~28 distinct player actions spread across multiple phases (role reveal, sheriff election, day, voting,
 night). We needed to decide whether to expose a REST endpoint per action or one unified endpoint.
 
 ## Decision
@@ -18,19 +18,20 @@ POST /api/game/action
 { gameId, actionType: ActionType, targetUserId?, payload? }
 ```
 
-`ActionType` is a Kotlin enum (`model/Enums.kt`) covering all 21 action types:
+`ActionType` is a Kotlin enum in `backend/src/main/kotlin/com/werewolf/model/Enums.kt` — that file is the source of truth. The groups below are provided for orientation.
 
-| Group            | Actions                                                                                                       |
-|------------------|---------------------------------------------------------------------------------------------------------------|
-| Role reveal      | `CONFIRM_ROLE`                                                                                                |
-| Day              | `REVEAL_NIGHT_RESULT`, `DAY_ADVANCE`                                                                          |
-| Voting           | `SUBMIT_VOTE`, `VOTING_REVEAL_TALLY`, `VOTING_CONTINUE`                                                       |
-| Post-elimination | `HUNTER_SHOOT`, `HUNTER_SKIP`, `BADGE_PASS`, `BADGE_DESTROY`                                                  |
-| Night: wolf      | `WOLF_KILL`                                                                                                   |
-| Night: seer      | `SEER_CHECK`, `SEER_CONFIRM`                                                                                  |
-| Night: witch     | `WITCH_ACT`                                                                                                   |
-| Night: guard     | `GUARD_PROTECT`, `GUARD_SKIP`                                                                                 |
-| Sheriff election | `SHERIFF_CAMPAIGN`, `SHERIFF_QUIT`, `SHERIFF_START_SPEECH`, `SHERIFF_ADVANCE_SPEECH`, `SHERIFF_REVEAL_RESULT` |
+| Group            | Actions                                                                                                                                                  |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Role reveal      | `CONFIRM_ROLE`, `START_NIGHT`                                                                                                                            |
+| Day              | `REVEAL_NIGHT_RESULT`, `DAY_ADVANCE`                                                                                                                     |
+| Voting           | `SUBMIT_VOTE`, `VOTING_UNVOTE`, `VOTING_REVEAL_TALLY`, `VOTING_CONTINUE`                                                                                 |
+| Post-elimination | `HUNTER_SHOOT`, `HUNTER_PASS`, `BADGE_PASS`, `BADGE_DESTROY`                                                                                             |
+| Night: wolf      | `WOLF_SELECT`, `WOLF_KILL`                                                                                                                               |
+| Night: seer      | `SEER_CHECK`, `SEER_CONFIRM`                                                                                                                             |
+| Night: witch     | `WITCH_ACT`                                                                                                                                              |
+| Night: guard     | `GUARD_PROTECT`, `GUARD_SKIP`                                                                                                                            |
+| Idiot            | `IDIOT_REVEAL`                                                                                                                                           |
+| Sheriff election | `SHERIFF_CAMPAIGN`, `SHERIFF_QUIT`, `SHERIFF_QUIT_CAMPAIGN`, `SHERIFF_PASS`, `SHERIFF_START_SPEECH`, `SHERIFF_ADVANCE_SPEECH`, `SHERIFF_VOTE`, `SHERIFF_CONFIRM_VOTE`, `SHERIFF_ABSTAIN`, `SHERIFF_REVEAL_RESULT`, `SHERIFF_APPOINT` |
 
 `GameActionDispatcher` routes each `ActionType` to the appropriate pipeline or role handler. Jackson deserializes the
 string from JSON to the enum automatically.

--- a/docs/adr/ADR-007-e2e-testing-strategy.md
+++ b/docs/adr/ADR-007-e2e-testing-strategy.md
@@ -1,243 +1,86 @@
-# ADR-007 — E2E Testing Strategy
-
-**Date:** 2026-03-20
-**Status:** Accepted
-
+---
+id: ADR-007
+title: E2E Testing Strategy
+status: accepted
 ---
 
 ## Context
 
-As the Werewolf game grows in complexity (multi-phase game loop, per-role private events, action gating), we need a
-testing strategy that:
+Werewolf has many phase transitions, per-role private events and action-gating rules. We need
+automated coverage at three levels:
 
-1. **Correctness** — each phase transition fires only when the right actions complete; wrong phases reject actions
-2. **Role visibility** — each player receives exactly the private info their role entitles them to (no role leaks)
-3. **Action gating** — roles can only execute their allowed actions; others are rejected
-4. **Design fidelity** — what each player sees in the browser matches the design spec per phase
-
-Manual testing with multiple browser windows does not scale. We need automated, reproducible coverage at each layer.
-
----
+1. **Rule correctness** — actions accepted or rejected in the right sub-phase.
+2. **Role isolation** — each player receives only the private info their role entitles them to.
+3. **UI correctness** — the right screen is rendered for each phase and role.
 
 ## Decision
 
-We adopt a **three-layer testing architecture** unified by a shared **Scenario Fixture** format.
+Two test layers, both in the frontend (`frontend/`), plus backend JUnit unit tests on the Kotlin
+side. Intentionally no bespoke Spring "scenario fixture" layer — the real-backend Playwright
+suite gives us integration-level coverage while exercising the same code paths real clients use.
 
-```
-┌─────────────────────────────────────────────────────┐
-│  Game Scenario (Kotlin data class or YAML fixture)  │
-│  • player count, role assignments                   │
-│  • action sequence (who does what, when)            │
-│  • expected events per player per phase             │
-└────────────────┬────────────────┬───────────────────┘
-                 │                │
-    ┌────────────▼──────┐  ┌──────▼──────────────────┐
-    │ Spring Integration│  │ Playwright Multi-Context │
-    │    Tests (B)      │  │     Visual E2E (C)       │
-    │                   │  │                          │
-    │ - Real Spring ctx │  │ - N browser contexts     │
-    │ - Real DB         │  │ - Real backend           │
-    │ - STOMP clients   │  │ - Screenshot each phase  │
-    │ - Assert events   │  │ - HTML visual report     │
-    └───────────────────┘  └──────────────────────────┘
-```
+### Layer 1 — Backend unit tests (Kotlin, JUnit 5)
 
----
+Location: `backend/src/test/kotlin/com/werewolf/unit/`.
 
-## Layer 1 — Scenario Fixtures
+Covers role handlers, voting pipeline, tally calculator, night orchestrator helpers, and the
+action dispatcher in isolation. Focus is on acceptance/rejection rules per sub-phase and on
+state transitions, with mocked repositories.
 
-**File:** `backend/src/test/kotlin/com/werewolf/test/scenarios/GameScenario.kt`
+Run: `cd backend && ./gradlew test`.
 
-```kotlin
-data class GameScenario(
-    val name: String,
-    val players: List<PlayerSpec>,           // nickname + role
-    val roomConfig: RoomConfig,              // hasSeer, hasWitch, etc.
-    val steps: List<ScenarioStep>,           // ordered action sequence
-)
+### Layer 2 — Frontend unit / component tests (Vitest)
 
-data class PlayerSpec(val nickname: String, val role: PlayerRole)
+Location: `frontend/src/__tests__/` and co-located `*.test.ts` files.
 
-data class ScenarioStep(
-    val description: String,
-    val actions: List<PlayerAction>,         // what each player does this step
-    val expectBroadcast: List<EventMatcher>, // /topic/game/{id} assertions
-    val expectPrivate: Map<String, List<EventMatcher>>, // /user/queue/private per nickname
-    val expectPhase: PhaseAssertion?,        // phase + subPhase after step
-    val expectRejected: List<RejectionSpec>? = null, // actions that must fail
-)
-```
+Covers Pinia stores, action dispatch wiring, and component rendering with mocked services.
 
-### Built-in Scenarios
+Run: `cd frontend && npx vitest run`.
 
-| Scenario                 | Players | Roles                                    | Notes                                  |
-|--------------------------|---------|------------------------------------------|----------------------------------------|
-| `StandardSixPlayer`      | 6       | 2W, Seer, Witch, Hunter, Villager        | Full happy path, wolves win            |
-| `StandardSixVillagerWin` | 6       | 2W, Seer, Witch, Hunter, Villager        | Villagers win by day 2                 |
-| `MinimalFourPlayer`      | 4       | 2W, 2 Villager                           | No special roles                       |
-| `WithGuard`              | 7       | 2W, Seer, Witch, Hunter, Guard, Villager | Guard saves wolf target                |
-| `WitchPoisonPath`        | 6       | 2W, Seer, Witch, Hunter, Villager        | Witch uses poison not antidote         |
-| `HunterShootsAfterVote`  | 6       | 2W, Seer, Witch, Hunter, Villager        | Hunter eliminated by vote, shoots back |
-| `TieVote`                | 6       | 2W, Seer, Witch, Hunter, Villager        | Vote ties, no elimination              |
-| `SheriffElectionPath`    | 6       | 2W, Seer, Witch, Hunter, Villager        | Election enabled                       |
+### Layer 3 — UI E2E with mocked backend (Playwright)
 
----
+Config: `frontend/playwright.config.ts`. Specs: `frontend/e2e/*.spec.ts` (top level).
 
-## Layer 2 — Spring Integration Tests
+Uses the axios mock adapter in `frontend/src/mocks/` to simulate the backend. Covers view-layer
+flows without requiring a running backend. Fast and deterministic.
 
-**Location:** `backend/src/test/kotlin/com/werewolf/test/integration/`
+Run: `cd frontend && npx playwright test`.
 
-### Setup
+### Layer 4 — Real-backend E2E (Playwright, multi-browser)
 
-```kotlin
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-class GameFlowIntegrationTest {
+Config: `frontend/playwright.real.config.ts`. Specs: `frontend/e2e/real/*.spec.ts`.
 
-    // One WebSocketStompClient per player
-    // Connected via ws://localhost:{port}/ws
-    // Each has own JWT (from POST /api/auth/dev)
-    // Each subscribes to /topic/game/{gameId} + /user/queue/private
+Each player runs in its own `BrowserContext` with its own STOMP connection. Tests drive bots via
+shell helpers (`scripts/join-room.sh`, `scripts/act.sh`) and verify UI state, phase transitions,
+and per-role private events end-to-end. This is the layer that catches backend/frontend
+integration regressions.
 
-    // Message collection: CopyOnWriteArrayList<> per player
-    // Assertions: Awaitility.await().atMost(5, SECONDS).until { ... }
-}
-```
+Helpers live in `frontend/e2e/real/helpers/`:
+- `assertions.ts` — backend-state snapshots + cross-browser phase assertions (with a CI timeout
+  scale).
+- `multi-browser.ts` — spawns N `BrowserContext`s and wires them to one room.
+- `shell-runner.ts` — wraps `act.sh` with retry/logging for race-prone actions.
+- `composite-screenshot.ts` — arranges per-player screenshots into a single image for regression
+  review.
 
-### What each test verifies per ScenarioStep
+Key specs: `game-flow`, `flow-12p-sheriff`, `sheriff-flow`, `revote-flow`, `idiot-flow`,
+`guard-audio-sequence`, `dead-role-audio`, `werewolf-win`.
 
-1. **Phase transition** — `game.phase` + `game.subPhase` match `expectPhase` after step actions
-2. **Broadcast events** — `/topic/game/{gameId}` messages match `expectBroadcast` (type + key fields)
-3. **Private events** — each player's `/user/queue/private` inbox matches `expectPrivate[nickname]`
-4. **Role info isolation** — WEREWOLF players get teammate list; SEER gets check result; others do not
-5. **Action gating** — actions in `expectRejected` return `GameActionResult.Rejected` (not accepted)
+Run: `cd frontend && npx playwright test --config=playwright.real.config.ts`.
+Full regression (boots backend + DB + both CLASSIC and HARD_MODE):
+`./scripts/run-e2e-full-flow.sh`.
 
-### Key files
+CI runs Layer 4 as a 3-way sharded matrix — see `.github/workflows/ci.yml`.
 
-| File                         | Purpose                                               |
-|------------------------------|-------------------------------------------------------|
-| `GameFlowIntegrationTest.kt` | Main test class, scenario runner                      |
-| `StompTestClient.kt`         | Wraps `WebSocketStompClient`, collects messages       |
-| `ScenarioRunner.kt`          | Drives a `GameScenario` through HTTP + STOMP          |
-| `EventMatcher.kt`            | Flexible assertion on `DomainEvent` fields            |
-| `application-test.yml`       | Test profile: H2 in-memory or Testcontainers Postgres |
+## Scenario documentation
 
-### Dependencies to add to `build.gradle.kts`
-
-```kotlin
-testImplementation("org.awaitility:awaitility-kotlin:4.2.1")
-testImplementation("org.springframework.boot:spring-boot-starter-websocket")
-// For Testcontainers (optional, alternative to H2):
-testImplementation("org.testcontainers:postgresql:1.19.3")
-testImplementation("org.testcontainers:junit-jupiter:1.19.3")
-```
-
----
-
-## Layer 3 — Playwright Visual E2E
-
-**Location:** `frontend/e2e/full-flow/`
-
-### Setup
-
-Each player = separate `BrowserContext` (own cookies, own localStorage, own WebSocket connection).
-
-```typescript
-// e2e/full-flow/standard-six-player.spec.ts
-test('6-player standard game — wolves win', async ({browser}) => {
-    const players = await createPlayerContexts(browser, 6)
-    // players[0] = host (Alice), players[1..5] = guests
-
-    // Step 1: All join room
-    // Step 2: Host starts game
-    // Step 3: All confirm roles → screenshot each player's role reveal
-    // Step 4: Night phase — wolves pick, seer checks, witch acts
-    // Step 5: Day phase → screenshot each player's day view
-    // Step 6: Vote → screenshot tally
-    // Step 7: Repeat until game over → screenshot result screen
-})
-```
-
-### Screenshot Strategy
-
-At each phase transition, capture all N player views into a named directory:
-
-```
-playwright-report/
-  visual/
-    standard-6-player/
-      step-01-role-reveal/
-        alice-WEREWOLF.png
-        bob-WEREWOLF.png
-        carol-SEER.png
-        dave-WITCH.png
-        eve-HUNTER.png
-        frank-VILLAGER.png
-      step-02-night-werewolf-pick/
-        alice-WEREWOLF.png    ← sees wolf UI (targeting)
-        carol-SEER.png        ← sees waiting UI
-      step-03-day-result-hidden/
-        ...
-```
-
-### What each screenshot verifies
-
-- **Role reveal**: correct role name, correct teammate display (wolves see each other, others don't)
-- **Night pick**: only the active role sees targeting UI; others see "waiting" screen
-- **Day**: all see same killed player list
-- **Voting**: all see same tally; eliminated player's role revealed
-- **Game over**: winner banner, all roles revealed
-
-### Helper utilities
-
-| File                                     | Purpose                                                 |
-|------------------------------------------|---------------------------------------------------------|
-| `e2e/full-flow/helpers/playerContext.ts` | `createPlayerContexts(browser, n)` — auth, join room    |
-| `e2e/full-flow/helpers/gameDriver.ts`    | `advancePhase(players, step)` — drives scenario step    |
-| `e2e/full-flow/helpers/screenshotAll.ts` | `screenshotAll(players, stepName)` — captures all views |
-| `e2e/full-flow/scenarios/standardSix.ts` | Scenario data (mirrors backend `StandardSixPlayer`)     |
-
----
-
-## Test Profile Config
-
-**`backend/src/test/resources/application-test.yml`**
-
-```yaml
-spring:
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
-    driver-class-name: org.h2.Driver
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-  flyway:
-    enabled: false   # Let Hibernate manage schema in tests
-```
-
-*(Alternative: Testcontainers Postgres for closer-to-prod fidelity)*
-
----
+Scenarios in `docs/scenarios/` are the source of truth for what a given flow should do. Assertions
+in the real-backend specs should be derivable from those docs.
 
 ## Consequences
 
-**Positive:**
-
-- Scenario fixtures serve as living documentation of game rules
-- Integration tests catch backend regressions without browser overhead
-- Visual E2E screenshots catch UI regressions and role-visibility bugs simultaneously
-- A single scenario description drives both backend and frontend tests
-
-**Negative:**
-
-- Multi-context Playwright tests are slower (~30–60 s per scenario)
-- Maintaining scenario fixtures requires updating when game rules change
-- H2 in-memory DB may diverge from production Postgres behavior (mitigated by Testcontainers option)
-
----
-
-## Alternatives Considered
-
-- **Unit tests only**: Too granular to catch integration bugs (STOMP event routing, phase gating)
-- **Single-browser E2E**: Cannot test per-player role isolation (the key correctness concern)
-- **Cypress**: Less suitable for multi-context; Playwright's `BrowserContext` model is the right fit
+- No separate "scenario fixture" DSL to maintain — assertions live next to the Playwright specs.
+- CI wall-clock is dominated by Layer 4 (real-backend) due to STOMP timing and multi-browser
+  coordination; sharding mitigates.
+- Local-vs-CI env differences are real and sometimes subtle — see
+  `memory/feedback_e2e_ci_vs_local.md`.

--- a/docs/adr/ADR-010-night-orchestrator.md
+++ b/docs/adr/ADR-010-night-orchestrator.md
@@ -1,298 +1,85 @@
-# Werewolf Game — Backend Architecture Design
-**Date**: 2026-04-14
-**Stack**: Kotlin + Spring Boot · Vue 3 · PostgreSQL · STOMP over WebSocket
-**Scope**: Single game room, 6–12 players, one developer
-
+---
+id: ADR-010
+title: Night Phase Orchestration
+status: accepted
 ---
 
-# Context
-Building a digital Werewolf game host. The backend drives the night phase fully automatically (including audio cues via STOMP events), while the human host controls day phase pacing. A critical security requirement is that the backend must never leak which special roles have been eliminated — it achieves this by always emitting `OPEN_EYES`/`CLOSE_EYES` events for dead roles (with a fixed configurable delay), making the timing pattern indistinguishable from a live role acting.
+## Context
 
----
+The night phase is fully backend-driven: the server steps through each role in a fixed order,
+waits for that role's action (or its dead-role delay), and broadcasts audio cues via STOMP so every
+client plays the same sound at the same moment. A critical security requirement is **dead-role
+information hiding**: observers must not be able to infer which special roles are dead from
+audio/timing cues.
 
-## Roles (v1)
-|Role      |Night Actor  | Death Trigger                                                     |
-|--------|------------|-------------------------------------------------------------------|
-|Werewolf|	Yes — votes to kill (first vote wins)| 	No special action                                                |
-|Villager|	No| 	No special action                                                |
-|Seer|	Yes — investigates one player's role| No special action                                                 |
-|Witch|	Yes — one heal potion + one poison potion| 	No special action                                                |
-|Guard|	Yes — protects one player (not same player consecutively)	| No special action                                                 |
-|Hunter|	No night action| 	Shot triggered only when voted out by day vote                   |
-|Idiot|	No night action| 	When day-voted: revealed as Idiot, survives, loses voting rights |
+## Decision
 
------
+Drive the night phase from a single Kotlin-coroutine-based orchestrator that owns the night
+timeline and emits role-locked STOMP events for every active night role, regardless of whether
+the role's player is alive.
 
-## System Architecture
+**Implementation:** `backend/src/main/kotlin/com/werewolf/game/night/NightOrchestrator.kt`.
 
-┌─────────────────────────────────────────────────────────┐  	
-│                  Vue Frontend                           │
-│ PlayerView  │ HostView  │ SpectatorView                 │
-│ - Audio FSM │ - Controls│ - Observer only               │
-└──────────────┬──────────────────────────────────────────┘
-               │ STOMP over WebSocket
-┌──────────────▼─────────────────────────────────────────┐
-│           Spring Boot (Kotlin)                         │
-│                                                        │
-│ WebSocketConfig ──► STOMP broker configuration         │
-│ GameController ──► host/player command entry           │
-│ GameService ──► game lifecycle + phase state           │
-│ NightPhaseOrchestrator──► coroutine, drives night seq  │
-│ GameEventPublisher ──► sole owner of SimpMessaging     │
-│ GameStateRepository ──► reads/writes PostgreSQL        │
-│ RoleActionRegistry ──► maps Role → NightAction impl    │
-└──────────────┬─────────────────────────────────────────┘
-               │ JPA
-┌──────────────▼──────────────────────────────────────────┐
-│ PostgreSQL                                              │
-│ game_room │ player │ night_log │ game_action │ day_vote │
-└─────────────────────────────────────────────────────────┘
+The class collaborates with a list of `RoleHandler` plugins (one per role; see ADR-003). For each
+active role in the room's config it plays open-eyes audio, waits for the action (via
+`CompletableDeferred`), plays close-eyes audio, then advances to the next sub-phase. Each handler
+declares the `NightSubPhase` values it owns (`nightSubPhases()`), so the sequence is derived from
+active roles rather than hard-coded.
 
------
+Other collaborators (injected): `GameRepository`, `GamePlayerRepository`, `NightPhaseRepository`,
+`EliminationHistoryRepository`, `WinConditionChecker`, `StompPublisher`, `GameContextLoader`,
+`AudioService`, `ActionLogService`, `GameTimingProperties`, and a `CoroutineScope`.
 
-**Invariant**: `GameEventPublisher` is the only class that calls `SimpMessagingTemplate`. All game logic talks to the publisher, never directly to STOMP.
+## Night Order
 
-## Phase Model
+Driven by `@Order` on each handler (lowest runs first):
 
-```
-WAITING ──► NIGHT ──► DAY_PENDING ──► DAY_DISCUSSION ──► DAY_VOTING ──► GAME_OVER
-▲                                                            │
-│                                                            │
-└────────────────────────────────────────────────────────────┘ 
-               (loop: host triggers next night)
-```
+1. Werewolves — `WEREWOLF_PICK`
+2. Seer — `SEER_PICK`, `SEER_RESULT`
+3. Witch — `WITCH_ACT`
+4. Guard — `GUARD_PICK`
 
-| Phase| Who Controls                      |
-|------|-----------------------------------|
-|WAITING| Host (sets up roles, starts game) |
-|NIGHT|               Backend (fully automated coroutine)|
-|DAY_PENDING|Backend signals host when night ends|
-|DAY_DISCUSSION|Host (free discussion, no backend action)|
-|DAY_VOTING|Host opens vote; players submit; backend tallies|
-|GAME_OVER|Backend broadcasts winner|
+Role sub-phases whose `hasXxx` flag is `false` are skipped entirely (no open-eyes, no close-eyes,
+no audio).
 
-----
+## Dead-Role Information Hiding
 
+A special role that is dead still produces observable audio and timing consistent with a live
+role. Without this, listeners could infer who is dead from silence.
 
-## Night Phase Orchestrator (Kotlin Coroutines)
-### Night Order
-1. **Werewolves**
-2. **Seer**
-3. **Witch** 
-4. **Guard**
+| Live Role                                                     | Dead Role                                             |
+|---------------------------------------------------------------|-------------------------------------------------------|
+| Broadcast open-eyes → wait up to `actionWindowMs` → close-eyes | Broadcast open-eyes → `delay(deadRoleDelayMs)` → close-eyes |
+| Private action prompt sent to the role's player                | Nothing private is sent                                 |
+| Action mutates game state                                     | No state change                                        |
 
+`deadRoleDelayMs` is calibrated per role (see `GameTimingProperties` / `rooms.config` JSONB — V9
+migration) to match the typical acting time of a live role.
 
+## Complex Rules (owned by the orchestrator + role handlers)
 
-### Coroutine Design
+- **Werewolf vote — first vote wins.** The first `WOLF_KILL` completes the deferred; subsequent
+  submissions are rejected.
+- **Witch single-use.** Antidote and poison are each once-per-game; enforced by `WitchHandler`.
+  Can't use both the same night. State persists in `night_phases` columns.
+- **Guard consecutive rule.** Guard cannot protect the same player two nights in a row; prior
+  target is stored in `night_phases.prev_guard_target_user_id`. Self-protect is allowed.
+- **Hunter — day-vote only.** Hunter's revenge shot is triggered exclusively by
+  `DAY_VOTING / HUNTER_SHOOT`. Night kills do **not** trigger the hunter.
+- **Idiot — day-vote reveal.** On first vote-elimination the idiot is revealed, stays alive, and
+  loses their vote right (`game_players.idiot_revealed = true`, `can_vote = false`). Second
+  vote-elimination kills normally.
+- **Win condition check** runs after each death event (night resolution, hunter shot, vote
+  elimination). Logic in `WinConditionChecker` — mode is `CLASSIC` vs `HARD_MODE`
+  (`rooms.win_condition`).
 
-```kotlin
-class NightPhaseOrchestrator( 
-    private val room: GameRoom, 
-    private val publisher: GameEventPublisher, 
-    private val actionRegistry: RoleActionRegistry, 
-    private val scope: CoroutineScope
-){ 
-    private val pendingActions = ConcurrentHashMap<Role, CompletableDeferred<ActionResult?>>() 
-    fun start(): Job = scope.launch { 
-        val nightOrder = listOf(WEREWOLF, SEER, WITCH, GUARD)
-        for (role in nightOrder) { 
-            val alivePlayers = getAlivePlayers(role) 
-            val config = room.config.roleConfig(role) 
-            publisher.broadcastNightEvent(OPEN_EYES, role) 
-            if (alivePlayers.isNotEmpty()) { 
-                val deferred = CompletableDeferred<ActionResult?>() 
-                pendingActions[role] = deferred 
-                alivePlayers.forEach { player -> 
-                    publisher.sendActionPrompt(player, role, buildPrompt(role)) 
-                } 
-                val action = withTimeoutOrNull(config.actionWindowMs) { deferred.await() } 
-                actionRegistry.process(role, action) 
-                pendingActions.remove(role) 
-            } else { 
-                delay(config.deadRoleDelayMs) // simulate dead role — identical timing 
-            } 
-            publisher.broadcastNightEvent(CLOSE_EYES, role) 
-        } 
-        resolveNightOutcome() 
-        publisher.notifyHost(NIGHT_RESULTS_READY) 
-    } 
-    fun submitAction(role: Role, action: ActionResult) { 
-        pendingActions[role]?.complete(action) 
-    }
-}
-```
- 
+## Consequences
 
-**Key properties:**
-- The `Job` reference is stored in `GameService`. Calling `job.cancel()` cleanly aborts the night.
-- Dead role path: `OPEN_EYES` sent → `delay(deadRoleDelayMs)` → `CLOSE_EYES` sent. Same broadcast, same audio. No action prompt ever sent.
-- Werewolf: first `submitAction()` call wins. Subsequent calls from other werewolves are ignored (deferred already completed).
-
----
-
-## Dead Role Information Hiding Protocol
-
-When a special role is dead, the backend must produce identical observable behavior to a live role. This prevents players from inferring deaths from audio/timing cues.
-
-| Live Role | Dead Role |
-|-----------|-----------|
-| `OPEN_EYES` broadcast → wait up to `actionWindowMs` → `CLOSE_EYES` | `OPEN_EYES` broadcast → `delay(deadRoleDelayMs)` → `CLOSE_EYES` |
-| `ROLE_ACTION` sent to player | Nothing sent (dead player sees no action panel) |
-| Action resolves game state | No game state change |
-
-`deadRoleDelayMs` should be calibrated to approximate the typical action time for that role (configured in `game_room.config` JSONB).
-
----
-## STOMP Topic Design
-### Channels
-
-```
-Server → Client (subscribe)
-────────────────────────────────────────────────────
-/topic/game/{roomId}/events ← broadcast ALL players
-/topic/game/{roomId}/host ← host-only events
-/user/queue/game/action ← private per-player prompts
-/user/queue/game/state ← private player state on join/reconnect
-
-Client → Server (send)
-────────────────────────────────────────────────────
-/app/game/join ← player joins room
-/app/game/action ← player submits night action
-/app/game/vote ← player casts day vote
-/app/game/host/reveal ← host reveals night results to all
-/app/game/host/vote-start ← host opens day voting
-/app/game/host/start-night ← host triggers next night
-```
-
-### Event Payloads
-**Broadcast (night events):**
-```
-json{"type": "OPEN_EYES","role": "seer","phase": "NIGHT","nightNumber": 2}
-```
-**Private action prompt (`/user/queue/game/action`):**
-```
-json{"type": "ROLE_ACTION","role": "witch","actionType": "WITCH_POTIONS","victimId": "player-3","canHeal": true,"canPoison": true,"targets": ["player-1", "player-4", "player-7"],"timeoutMs": 25000}
-```
-### Audio Contract (Frontend Responsibility)
-
-```
-On OPEN_EYES { role: "witch" } → play witch_open_eyes.mp3
-On CLOSE_EYES { role: "witch" } → play witch_close_eyes.mp3
-On ROLE_ACTION received → show action panel (player alive check on frontend)
-```
-
-Audio is played for **every** `OPEN_EYES`/`CLOSE_EYES` event regardless of whether the local player is the named role or whether that role is dead. This is correct behavior — it preserves the game's information hiding.
-
----
-
-## PostgreSQL Schema
-
-```sql
-CREATE TABLE game_room (id UUID PRIMARY KEY DEFAULT gen_random_uuid(),code VARCHAR(6) UNIQUE NOT NULL,status VARCHAR(20) NOT NULL DEFAULT 'WAITING',night_number INT NOT NULL DEFAULT 0,config JSONB NOT NULL DEFAULT '{}',created_at TIMESTAMP NOT NULL DEFAULT NOW());
-CREATE TABLE player (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    room_id UUID NOT NULL REFERENCES game_room(id),
-    name VARCHAR(50) NOT NULL,
-    role VARCHAR(30),
-    status VARCHAR(30) NOT NULL DEFAULT 'ALIVE', -- ALIVE | DEAD | IDIOT_REVEALED
-    voting_rights BOOLEAN NOT NULL DEFAULT TRUE,
-    is_host BOOLEAN NOT NULL DEFAULT FALSE,
-    session_id VARCHAR(100), -- STOMP session for /user/ routing
-    created_at TIMESTAMP NOT NULL DEFAULT NOW()
-);
-CREATE TABLE night_log (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),room_id UUID NOT NULL REFERENCES game_room(id),night_number INT NOT NULL,werewolf_target_id UUID REFERENCES player(id),guard_protected_id UUID REFERENCES player(id),witch_healed BOOLEAN NOT NULL DEFAULT FALSE,witch_poisoned_id UUID REFERENCES player(id),
-    final_dead_id UUID REFERENCES player(id), -- net result
-    created_at TIMESTAMP NOT NULL DEFAULT NOW());
-CREATE TABLE game_action (id UUID PRIMARY KEY DEFAULT gen_random_uuid(),room_id UUID NOT NULL REFERENCES game_room(id),night_number INT NOT NULL,player_id UUID NOT NULL REFERENCES player(id),action_type VARCHAR(30) NOT NULL, -- WEREWOLF_VOTE | INVESTIGATE | GUARD | WITCH_HEAL | WITCH_POISON
-target_id UUID REFERENCES player(id),created_at TIMESTAMP NOT NULL DEFAULT NOW());
-CREATE TABLE day_vote (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    room_id UUID NOT NULL REFERENCES game_room(id),
-    night_number INT NOT NULL, -- day N follows night N
-    voter_id UUID NOT NULL REFERENCES player(id),target_id UUID NOT NULL REFERENCES player(id),created_at TIMESTAMP NOT NULL DEFAULT NOW());
-```
-**`config` JSONB structure:**
-```json
-{"roleDelays": {"WEREWOLF": { "actionWindowMs": 30000, "deadRoleDelayMs": 25000 },"SEER": { "actionWindowMs": 20000, "deadRoleDelayMs": 15000 },"WITCH": { "actionWindowMs": 25000, "deadRoleDelayMs": 20000 },"GUARD": { "actionWindowMs": 20000, "deadRoleDelayMs": 15000 }}}
-```
----
-
-## Complex Rules
-### Night Outcome Resolution (order matters)
-
-```
-1. Werewolf vote → sets candidateVictim
-2. Witch heal → if witchHealed, victim = null (uses heal potion)
-3. Witch poison → poisonTarget added to finalDead5. finalDead = victim (if not null) + poisonTarget (if any)
-4. Guard protection → if guardTarget == candidateVictim, victim = null
-```
-
-### Hunter — Day Vote Only
-- Hunter night death: silent, no special action
-- Hunter day vote elimination:
-1. Pause vote resolution
-2. Send `ROLE_ACTION { actionType: HUNTER_SHOOT }` to Hunter
-3. Await target selection (with timeout; no shot if no response)
-4. Kill target → check win condition
-5. Resume / close day phase
-
-### Idiot — Day Vote Reveal
-When Idiot receives majority day vote:
-1. Do NOT eliminate
-2. Broadcast `IDIOT_REVEALED { playerId }` to all
-3. Set `player.status = IDIOT_REVEALED`, `player.voting_rights = false`
-4. Continue game — Idiot stays alive without voting rights
-
-### Guard — Consecutive Protection Rule
-Before accepting Guard's action, validate:
-```kotlin
-val lastNight = nightLogRepo.findByRoomAndNight(roomId, nightNumber - 1)require(lastNight?.guardProtectedId != targetId) { "Cannot protect same player consecutively" }
-```
-### Witch Potions — Single Use
-Track on `NightPhaseOrchestrator` instance:
-```kotlin
-var healUsed: Boolean = falsevar poisonUsed: Boolean = false
-```
-Persisted in `night_log.witch_healed` and `night_log.witch_poisoned_id` for auditability. Witch action prompt only includes available potions.
-
-### Werewolf Vote — First Vote Wins
-First werewolf to submit an action resolves the `CompletableDeferred`. Subsequent submissions are ignored (deferred already completed). No consensus mechanism.
-
-### Win Condition
-Evaluated after every death event:
-```kotlin
-fun checkWinCondition(roomId: UUID): WinResult? {val alive = playerRepo.findAliveByRoom(roomId)val werewolves = alive.count { it.role == WEREWOLF }val village = alive.size - werewolvesreturn when {werewolves == 0 -> VILLAGE_WINSwerewolves >= village -> WEREWOLF_WINSelse -> null}}
-```
-
-Win condition is checked:
-- After `resolveNightOutcome()`
-- After Hunter shot resolves
-- After each day vote elimination
-
----
-## Extensibility for Future Roles
-
-The `RoleActionRegistry` maps `Role → NightAction` interface:
-```kotlin
-interface NightAction {
-    val role: Role
-    val nightOrderIndex: Int // determines sequence position
-    val actionWindowMs: Long // live player window
-    val deadRoleDelayMs: Long // simulated window when dead
-suspend fun buildPrompt(player: Player, room: GameRoom): ActionPrompt
-suspend fun process(action: ActionResult?, room: GameRoom)}
-```
-
-Adding a new role = implementing `NightAction` + registering it. Night order is derived from `nightOrderIndex`. No changes to `NightPhaseOrchestrator` itself.
-
----
-## Verification Plan
-1. **Night phase flow**: Start a game with 2 werewolves, 1 seer, 1 witch, 1 guard. Observe STOMP events in browser dev tools — confirm `OPEN_EYES`/`CLOSE_EYES` events fire in correct order with correct timing.
-2. **Dead role hiding**: Kill the Seer on night 1. On night 2, confirm `OPEN_EYES {role: seer}` and `CLOSE_EYES {role: seer}` still broadcast with the configured delay between them. Confirm no `ROLE_ACTION` is sent.
-3. **Guard consecutive rule**: Have Guard protect player A on night 1. On night 2, attempt to protect A again — confirm the action is rejected.
-4. **Witch single-use**: Have Witch use heal on night 1. On night 2, confirm `canHeal: false` in the prompt.
-5. **Hunter day vote**: Vote out Hunter during day phase — confirm `HUNTER_SHOOT` prompt fires before day phase closes.
-6. **Idiot reveal**: Vote out Idiot — confirm they stay alive with `voting_rights = false` and cannot submit a vote on the next day.
-7. **Win condition**: Eliminate all werewolves — confirm `GAME_OVER { winner: VILLAGE }` broadcast fires immediately.
-8. **Coroutine cancel**: During night phase, trigger game reset — confirm the orchestrator job cancels cleanly with no orphaned actions.
+- The orchestrator is the only driver of the night timeline; `StompPublisher` is the only class
+  that calls `SimpMessagingTemplate` (see ADR-006).
+- Adding a new night role = implementing `RoleHandler` with the right `@Order` and
+  `nightSubPhases()`; no change to `NightOrchestrator`.
+- The dead-role delay is a real gameplay cost (nights get longer when many special roles die) —
+  accepted in exchange for information hiding.
+- `job.cancel()` on the stored orchestrator `Job` cleanly aborts the night without orphaned
+  actions.

--- a/docs/adr/audio.md
+++ b/docs/adr/audio.md
@@ -1,29 +1,34 @@
-音频映射
+# Audio
 
+Audio files are served by the backend from `backend/src/main/resources/static/audio/`
+(accessible as `/audio/<filename>.mp3`). The frontend triggers playback based on STOMP
+events; volume is controllable via `useAudioService()`.
 
-┌─────────────────────┬──────────────────┐
-│ 游戏阶段/子阶段     │ 音频文件         │
-├─────────────────────┼──────────────────┤
-│ NIGHT 阶段开始      │ goes_dark_close_eyes.mp3   │
-│ DAY 阶段开始        │ day_time.mp3       │
-│ NIGHT.WEREWOLF_PICK │ wolf_open_eyes.mp3   │
-│ 狼人行动结束        │ wolf_close_eyes.mp3   │
-│ NIGHT.SEER_PICK     │ seer_open_eyes.mp3 │
-│ 预言家行动结束      │ seer_close_eyes.mp3 │
-│ NIGHT.WITCH_ACT     │ witch_open_eyes.mp3   │
-│ 女巫行动结束        │ witch_close_eyes.mp3   │
-│ NIGHT.GUARD_PICK    │ guard_open_eyes.mp3   │
-│ 守卫行动结束        │ guard_close_eyes.mp3   │
-└─────────────────────┴──────────────────┘
+## Trigger Map
 
-使用方式
+| Event / sub-phase                     | File                        |
+|---------------------------------------|-----------------------------|
+| `NIGHT` enter                         | `goes_dark_close_eyes.mp3`  |
+| Night atmosphere (loop)               | `crow_night.mp3`            |
+| `NIGHT / WEREWOLF_PICK` enter         | `wolf_howl.mp3` → `wolf_open_eyes.mp3` |
+| Werewolf phase close                  | `wolf_close_eyes.mp3`       |
+| `NIGHT / SEER_PICK` enter             | `seer_open_eyes.mp3`        |
+| Seer phase close                      | `seer_close_eyes.mp3`       |
+| `NIGHT / WITCH_ACT` enter             | `witch_open_eyes.mp3`       |
+| Witch phase close                     | `witch_close_eyes.mp3`      |
+| `NIGHT / GUARD_PICK` enter            | `guard_open_eyes.mp3`       |
+| Guard phase close                     | `guard_close_eyes.mp3`      |
+| Dawn / `DAY_PENDING`                  | `rooster_crowing.mp3`       |
+| `DAY_DISCUSSION` / `DAY_VOTING` enter | `day_time.mp3`              |
 
-音频会自动根据游戏阶段播放，无需手动调用。如果需要控制音量：
+Dead roles still receive the same open-eyes → delay → close-eyes sequence (see
+ADR-010 Dead-Role Information Hiding). Audio is identical whether the role player is
+alive or dead.
 
+## Frontend usage
+
+```ts
 const { setVolume, getVolume } = useAudioService()
-
-// 设置音量（0-1）
-setVolume(0.5)
-
-// 获取当前音量
+setVolume(0.5)         // 0–1
 const volume = getVolume()
+```

--- a/docs/database-design.md
+++ b/docs/database-design.md
@@ -1,11 +1,17 @@
 # Database Design
 
-## Design Principles
+**DB:** PostgreSQL 15+. Migrations in `backend/src/main/resources/db/migration/` (Flyway).
+The migration files are the source of truth — this doc mirrors their state after V1–V10.
 
-- Keep it simple
-- Auth via **WeChat OAuth** (China) or **Google OAuth** (international)
-- Re-authenticate each game session — short-lived JWT, no persistent client session
-- Payment tables are **stubs only** — not implemented
+---
+
+## Auth
+
+- `POST /api/auth/dev` — dev-profile-only; `{nickname}` → `{token, user}` (issues a dev JWT with `userId=dev:<nickname>`). See `DevAuthController.kt`.
+- `POST /api/auth/google`, `POST /api/auth/wechat` — production OAuth code exchange. See ADR-001.
+
+JWT: HS256, 2 h expiry, payload `{ userId, nickname, avatarUrl }`.
+Attached as `Authorization: Bearer <token>` on HTTP and as a STOMP connect header on WebSocket.
 
 ---
 
@@ -13,100 +19,105 @@
 
 ### `users`
 
-Created/updated on each OAuth login.
+Created/updated on each auth call (OAuth or dev).
 
 ```sql
-CREATE TABLE users
-(
-    user_id      VARCHAR(128) PRIMARY KEY, -- provider-prefixed: "google:107..." or "wechat:oABC..."
+CREATE TABLE users (
+    user_id      VARCHAR(128) PRIMARY KEY,  -- "google:<sub>", "wechat:<openid>", or "dev:<nickname>"
     nickname     VARCHAR(50) NOT NULL,
     avatar_url   VARCHAR(500),
-    created_at   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_seen_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    created_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 ```
 
-**Auth flow:**
-
-```
-User taps "Login with Google/WeChat"
-  → OAuth redirect → POST /api/auth/google or /api/auth/wechat  {code}
-  → Backend exchanges code → upsert users row
-  → Issue JWT (2h, payload: userId + nickname + avatarUrl)
-  → Frontend stores JWT in sessionStorage
-```
-
----
-
 ### `rooms`
 
+Role/config flags determine which handlers run in each game. `config` holds JSONB role-timing tuning (see V9).
+
 ```sql
-CREATE TABLE rooms
-(
-    room_id       INT PRIMARY KEY AUTO_INCREMENT,
-    room_code     CHAR(4)                              NOT NULL UNIQUE, -- 4-digit code shared verbally
-    host_user_id  VARCHAR(128)                         NOT NULL REFERENCES users (user_id),
-    status        ENUM('WAITING', 'IN_GAME', 'CLOSED') NOT NULL DEFAULT 'WAITING',
-    total_players INT                                  NOT NULL,
-    has_seer      BOOLEAN                              NOT NULL DEFAULT FALSE,
-    has_witch     BOOLEAN                              NOT NULL DEFAULT FALSE,
-    has_hunter    BOOLEAN                              NOT NULL DEFAULT FALSE,
-    has_guard     BOOLEAN                              NOT NULL DEFAULT FALSE,
-    created_at    DATETIME                             NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    closed_at     DATETIME
+CREATE TABLE rooms (
+    room_id       SERIAL PRIMARY KEY,
+    room_code     VARCHAR(4)  NOT NULL UNIQUE,
+    host_user_id  VARCHAR(128) NOT NULL REFERENCES users(user_id),
+    status        VARCHAR(10) NOT NULL DEFAULT 'WAITING'
+                  CHECK (status IN ('WAITING','IN_GAME','CLOSED')),
+    total_players INT         NOT NULL,
+    has_seer      BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_witch     BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_hunter    BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_guard     BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_idiot     BOOLEAN     NOT NULL DEFAULT FALSE,   -- V1 / V4
+    has_sheriff   BOOLEAN     NOT NULL DEFAULT TRUE,    -- V5
+    win_condition VARCHAR(20) NOT NULL DEFAULT 'CLASSIC', -- V6: 'CLASSIC' | 'HARD_MODE'
+    config        JSONB,                                 -- V9: role delays, etc.
+    created_at    TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    closed_at     TIMESTAMP
 );
 ```
 
 ### `room_players`
 
 ```sql
-CREATE TABLE room_players
-(
-    id         INT PRIMARY KEY AUTO_INCREMENT,
-    room_id    INT                        NOT NULL REFERENCES rooms (room_id),
-    user_id    VARCHAR(128)               NOT NULL REFERENCES users (user_id),
+CREATE TABLE room_players (
+    id         SERIAL PRIMARY KEY,
+    room_id    INT          NOT NULL REFERENCES rooms(room_id),
+    user_id    VARCHAR(128) NOT NULL REFERENCES users(user_id),
     seat_index INT,
-    status     ENUM('NOT_READY', 'READY') NOT NULL DEFAULT 'NOT_READY',
-    is_host    BOOLEAN                    NOT NULL DEFAULT FALSE,
-    UNIQUE KEY uq_room_user (room_id, user_id),
-    UNIQUE KEY uq_room_seat (room_id, seat_index)
+    status     VARCHAR(10)  NOT NULL DEFAULT 'NOT_READY'
+               CHECK (status IN ('NOT_READY','READY')),
+    is_host    BOOLEAN      NOT NULL DEFAULT FALSE,
+    UNIQUE (room_id, user_id),
+    UNIQUE (room_id, seat_index)
 );
 ```
-
----
 
 ### `games`
 
 ```sql
-CREATE TABLE games
-(
-    game_id         INT PRIMARY KEY AUTO_INCREMENT,
-    room_id         INT                                                                            NOT NULL REFERENCES rooms (room_id),
-    host_user_id    VARCHAR(128)                                                                   NOT NULL REFERENCES users (user_id),
-    phase           ENUM('ROLE_REVEAL', 'SHERIFF_ELECTION', 'DAY', 'VOTING', 'NIGHT', 'GAME_OVER') NOT NULL DEFAULT 'ROLE_REVEAL',
-    day_number      INT                                                                            NOT NULL DEFAULT 1,
-    sheriff_user_id VARCHAR(128) REFERENCES users (user_id),
-    winner          ENUM('WEREWOLF', 'VILLAGER'),
-    started_at      DATETIME                                                                       NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    ended_at        DATETIME
+CREATE TABLE games (
+    game_id         SERIAL PRIMARY KEY,
+    room_id         INT          NOT NULL REFERENCES rooms(room_id),
+    host_user_id    VARCHAR(128) NOT NULL REFERENCES users(user_id),
+    phase           VARCHAR(20)  NOT NULL DEFAULT 'ROLE_REVEAL',
+    sub_phase       VARCHAR(25),                                   -- V3
+    day_number      INT          NOT NULL DEFAULT 1,
+    sheriff_user_id VARCHAR(128) REFERENCES users(user_id),
+    winner          VARCHAR(10) CHECK (winner IN ('WEREWOLF','VILLAGER')),
+    started_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ended_at        TIMESTAMP
 );
+```
+
+Check constraints (current, after V10 + V8):
+
+```sql
+-- phase
+CHECK (phase IN ('ROLE_REVEAL','SHERIFF_ELECTION','WAITING','NIGHT',
+                 'DAY_PENDING','DAY_DISCUSSION','DAY_VOTING','GAME_OVER'))
+-- sub_phase (VotingSubPhase + DaySubPhase union; NULL allowed)
+CHECK (sub_phase IN ('RESULT_HIDDEN','RESULT_REVEALED',
+                     'VOTING','RE_VOTING','VOTE_RESULT',
+                     'HUNTER_SHOOT','BADGE_HANDOVER'))
 ```
 
 ### `game_players`
 
 ```sql
-CREATE TABLE game_players
-(
-    id             INT PRIMARY KEY AUTO_INCREMENT,
-    game_id        INT                                                              NOT NULL REFERENCES games (game_id),
-    user_id        VARCHAR(128)                                                     NOT NULL REFERENCES users (user_id),
-    seat_index     INT                                                              NOT NULL,
-    role           ENUM('WEREWOLF', 'VILLAGER', 'SEER', 'WITCH', 'HUNTER', 'GUARD') NOT NULL,
-    is_alive       BOOLEAN                                                          NOT NULL DEFAULT TRUE,
-    is_sheriff     BOOLEAN                                                          NOT NULL DEFAULT FALSE,
-    confirmed_role BOOLEAN                                                          NOT NULL DEFAULT FALSE,
-    UNIQUE KEY uq_game_user (game_id, user_id),
-    UNIQUE KEY uq_game_seat (game_id, seat_index)
+CREATE TABLE game_players (
+    id             SERIAL PRIMARY KEY,
+    game_id        INT          NOT NULL REFERENCES games(game_id),
+    user_id        VARCHAR(128) NOT NULL REFERENCES users(user_id),
+    seat_index     INT          NOT NULL,
+    role           VARCHAR(10)  NOT NULL
+                   CHECK (role IN ('WEREWOLF','VILLAGER','SEER','WITCH','HUNTER','GUARD','IDIOT')),
+    is_alive       BOOLEAN      NOT NULL DEFAULT TRUE,
+    is_sheriff     BOOLEAN      NOT NULL DEFAULT FALSE,
+    confirmed_role BOOLEAN      NOT NULL DEFAULT FALSE,
+    can_vote       BOOLEAN      NOT NULL DEFAULT TRUE,    -- V7; set false on idiot reveal
+    idiot_revealed BOOLEAN      NOT NULL DEFAULT FALSE,   -- V7
+    UNIQUE (game_id, user_id),
+    UNIQUE (game_id, seat_index)
 );
 ```
 
@@ -114,26 +125,25 @@ CREATE TABLE game_players
 
 ## Night Phase
 
-### `night_phases` — one mutable row per night per game
-
-Tracks each role's action as it happens; used to resolve who dies at dawn and to send personalized private state via
-STOMP.
+One mutable row per `(game_id, day_number)`. Used to resolve dawn deaths and drive personalized STOMP private state.
 
 ```sql
-CREATE TABLE night_phases
-(
-    id                          INT PRIMARY KEY AUTO_INCREMENT,
-    game_id                     INT                                                                                      NOT NULL REFERENCES games (game_id),
-    day_number                  INT                                                                                      NOT NULL,
-    sub_phase                   ENUM('WEREWOLF_PICK', 'SEER_PICK', 'SEER_RESULT', 'WITCH_ACT', 'GUARD_PICK', 'COMPLETE') NOT NULL DEFAULT 'WEREWOLF_PICK',
-    wolf_target_user_id         VARCHAR(128) REFERENCES users (user_id),
-    seer_checked_user_id        VARCHAR(128) REFERENCES users (user_id),
+CREATE TABLE night_phases (
+    id                          SERIAL PRIMARY KEY,
+    game_id                     INT         NOT NULL REFERENCES games(game_id),
+    day_number                  INT         NOT NULL,
+    sub_phase                   VARCHAR(20) NOT NULL DEFAULT 'WAITING'
+                                CHECK (sub_phase IN
+                                  ('WAITING','WEREWOLF_PICK','SEER_PICK','SEER_RESULT',
+                                   'WITCH_ACT','GUARD_PICK','COMPLETE')),
+    wolf_target_user_id         VARCHAR(128),
+    seer_checked_user_id        VARCHAR(128),
     seer_result_is_werewolf     BOOLEAN,
-    witch_antidote_used         BOOLEAN                                                                                  NOT NULL DEFAULT FALSE,
-    witch_poison_target_user_id VARCHAR(128) REFERENCES users (user_id),
-    guard_target_user_id        VARCHAR(128) REFERENCES users (user_id),
-    prev_guard_target_user_id   VARCHAR(128) REFERENCES users (user_id),
-    UNIQUE KEY uq_game_night (game_id, day_number)
+    witch_antidote_used         BOOLEAN     NOT NULL DEFAULT FALSE,
+    witch_poison_target_user_id VARCHAR(128),
+    guard_target_user_id        VARCHAR(128),
+    prev_guard_target_user_id   VARCHAR(128),
+    UNIQUE (game_id, day_number)
 );
 ```
 
@@ -142,107 +152,91 @@ CREATE TABLE night_phases
 ## Sheriff Election
 
 ```sql
-CREATE TABLE sheriff_elections
-(
-    id                      INT PRIMARY KEY AUTO_INCREMENT,
-    game_id                 INT                                          NOT NULL UNIQUE REFERENCES games (game_id),
-    sub_phase               ENUM('SIGNUP', 'SPEECH', 'VOTING', 'RESULT') NOT NULL DEFAULT 'SIGNUP',
-    speaking_order          TEXT, -- comma-separated userIds, set once at SPEECH start
-    current_speaker_idx     INT                                          NOT NULL DEFAULT 0,
-    elected_sheriff_user_id VARCHAR(128) REFERENCES users (user_id),
-    started_at              DATETIME                                     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    completed_at            DATETIME
+CREATE TABLE sheriff_elections (
+    id                      SERIAL PRIMARY KEY,
+    game_id                 INT         NOT NULL UNIQUE REFERENCES games(game_id),
+    sub_phase               VARCHAR(10) NOT NULL DEFAULT 'SIGNUP'
+                            CHECK (sub_phase IN ('SIGNUP','SPEECH','VOTING','RESULT','TIED')),
+    speaking_order          TEXT,                   -- comma-separated userIds
+    current_speaker_idx     INT         NOT NULL DEFAULT 0,
+    elected_sheriff_user_id VARCHAR(128) REFERENCES users(user_id),
+    started_at              TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at            TIMESTAMP
 );
 
-CREATE TABLE sheriff_candidates
-(
-    id          INT PRIMARY KEY AUTO_INCREMENT,
-    election_id INT                     NOT NULL REFERENCES sheriff_elections (id),
-    user_id     VARCHAR(128)            NOT NULL REFERENCES users (user_id),
-    status      ENUM('RUNNING', 'QUIT') NOT NULL DEFAULT 'RUNNING',
-    UNIQUE KEY uq_election_user (election_id, user_id)
+CREATE TABLE sheriff_candidates (
+    id          SERIAL PRIMARY KEY,
+    election_id INT          NOT NULL REFERENCES sheriff_elections(id),
+    user_id     VARCHAR(128) NOT NULL REFERENCES users(user_id),
+    status      VARCHAR(10)  NOT NULL DEFAULT 'RUNNING'
+                CHECK (status IN ('RUNNING','QUIT')),
+    UNIQUE (election_id, user_id)
 );
 ```
+
+The `TIED` sub_phase is entered when a sheriff vote ties and a revote is needed.
 
 ---
 
-## Votes (generic — covers sheriff election + elimination)
+## Votes (generic — sheriff election + elimination)
+
+See ADR-005 for why this is a single table.
 
 ```sql
-CREATE TABLE votes
-(
-    id             INT PRIMARY KEY AUTO_INCREMENT,
-    game_id        INT                                     NOT NULL REFERENCES games (game_id),
-    vote_context   ENUM('SHERIFF_ELECTION', 'ELIMINATION') NOT NULL,
-    day_number     INT                                     NOT NULL, -- 0 for sheriff election
-    voter_user_id  VARCHAR(128)                            NOT NULL REFERENCES users (user_id),
-    target_user_id VARCHAR(128) REFERENCES users (user_id),          -- NULL = abstain/skip
-    voted_at       DATETIME                                NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY uq_vote (game_id, vote_context, day_number, voter_user_id)
+CREATE TABLE votes (
+    id             SERIAL PRIMARY KEY,
+    game_id        INT          NOT NULL REFERENCES games(game_id),
+    vote_context   VARCHAR(20)  NOT NULL
+                   CHECK (vote_context IN ('SHERIFF_ELECTION','ELIMINATION')),
+    day_number     INT          NOT NULL,   -- 0 for sheriff election
+    voter_user_id  VARCHAR(128) NOT NULL REFERENCES users(user_id),
+    target_user_id VARCHAR(128) REFERENCES users(user_id),  -- NULL = abstain
+    voted_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (game_id, vote_context, day_number, voter_user_id)
 );
 ```
+
+Sheriff weight (1.5× for the sheriff's vote during `ELIMINATION`) is applied at tally time, not stored here. See ADR-009 and `TallyCalculator.kt`.
 
 ---
 
 ## Elimination History
 
 ```sql
-CREATE TABLE elimination_history
-(
-    id                  INT PRIMARY KEY AUTO_INCREMENT,
-    game_id             INT      NOT NULL REFERENCES games (game_id),
-    day_number          INT      NOT NULL,
-    eliminated_user_id  VARCHAR(128) REFERENCES users (user_id),
-    eliminated_role     ENUM('WEREWOLF', 'VILLAGER', 'SEER', 'WITCH', 'HUNTER', 'GUARD'),
-    hunter_shot_user_id VARCHAR(128) REFERENCES users (user_id),
-    hunter_shot_role    ENUM('WEREWOLF', 'VILLAGER', 'SEER', 'WITCH', 'HUNTER', 'GUARD'),
-    recorded_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY uq_game_day (game_id, day_number)
+CREATE TABLE elimination_history (
+    id                  SERIAL PRIMARY KEY,
+    game_id             INT       NOT NULL REFERENCES games(game_id),
+    day_number          INT       NOT NULL,
+    eliminated_user_id  VARCHAR(128),
+    eliminated_role     VARCHAR(10) CHECK (eliminated_role IN
+                        ('WEREWOLF','VILLAGER','SEER','WITCH','HUNTER','GUARD','IDIOT')),
+    hunter_shot_user_id VARCHAR(128),
+    hunter_shot_role    VARCHAR(10) CHECK (hunter_shot_role IN
+                        ('WEREWOLF','VILLAGER','SEER','WITCH','HUNTER','GUARD','IDIOT')),
+    recorded_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (game_id, day_number)
 );
 ```
-
----
 
 ## Event Log
 
 ```sql
-CREATE TABLE game_events
-(
-    id             INT PRIMARY KEY AUTO_INCREMENT,
-    game_id        INT         NOT NULL REFERENCES games (game_id),
+CREATE TABLE game_events (
+    id             SERIAL PRIMARY KEY,
+    game_id        INT         NOT NULL REFERENCES games(game_id),
     event_type     VARCHAR(50) NOT NULL,
     message        TEXT        NOT NULL,
-    target_user_id VARCHAR(128) REFERENCES users (user_id),
-    created_at     DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    INDEX          idx_game_events(game_id)
+    target_user_id VARCHAR(128) REFERENCES users(user_id),
+    created_at     TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+CREATE INDEX idx_game_events ON game_events(game_id);
 ```
 
 ---
 
-## Payment — Placeholder (Not Implemented)
+## Payment — Placeholder
 
-Model when ready: 房卡 (Room Card) — host spends 1 card per game, guests join free.
-
-```sql
--- PLACEHOLDER — implement when payment is ready
--- wallet_accounts  (user_id FK, room_cards INT)
--- products         (product_key, room_cards, bonus_cards, price_fen)
--- payment_orders   (order_no, user_id, product_id, status, payment_channel, external_order_id)
--- payment_callbacks (order_id, raw_payload, signature_valid)
--- card_transactions (user_id, type PURCHASE/SPEND/REFUND, amount, balance_after, game_id)
-```
-
-Provider options: WeChat Pay H5 + Alipay WAP via Ping++ aggregator, or Stripe for international.
-
----
-
-## Auth Endpoints
-
-| Method | Path               | Description                |
-|--------|--------------------|----------------------------|
-| POST   | `/api/auth/google` | `{code}` → `{token, user}` |
-| POST   | `/api/auth/wechat` | `{code}` → `{token, user}` |
+Stub only. V2 migration contains commented-out scaffolding for a future 房卡 (room-card) system. Not implemented.
 
 ---
 
@@ -250,23 +244,21 @@ Provider options: WeChat Pay H5 + Alipay WAP via Ping++ aggregator, or Stripe fo
 
 ```
 users
-  ├─ rooms (host_user_id)
+  ├─ rooms                (host_user_id)
   │    └─ room_players
-  └─ games (host_user_id)
+  └─ games                (host_user_id)
        ├─ game_players
        ├─ night_phases        (one per day_number)
-       ├─ sheriff_elections   (1:1)
-       │    └─ sheriff_candidates
-       ├─ votes               (SHERIFF_ELECTION + ELIMINATION)
+       ├─ sheriff_elections   (1:1, candidates under it)
+       ├─ votes               (SHERIFF_ELECTION day=0 + ELIMINATION day=N)
        ├─ elimination_history (one per day_number)
        └─ game_events
 ```
 
 ---
 
-## Implementation Notes
+## Notes
 
-- **DB**: MySQL 8+ or PostgreSQL 15+
-- **Migrations**: Flyway — `V1__core.sql`, `V2__payment_stub.sql` (comment only)
-- **OAuth**: Spring Security OAuth2 Client — built-in Google; WeChat needs custom `OAuth2UserService`
-- **JWT**: `jjwt` — HS256, 2h expiry
+- Entity classes live at `backend/src/main/kotlin/com/werewolf/model/*.kt`.
+- Enum values in CHECK constraints must match `Enums.kt` — always update V__ migrations when an enum value is added (see V8 for `RE_VOTING`, V10 for `phase`).
+- String-backed enums in `games.sub_phase` hold values from either `DaySubPhase` or `VotingSubPhase` — the union is documented in ADR-004.

--- a/docs/real-backend-testing.md
+++ b/docs/real-backend-testing.md
@@ -339,7 +339,7 @@ curl -s -X POST http://localhost:8080/api/game/action \
 # ────────────────────────────────────────────────────────────────────
 ./scripts/act.sh HUNTER_SHOOT $HUNTER_NICK --target <seat>
 # OR hunter passes:
-./scripts/act.sh HUNTER_SKIP $HUNTER_NICK
+./scripts/act.sh HUNTER_PASS $HUNTER_NICK
 
 # If hunter's target was NOT the sheriff → goes to night
 # If hunter's target WAS the sheriff → subPhase = BADGE_HANDOVER (see Case C)

--- a/docs/scenarios/README.md
+++ b/docs/scenarios/README.md
@@ -1,7 +1,8 @@
 # Werewolf Game — Scenario Documentation Index
 
-This directory is the **single source of truth** for implementing backend integration tests (Spring + STOMP) and
-frontend visual E2E tests (Playwright). Every assertion a test makes should be derivable from these documents.
+This directory is the **single source of truth** for the design intent of each scenario, and for the assertions
+made by Playwright real-backend E2E tests (`frontend/e2e/real/`) and frontend unit tests. Every assertion a test
+makes should be derivable from these documents.
 
 ---
 
@@ -13,9 +14,11 @@ frontend visual E2E tests (Playwright). Every assertion a test makes should be d
 | 02 | [scenario-02-standard-six-villagers-win.md](scenario-02-standard-six-villagers-win.md) | 6 (W×2, S, Wi, H, V)    | Villagers win Day 2   | Seer leads to wolf elimination, villager win path       |
 | 03 | [scenario-03-minimal-four-player.md](scenario-03-minimal-four-player.md)               | 4 (W×2, V×2)            | Wolves win Night 1    | Minimal flow, immediate win condition, no special roles |
 | 04 | [scenario-04-witch-poison-path.md](scenario-04-witch-poison-path.md)                   | 6 (W×2, S, Wi, H, V)    | Villagers win Night 2 | Witch poison mechanic, dual-death night resolve         |
-| 05 | [scenario-05-hunter-shoots-after-vote.md](scenario-05-hunter-shoots-after-vote.md)     | 6 (W×2, S, Wi, H, V)    | Villagers win Day 2   | Hunter shoot on elimination, HUNTER_SKIP variant        |
+| 05 | [scenario-05-hunter-shoots-after-vote.md](scenario-05-hunter-shoots-after-vote.md)     | 6 (W×2, S, Wi, H, V)    | Villagers win Day 2   | Hunter shoot on elimination, HUNTER_PASS variant        |
 | 06 | [scenario-06-tie-vote.md](scenario-06-tie-vote.md)                                     | 6 (W×2, S, Wi, H, V)    | Villagers win Day 3   | Tie vote → no elimination, VOTING_CONTINUE              |
 | 07 | [scenario-07-with-guard.md](scenario-07-with-guard.md)                                 | 7 (W×2, S, Wi, H, G, V) | TBD (mid-game)        | Guard protect, same-player repeat rejection             |
+| 08 | [scenario-08-with-idiot.md](scenario-08-with-idiot.md)                                 | 6 (W×2, S, I, H, V)     | Mid-game (see doc)    | Idiot reveal on vote, loses vote right, stays alive     |
+| 09 | [scenario-09-e2e.md](scenario-09-e2e.md)                                               | 12 (hard mode)          | see doc               | HARD_MODE win condition, full 12-player regression      |
 
 > **Role abbreviations used throughout:** W = WEREWOLF, S = SEER, Wi = WITCH, H = HUNTER, G = GUARD, V = VILLAGER
 

--- a/docs/scenarios/ROLE-PHASE-SCREENS.md
+++ b/docs/scenarios/ROLE-PHASE-SCREENS.md
@@ -318,7 +318,7 @@ spec for each role's view at each phase/subphase.
     - List of all alive players
 - **Actions:**
     - Tap player → `HUNTER_SHOOT(targetUserId)`
-    - `[放弃技能]` → `HUNTER_SKIP`
+    - `[放弃技能]` → `HUNTER_PASS`
 - **Constraint:** Cannot shoot self (already eliminated); backend rejects self-target
 
 ---

--- a/docs/scenarios/scenario-05-hunter-shoots-after-vote.md
+++ b/docs/scenarios/scenario-05-hunter-shoots-after-vote.md
@@ -201,14 +201,14 @@ PhaseChanged(NIGHT, WEREWOLF_PICK)
 
 ---
 
-### Variant: Hunter Skips (HUNTER_SKIP Path)
+### Variant: Hunter Skips (HUNTER_PASS Path)
 
-This variant shows the `HUNTER_SKIP` action. Instead of shooting Bob, Eve skips.
+This variant shows the `HUNTER_PASS` action. Instead of shooting Bob, Eve skips.
 
 **Eve's action:**
 
 ```
-HUNTER_SKIP
+HUNTER_PASS
 ```
 
 **Events:**
@@ -234,8 +234,8 @@ GameOver(winner: WEREWOLF)
 
 This variant is useful for testing that:
 
-1. `HUNTER_SKIP` is a valid action and accepted by backend
-2. Win condition is checked immediately after HUNTER_SHOOT/SKIP completes, before moving to next phase
+1. `HUNTER_PASS` is a valid action and accepted by backend
+2. Win condition is checked immediately after HUNTER_SHOOT/HUNTER_PASS completes, before moving to next phase
 
 ---
 

--- a/scripts/act.sh
+++ b/scripts/act.sh
@@ -31,7 +31,7 @@
 #     IDIOT_REVEAL      idiot reveals identity when voted out (first time only, stays alive)
 #   Hunter / Badge:
 #     HUNTER_SHOOT      hunter shoots a target               (requires --target)
-#     HUNTER_SKIP       hunter skips shooting
+#     HUNTER_PASS       hunter skips shooting                (HUNTER_SKIP kept as legacy alias)
 #     BADGE_PASS        sheriff passes badge to target       (requires --target)
 #     BADGE_DESTROY     sheriff destroys the badge
 #   Sheriff election (also in sheriff.sh):
@@ -99,7 +99,7 @@
 #   ./scripts/act.sh VOTING_REVEAL_TALLY                          # host reveals tally
 #   ./scripts/act.sh VOTING_CONTINUE                              # host continues after result
 #   ./scripts/act.sh HUNTER_SHOOT --target 4                      # hunter shoots seat 4
-#   ./scripts/act.sh HUNTER_SKIP                                  # hunter skips
+#   ./scripts/act.sh HUNTER_PASS                                  # hunter skips
 #   ./scripts/act.sh BADGE_PASS --target 3                        # sheriff passes badge to seat 3
 #   ./scripts/act.sh BADGE_DESTROY                                # sheriff destroys badge
 #   ./scripts/act.sh SHERIFF_QUIT <nick>                          # candidate drops out (SIGNUP)
@@ -129,7 +129,7 @@ Usage: $0 <ACTION_TYPE> [PLAYER] [--target PLAYER] [--payload JSON] [--room CODE
   Actions : WOLF_SELECT WOLF_KILL SEER_CHECK SEER_CONFIRM WITCH_ACT GUARD_PROTECT GUARD_SKIP
             CONFIRM_ROLE START_NIGHT REVEAL_NIGHT_RESULT DAY_ADVANCE
             SUBMIT_VOTE VOTING_UNVOTE VOTING_REVEAL_TALLY VOTING_CONTINUE IDIOT_REVEAL
-            HUNTER_SHOOT HUNTER_SKIP BADGE_PASS BADGE_DESTROY
+            HUNTER_SHOOT HUNTER_PASS BADGE_PASS BADGE_DESTROY
             SHERIFF_CAMPAIGN SHERIFF_PASS SHERIFF_QUIT SHERIFF_QUIT_CAMPAIGN
             SHERIFF_VOTE SHERIFF_ABSTAIN SHERIFF_CONFIRM_VOTE
             SHERIFF_START_SPEECH SHERIFF_ADVANCE_SPEECH SHERIFF_REVEAL_RESULT SHERIFF_APPOINT
@@ -179,13 +179,18 @@ done
 
 [ -z "$ACTION_TYPE" ] && usage
 
+# Legacy aliases → rewrite to backend action name
+case "$ACTION_TYPE" in
+  HUNTER_SKIP) ACTION_TYPE="HUNTER_PASS" ;;
+esac
+
 # Validate ACTION_TYPE
 case "$ACTION_TYPE" in
   STATUS|CONSOLE_LOGIN) ;;  # pseudo-action handled below
   WOLF_SELECT|WOLF_KILL|SEER_CHECK|SEER_CONFIRM|WITCH_ACT|GUARD_PROTECT|GUARD_SKIP| \
   CONFIRM_ROLE|START_NIGHT|REVEAL_NIGHT_RESULT|DAY_ADVANCE| \
   SUBMIT_VOTE|VOTING_UNVOTE|VOTING_REVEAL_TALLY|VOTING_CONTINUE|IDIOT_REVEAL| \
-  HUNTER_SHOOT|HUNTER_SKIP|BADGE_PASS|BADGE_DESTROY| \
+  HUNTER_SHOOT|HUNTER_PASS|BADGE_PASS|BADGE_DESTROY| \
   SHERIFF_CAMPAIGN|SHERIFF_PASS|SHERIFF_QUIT|SHERIFF_QUIT_CAMPAIGN| \
   SHERIFF_VOTE|SHERIFF_ABSTAIN|SHERIFF_CONFIRM_VOTE| \
   SHERIFF_START_SPEECH|SHERIFF_ADVANCE_SPEECH|SHERIFF_REVEAL_RESULT|SHERIFF_APPOINT) ;;


### PR DESCRIPTION
## Summary

- Updated docs + ADRs to match current code evidence; removed aspirational or incorrect content that hurts AI and human understanding of the codebase.
- Net: **367 insertions / 727 deletions** across 12 files.
- Goal: shorter, accurate docs that AI assistants can trust.

## What changed (and why)

**Naming fix (HUNTER_SKIP → HUNTER_PASS)**
Backend `ActionType.HUNTER_PASS` (`Enums.kt:47`) — `HUNTER_SKIP` does not exist. Updated `README.md`, `ADR-002`, `scenarios/README.md`, `ROLE-PHASE-SCREENS.md`, `scenario-05`, `real-backend-testing.md`. Added `HUNTER_PASS` to `scripts/act.sh` with `HUNTER_SKIP` kept as legacy alias (previously the script sent the literal unknown action and backend rejected — latent bug).

**database-design.md — full rewrite**
Was MySQL syntax; now PostgreSQL (matches `V1__core.sql` onward). Added missing schema elements from V3–V10: `has_idiot`, `has_sheriff`, `win_condition`, `config` JSONB, `IDIOT` role, `can_vote`, `idiot_revealed`, `games.sub_phase`, sheriff `TIED` state, V10 phase constraint.

**ADR-007 (E2E testing) — rewritten**
Described a Spring "scenario-fixture" integration layer that never existed (`GameScenario.kt`, `StompTestClient.kt`, `e2e/full-flow/`). Now describes the real 4-layer setup: backend JUnit, Vitest, mocked Playwright (`e2e/*`), real-backend Playwright (`e2e/real/`).

**ADR-010 (Night orchestrator) — rewritten**
Pseudocode referenced `NightPhaseOrchestrator` / `GameEventPublisher` / `RoleActionRegistry`. Real class is `NightOrchestrator` with `List<RoleHandler>` + `StompPublisher`. Also removed duplicated MySQL schema and STOMP topic section (covered in `database-design.md` + `ADR-006`).

**Smaller cleanups**
- `ADR-002`: action table expanded to current ~28 `ActionType` values; points to `Enums.kt` as source of truth.
- `audio.md`: added `wolf_howl`, `rooster_crowing`, `crow_night`; clarified audio lives in `backend/src/main/resources/static/audio/`.
- `CLAUDE.md`: "MySQL/PostgreSQL" → "PostgreSQL + Flyway".
- `scenarios/README.md`: removed "source of truth for Spring integration tests" claim; added rows for scenario 08 + 09.

## What was **not** touched (verified still accurate per audit)

ADRs 001, 003, 004, 005, 006, 008, 009 · `docs/debug-endpoints.md` · `docs/ci-tests-issues.md` (your file) · scenarios 01–08 · `scenario-09-e2e.md` (your in-progress draft) · `simple-game-flow.md`.

## Test plan

- [ ] Review the rewritten `ADR-007`, `ADR-010`, `database-design.md`, and `audio.md` to confirm the reshaped content still tells the story you want.
- [ ] Spot-check `HUNTER_PASS` changes by running `./scripts/act.sh HUNTER_PASS <nick>` (legacy `HUNTER_SKIP` still works via the alias).
- [ ] `cd backend && ./gradlew test` (no code logic changed, but confirms nothing regressed from the one `scripts/act.sh` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)