### PR TITLE
chore: env-driven Spring profile + BACKEND_BASE-aware helper scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      SPRING_PROFILES_ACTIVE: prod
       DB_HOST: postgres
       DB_PORT: "5432"
     env_file:

--- a/scripts/act.sh
+++ b/scripts/act.sh
@@ -109,7 +109,7 @@
 
 set -euo pipefail
 
-BASE="http://localhost:8080/api"
+BASE="${BACKEND_BASE:-http://localhost:8080/api}"
 STATE_DIR="/tmp"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'

--- a/scripts/dev-login.sh
+++ b/scripts/dev-login.sh
@@ -34,7 +34,7 @@
 
 set -euo pipefail
 
-BASE="http://localhost:8080/api"
+BASE="${BACKEND_BASE:-http://localhost:8080/api}"
 CACHE_DIR="/tmp"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RESET='\033[0m'

--- a/scripts/join-room.sh
+++ b/scripts/join-room.sh
@@ -33,7 +33,7 @@
 
 set -euo pipefail
 
-BASE="http://localhost:8080/api"
+BASE="${BACKEND_BASE:-http://localhost:8080/api}"
 STATE_DIR="/tmp"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'

--- a/scripts/roles.sh
+++ b/scripts/roles.sh
@@ -22,7 +22,7 @@
 
 set -euo pipefail
 
-BASE="http://localhost:8080/api"
+BASE="${BACKEND_BASE:-http://localhost:8080/api}"
 STATE_DIR="/tmp"
 
 CYAN='\033[0;36m'; RED='\033[0;31m'; RESET='\033[0m'
@@ -82,7 +82,7 @@ try:
     for gid in range(1, 10000):
         try:
             req = urllib.request.Request(
-                f"http://localhost:8080/api/game/{gid}/state",
+                f"{BASE}/game/{gid}/state",
                 headers={"Authorization": f"Bearer {token}"}
             )
             with urllib.request.urlopen(req) as r:

--- a/scripts/sheriff.sh
+++ b/scripts/sheriff.sh
@@ -44,7 +44,7 @@
 
 set -euo pipefail
 
-BASE="http://localhost:8080/api"
+BASE="${BACKEND_BASE:-http://localhost:8080/api}"
 STATE_DIR="/tmp"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'


### PR DESCRIPTION
## Summary

Two related cleanups so toggling between prod and prod+dev profiles on a live deployment doesn't require editing tracked files on the VM.

- **Remove `SPRING_PROFILES_ACTIVE: prod` hardcode from docker-compose.yml** — compose's \`environment:\` block was silently overriding \`.env.prod\`, so setting \`SPRING_PROFILES_ACTIVE=dev,prod\` in \`.env.prod\` had no effect. Now \`env_file\` drives the value. \`.env.prod.example\` still defaults to \`prod\`.
- **\`BACKEND_BASE\` env var in helper scripts** — \`scripts/{act,dev-login,join-room,roles,sheriff}.sh\` now read \`\${BACKEND_BASE:-http://localhost:8080/api}\`. Local dev behaviour unchanged; to exercise production: \`export BACKEND_BASE=https://your-domain/api\`.

## Motivation

While smoke-testing the production deploy, two footguns surfaced:
1. Setting \`SPRING_PROFILES_ACTIVE=dev,prod\` in \`.env.prod\` did nothing because compose's \`environment:\` overrode env_file values.
2. Running existing bot scripts against prod required editing them in place because \`BASE\` was hardcoded.

## Test plan

- [ ] Local dev unchanged: \`./scripts/dev-login.sh Alice\` still hits \`http://localhost:8080/api\`
- [ ] With \`BACKEND_BASE\` set: \`BACKEND_BASE=https://youplay123.online/api ./scripts/dev-login.sh Alice\` hits prod
- [ ] On a fresh compose boot with \`.env.prod\` containing \`SPRING_PROFILES_ACTIVE=dev,prod\`: \`POST /api/auth/dev\` returns a JWT
- [ ] On a fresh compose boot with \`.env.prod\` containing \`SPRING_PROFILES_ACTIVE=prod\` only: \`POST /api/auth/dev\` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)