### PR TITLE
test(e2e): fix revote-flow completeNight WOLF_KILL stall on stale target

### DIFF
--- a/frontend/e2e/real/revote-flow.spec.ts
+++ b/frontend/e2e/real/revote-flow.spec.ts
@@ -169,11 +169,15 @@ test.describe('Voting tie → revote → game proceeds', () => {
     const hostPage = ctx.hostPage
     const gameId = ctx.gameId
 
-    // Pick a non-wolf target
-    const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots].filter(
-      (b) => b.nick !== 'Host',
-    )
-    const target = allTargets[0]
+    // Pick an alive non-wolf target from live DB state, not from the
+    // start-of-game roleMap. Using roleMap[0] causes infinite WEREWOLF_PICK
+    // loops once the first villager dies — every subsequent WOLF_KILL hits a
+    // "target is dead" rejection for ~500+s (observed in CI run 24649855990
+    // shard 2 attempt 1).
+    const alivePlayers = await readAlivePlayersNonHost(ctx.hostPage, ctx.gameId)
+    const wolfNicks = new Set((ctx.roleMap.WEREWOLF ?? []).map((b) => b.nick))
+    const aliveNonWolf = alivePlayers.filter((p) => !wolfNicks.has(p.nickname))
+    const target = aliveNonWolf[0]
 
     // ── Wolf kill ──
     // Wait for the coroutine to reach WEREWOLF_PICK before firing the action.
@@ -220,7 +224,8 @@ test.describe('Voting tie → revote → game proceeds', () => {
     let seerDone = false
     if (reachedSeerPick) {
       for (const sb of seerBots.filter((b) => b.nick !== 'Host')) {
-        const seats = allTargets.map((t) => t.seat)
+        // Use live alive seats; exclude the seer's own seat (self-check rejects).
+        const seats = alivePlayers.filter((p) => p.nickname !== sb.nick).map((p) => p.seat)
         for (const seat of seats) {
           if (tryAct('SEER_CHECK', sb.nick, { target: String(seat), room: ctx.roomCode })) {
             seerDone = true


### PR DESCRIPTION
## Summary

Fixes the intermittent 8+ minute stall in `revote-flow.spec.ts:422 › 4. Game proceeds to completion after revote` on CI shard 2. This was the test flagged as \"flaky\" on PR #43's CI run 24649855990 and the remaining source of shard 2's 14m21s runtime.

## Root cause (evidence)

`completeNight` helper at `frontend/e2e/real/revote-flow.spec.ts:172-176` computed the wolf-kill target from the **start-of-game** `ctx.roleMap`:

```ts
const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots]
const target = allTargets[0]
```

On nights after the game started, if `allTargets[0]` had died (vote, wolf kill, witch poison), every alive wolf's `WOLF_KILL` against that dead seat was rejected by the backend. With 3 alive wolves × 3 `act.sh` retries each with ~600 ms backoff, plus ~2 min between iteration logs, the test pinned itself in `NIGHT/WEREWOLF_PICK` indefinitely.

CI log evidence (run 24649855990 shard 2 attempt 1, room `R9KP`):

```
[revote] iter=4 elapsed=51s  backend={phase:NIGHT,nightSub:WEREWOLF_PICK,aliveCount:6}
[act rejected] ×9  WOLF_KILL target=3 from Bot2/Bot4/Bot8
[revote] iter=5 elapsed=171s backend={phase:NIGHT,nightSub:WEREWOLF_PICK,aliveCount:6}
[act rejected] ×9  WOLF_KILL target=3 from Bot2/Bot4/Bot8
[revote] iter=6 elapsed=290s ... (same)
[revote] iter=7 elapsed=409s ... (same)
[revote] iter=8 elapsed=528s ... (same)
```

500+ s of identical rejections on seat 3 — seat 3 had been voted out two rounds earlier.

## Fix

Re-query live alive players at the top of every `completeNight` call and pick the wolf target from that:

```ts
const alivePlayers = await readAlivePlayersNonHost(ctx.hostPage, ctx.gameId)
const wolfNicks = new Set((ctx.roleMap.WEREWOLF ?? []).map(b => b.nick))
const aliveNonWolf = alivePlayers.filter(p => !wolfNicks.has(p.nickname))
const target = aliveNonWolf[0]
```

Also applied the same fix to the seer-pick seat loop (`seats = alivePlayers.filter(...)` instead of the stale `allTargets.map(t => t.seat)`) — it was seeing the same staleness but recovered by cycling through seats, so it was only wasting a few seconds per night, not stalling.

## Why this fix and not a retry/timeout band-aid

Playwright's retry already rescued this run — the real cost is the 7+ minutes of compute per failed attempt on every CI run. Fixing the test's state-freshness invariant is the root cause and leaves the rest of the suite's timings untouched.

## Diff

`frontend/e2e/real/revote-flow.spec.ts` only — 11 insertions, 6 deletions.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.e2e.json` — clean
- [ ] CI passes shard 2 in normal time (~3-4 min, no retry)
- [ ] (optional) run `revote-flow.spec.ts` twice locally against a live backend to confirm non-flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)