### PR TITLE
chore(ai): add project skills + PostgreSQL MCP for Claude

### DIFF
--- a/.claude/skills/verify-enum-values/SKILL.md
+++ b/.claude/skills/verify-enum-values/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: verify-enum-values
+description: Use before writing or changing any ActionType, NightSubPhase, VotingSubPhase, ElectionSubPhase, DaySubPhase, GamePhase, Role, VoteContext, WinConditionMode, CandidateStatus, RoomStatus, or ReadyStatus string literal in code, tests, docs, or shell scripts. Cheap to run, prevents a whole class of silent bugs.
+---
+
+# Verify Enum Values Against `Enums.kt`
+
+Enum names in this codebase have drifted between code, scripts, and docs more than once. Example: scripts and docs referenced `HUNTER_SKIP`, but the backend only ever defined `HUNTER_PASS`. The script accepted the alias and sent the literal string, which the backend silently rejected — a latent bug that lived in docs and scripts for months.
+
+**Rule:** any string literal that represents an enum value must be proved against `backend/src/main/kotlin/com/werewolf/model/Enums.kt` before use.
+
+## Source of truth
+
+`backend/src/main/kotlin/com/werewolf/model/Enums.kt` is authoritative. Enums defined there:
+
+- `RoomStatus`, `ReadyStatus`
+- `GamePhase`, `NightSubPhase`, `DaySubPhase`, `VotingSubPhase`, `ElectionSubPhase`
+- `PlayerRole`, `CandidateStatus`, `VoteContext`, `WinnerSide`, `WinConditionMode`
+- `ActionType`
+
+If you need an audio filename, look at `backend/src/main/resources/static/audio/` and the handlers in `backend/src/main/kotlin/com/werewolf/game/role/*Handler.kt`, not docs.
+
+## How to verify
+
+Run one of these before writing the literal:
+
+```
+grep -n '^\s*[A-Z_]*\b' backend/src/main/kotlin/com/werewolf/model/Enums.kt
+```
+
+Or, for a specific enum:
+
+```
+grep -n 'enum class ActionType' -A 40 backend/src/main/kotlin/com/werewolf/model/Enums.kt
+```
+
+Or, cheapest — ask the Grep tool:
+
+```
+Grep pattern="^\s*(HUNTER_|WOLF_|SEER_|WITCH_|GUARD_|SHERIFF_|IDIOT_|BADGE_|VOTING_|CONFIRM_|START_|REVEAL_|DAY_)"
+      path="backend/src/main/kotlin/com/werewolf/model/Enums.kt"
+      output_mode="content"
+```
+
+If the literal you intend to write is not in the file, **do not write it.** Either add it to `Enums.kt` (with a matching handler branch and, if it changes the DB enum, a Flyway migration — see V8 and V10 for the pattern) or use the correct existing value.
+
+## Cross-file parity checklist
+
+When you add or rename a value, these must all move together:
+
+| Layer                   | Where                                                                         |
+|-------------------------|-------------------------------------------------------------------------------|
+| Kotlin enum             | `backend/src/main/kotlin/com/werewolf/model/Enums.kt`                          |
+| Dispatcher branch       | `backend/src/main/kotlin/com/werewolf/game/action/GameActionDispatcher.kt`     |
+| Role handler            | `backend/src/main/kotlin/com/werewolf/game/role/<Role>Handler.kt`              |
+| DB CHECK constraint     | Latest Flyway migration under `backend/src/main/resources/db/migration/`       |
+| Frontend action types   | `frontend/src/types/` and `frontend/src/mocks/index.ts`                        |
+| CLI wrapper             | `scripts/act.sh` (case statement + usage + examples)                           |
+| Docs                    | `README.md`, `docs/adr/ADR-002-*`, `docs/scenarios/*`, `docs/real-backend-testing.md` |
+
+If you rename a value, prefer keeping the old name as a legacy alias in the CLI wrapper that rewrites to the new value — this is how we handle `HUNTER_SKIP → HUNTER_PASS` today (`scripts/act.sh`).
+
+## Doc parity
+
+Docs that claim an enum value exists should cite `Enums.kt` so the next reader doesn't have to verify from scratch. Example:
+
+```markdown
+Action routing: see `backend/src/main/kotlin/com/werewolf/model/Enums.kt` (source of truth).
+```
+
+## When to skip
+
+This skill is cheap. There is no situation where skipping it saves meaningful time, because the failure modes it prevents (silent backend rejection, broken docs, test flake after rename) cost hours.

--- a/.claude/skills/write-real-e2e-test/SKILL.md
+++ b/.claude/skills/write-real-e2e-test/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: write-real-e2e-test
+description: Use when creating, editing, or debugging any spec under frontend/e2e/real/. Encodes the CI-vs-local pitfalls that repeatedly break this suite so you design around them up front.
+---
+
+# Writing Real-Backend E2E Tests
+
+You are about to touch a real-backend Playwright spec. **This suite has a history of passing locally and failing in CI.** Every correction has been absorbed into a checklist so we stop paying for it twice.
+
+## Step 1 — Read the memory first (non-negotiable)
+
+Before writing or editing a line, read:
+
+- `/Users/dq/.claude/projects/-Users-dq-workspace-werewolf-simple/memory/feedback_e2e_ci_vs_local.md`
+
+It enumerates 8 specific CI-vs-local differences. If any of them apply, your design must handle them upfront. Do not decide that a difference "probably won't matter here" — that is the exact reasoning that produced the current quarantine list.
+
+Also check:
+
+- `/Users/dq/.claude/projects/-Users-dq-workspace-werewolf-simple/memory/project_quarantined_e2e_tests.md` — so you do not accidentally re-introduce a pattern we already know is broken.
+
+## Step 2 — Understand the code before asserting
+
+Never assume an action/sub-phase name. Verify against:
+
+- `backend/src/main/kotlin/com/werewolf/model/Enums.kt` — `ActionType`, `NightSubPhase`, `VotingSubPhase`, `ElectionSubPhase`, `DaySubPhase`, `GamePhase`
+- `backend/src/main/kotlin/com/werewolf/game/night/NightOrchestrator.kt` — real night sub-phase sequence
+- The relevant `*Handler.kt` under `backend/src/main/kotlin/com/werewolf/game/role/` — accepted actions per sub-phase, rejection reasons
+
+If you cannot point to the line that proves your assertion holds, the assertion is a guess — do not write it.
+
+## Step 3 — Use the existing helpers (don't reinvent)
+
+`frontend/e2e/real/helpers/`:
+
+- `assertions.ts` — `verifyAllBrowsersPhase`, `snapshotBackendState`, `TIMEOUT_SCALE` (CI-aware). Use these for phase checks; do not write raw `waitForTimeout` calls.
+- `multi-browser.ts` — `createPlayerContexts(...)`. Always isolate per-player contexts; never share storage.
+- `shell-runner.ts` — `act(...)` with retry/log. Prefer this over raw `execSync` so rejections surface in the report.
+- `composite-screenshot.ts` — capture per-player screenshots in one image when debugging a phase-specific failure.
+
+The shell helpers under `scripts/act.sh` drive bots. When the host needs to fire an action, pass the host nickname explicitly — `PLAYER_SEL=all` is the default fan-out which has bitten us before.
+
+## Step 4 — Gate on sub-phase, not on time
+
+When waiting for a phase/sub-phase transition, poll `/api/game/{id}/state` via `waitForSubPhase(hostPage, gameId, target, timeoutMs)` rather than sleeping. Use `TIMEOUT_SCALE` from `assertions.ts` for CI-friendly timeouts (CI is ~2× slower locally).
+
+`verifyAllBrowsersPhase` already appends a backend-state snapshot on failure — leave that in. It turns "flaky test" into "here is exactly what the DB looked like when we gave up."
+
+## Step 5 — Minimal per-iteration logging
+
+If your test has a loop (revote, multi-night), log one structured line per iteration:
+
+```
+[feature] iter=N elapsed=Ns ui={...} backend={phase, subPhase, aliveCount}
+```
+
+This diff-reads CI failures in seconds instead of running a local bisect.
+
+## Step 6 — Run locally before pushing
+
+```
+cd frontend && npx playwright test --config=playwright.real.config.ts <your-spec>
+```
+
+If it passes locally, run it **twice** before pushing. Flake surfaces on the second run half the time.
+
+For full regression before big changes:
+
+```
+./scripts/run-e2e-full-flow.sh
+```
+
+## Step 7 — If you have to skip
+
+Quarantine must update `memory/project_quarantined_e2e_tests.md`. A `test.skip()` with no memory entry is how we end up rediscovering the same bug.
+
+## Non-goals
+
+- Do not mock the backend in this suite. If a mock is called for, the spec belongs under `frontend/e2e/` (mocked config), not `frontend/e2e/real/`.
+- Do not assert on the felt duration of a phase. Only assert sub-phase state transitions. Timing asserts are the single largest source of CI flake in this repo.

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@ frontend/*.tsbuildinfo
 /console_log.md
 /simple-game-flow.md
 /minor-changes/
-/.claude/
+/.claude/*
+!/.claude/skills/
+!/.claude/skills/**
 
 # ─── IDE ───────────────────────────────────────────────────────────────────────
 .idea/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "werewolf-db": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Repo-level Claude Code tooling to cut iteration time on recurring workflows and encode CI/local pitfalls that have cost us rework.

- **`.mcp.json`** — adds a `werewolf-db` PostgreSQL MCP so Claude can query the dev DB directly. Huge win for E2E debugging where the question is always "what did the backend actually store" — previously answered with `docker exec werewolf-db psql` on every failure.
- **`.claude/skills/write-real-e2e-test`** — project-scoped skill that forces reading the CI-vs-local pitfall list before editing any `frontend/e2e/real/` spec. Targets the exact pattern that drove PR #41's back-and-forth.
- **`.claude/skills/verify-enum-values`** — skill that requires verifying `ActionType` / `NightSubPhase` / `Role` literals against `Enums.kt` before writing them. Encodes the cross-layer parity checklist that the `HUNTER_SKIP` drift exposed (doc/PR #42 fixes the outcome; this skill prevents the next one).
- **`.gitignore`** — narrowed `/.claude/` rule so skills ship but per-user files (`settings.local.json`, `scheduled_tasks.lock`) stay ignored.

## Setup for use

1. Ensure `backend/.env` has `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` set (existing first-time setup step from `README.md`).
2. Before launching Claude Code in this repo: `source backend/.env` so the MCP config can interpolate the credentials.
3. Claude Code will prompt to approve the `werewolf-db` MCP the first time — say yes.
4. Skills auto-discover — no action required.

## Why these three first

The same memory / feedback file listed ~7 candidate skills; these three are highest-ROI because they each directly prevent a failure mode we've already paid for:

| Skill / MCP | Prevents |
|---|---|
| PostgreSQL MCP | "shell out to `psql` again to debug a night phase" |
| `write-real-e2e-test` | repeat of PR #41's CI/local divergence |
| `verify-enum-values` | repeat of the `HUNTER_SKIP` doc + script drift |

Other candidates (`add-migration`, `add-role-handler`, `add-stomp-event`, `memory-audit`) can follow in a separate PR if these prove useful.

## Test plan

- [ ] After merging: restart Claude Code in the repo, confirm `werewolf-db` MCP offer appears, approve it.
- [ ] In a new Claude Code session, start with a task like "tell me the alive players in game 1" — should use the MCP, not shell psql.
- [ ] Run `/write-real-e2e-test` or reference it when editing a real-E2E spec — verify the skill content loads.
- [ ] Run `/verify-enum-values` before adding any action type literal — verify the skill content loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)