### PR TITLE
fix(prod): backend action logging + role-card STOMP fix + vm-debug tooling

### DIFF
--- a/.claude/skills/vm-debug/SKILL.md
+++ b/.claude/skills/vm-debug/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: vm-debug
+description: Use when debugging the live werewolf-simple game on the GCP production VM — checking backend / frontend logs, querying the Postgres DB, inspecting container health, or running the repo's debugging scripts (act.sh, roles.sh, etc.) against the running server. Also use when a bug reproduces only in prod and you need evidence from the VM before editing code.
+---
+
+# VM Debug — werewolf-simple (GCP)
+
+## Coordinates
+
+| Field | Value |
+|---|---|
+| VM name | `werewolf-server` |
+| Zone | `us-east1-d` |
+| GCP project | `werewolf-301709` |
+| External IP | `35.243.171.224` |
+| Internal IP | `10.142.0.2` |
+| Repo path on VM | `/opt/werewolf-simple` |
+
+**Stack on VM:** docker compose. Three services — `postgres`, `backend` (`127.0.0.1:8080`), `frontend` (`127.0.0.1:8081`). Host Nginx terminates TLS and proxies `/api` + `/ws` to `backend`. See `deploy/README.md` and `docker-compose.yml` at the repo root.
+
+## Step 1 — Verify gcloud auth before SSH (do this every session)
+
+Expired gcloud creds surface as "permission denied" on SSH, not as an auth error. Check first:
+
+```bash
+gcloud auth list        # must show an ACTIVE account, not "No credentialed accounts"
+gcloud config get-value project   # must print werewolf-301709
+```
+
+If either fails, STOP and ask the user to run (in their own terminal — interactive OAuth):
+
+```bash
+gcloud auth login
+gcloud config set project werewolf-301709
+```
+
+Do not try to run SSH commands until this passes. Retrying a failing SSH just produces noise.
+
+## Step 2 — Pick the right SSH shape
+
+**Helper script (default — use this for everything):**
+
+```bash
+./scripts/vm-ssh.sh '<remote command>'
+```
+
+`scripts/vm-ssh.sh` opens an SSH ControlMaster on first call (~6s, mostly gcloud overhead) and reuses it for every subsequent call (~0.5s each, bypassing gcloud). Master persists 30 min after the last command. Without this, every gcloud-ssh invocation pays a fresh 3s+ Python startup tax.
+
+```bash
+./scripts/vm-ssh.sh 'curl -sf http://127.0.0.1:8080/api/health'
+./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && sudo docker compose --env-file .env.prod ps'
+```
+
+**Raw gcloud one-shot** (fall back when the helper isn't available, e.g. from a fresh checkout):
+
+```bash
+gcloud compute ssh werewolf-server --zone=us-east1-d --command="<cmd>"
+```
+
+**Interactive shell** (for poking around, multi-step debugging):
+
+```bash
+gcloud compute ssh werewolf-server --zone=us-east1-d
+```
+
+**Port-forward** (run LOCAL scripts against the remote backend — keeps `/tmp/werewolf-*.json` state files local):
+
+```bash
+# Terminal 1: forward 8080 → VM backend
+gcloud compute ssh werewolf-server --zone=us-east1-d -- -L 8080:127.0.0.1:8080 -N
+
+# Terminal 2: local scripts use the tunnel
+BACKEND_BASE=http://localhost:8080/api ./scripts/act.sh STATUS --room ABCD
+```
+
+## Step 3 — Common debug commands
+
+All commands below assume you wrap them in `./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && <CMD>'` (or the raw gcloud equivalent if the helper isn't available).
+
+**Two things every docker command needs on this VM:**
+
+1. `sudo` — the login user is not in the `docker` group, so bare `docker ...` fails with `permission denied ... /var/run/docker.sock`.
+2. `--env-file .env.prod` — compose does not auto-load that file (only `.env`). Without it `POSTGRES_USER`/`POSTGRES_DB`/`POSTGRES_PASSWORD` resolve to blank strings and commands fail or target the wrong DB.
+
+So the real prefix is `sudo docker compose --env-file .env.prod ...`. Use `-T` on `exec` for non-interactive calls or it errors with "the input device is not a TTY".
+
+### Health & status
+
+```bash
+curl -sf http://127.0.0.1:8080/api/health                       # {"status":"UP"}
+sudo docker compose --env-file .env.prod ps                     # container states + ports
+sudo docker compose --env-file .env.prod config                 # resolved compose config
+```
+
+### Backend logs
+
+```bash
+sudo docker compose --env-file .env.prod logs --tail=200 backend
+sudo docker compose --env-file .env.prod logs --since=10m backend
+sudo docker compose --env-file .env.prod logs backend | grep -i 'ROOM_CODE\|ERROR'
+```
+
+Do not use `-f` (follow) over `--command` — it blocks forever. Use `--since` or `--tail` for snapshots, or open an interactive shell if you really need to stream.
+
+### Frontend logs
+
+```bash
+sudo docker compose --env-file .env.prod logs --tail=200 frontend   # nginx in the container
+sudo tail -n 200 /var/log/nginx/access.log                          # host nginx (TLS + proxy)
+sudo tail -n 200 /var/log/nginx/error.log
+```
+
+The frontend container serves static assets only — 404s and TLS issues show up in the **host** nginx logs, not the container log.
+
+### Postgres
+
+Credentials live in `/opt/werewolf-simple/.env.prod` on the VM (POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB — defaults to `werewolf` / `werewolf` / `werewolf`). Password is not in git.
+
+```bash
+# Ad-hoc query (non-interactive — note -T)
+sudo docker compose --env-file .env.prod exec -T postgres psql -U werewolf -d werewolf \
+  -c 'SELECT room_id, room_code, status, created_at FROM rooms ORDER BY room_id DESC LIMIT 10;'
+
+# List tables
+sudo docker compose --env-file .env.prod exec -T postgres psql -U werewolf -d werewolf -c '\dt'
+
+# Interactive psql (open an SSH shell first, then run)
+sudo docker compose --env-file .env.prod exec postgres psql -U werewolf -d werewolf
+```
+
+Primary-key columns are domain-prefixed, not `id`: `rooms.room_id`, `games.game_id`, `users.user_id`. The join tables (`room_players`, `game_players`) do use `id`. Full schema: `backend/src/main/resources/db/migration/V1__core.sql` and later `V*.sql`.
+
+Tables: `users`, `rooms`, `room_players`, `games`, `game_players`, `night_phases`, `votes`, `elimination_history`, `game_events`, `sheriff_elections`, `sheriff_candidates`.
+
+### Running the in-repo debug scripts remotely
+
+The same `scripts/` that work locally are at `/opt/werewolf-simple/scripts/` on the VM. They honor `BACKEND_BASE` so pointing them at the in-VM backend works (no sudo needed — these are plain curl against `:8080`):
+
+```bash
+cd /opt/werewolf-simple && BACKEND_BASE=http://127.0.0.1:8080/api ./scripts/act.sh STATUS --room ABCD
+cd /opt/werewolf-simple && BACKEND_BASE=http://127.0.0.1:8080/api ./scripts/roles.sh --room ABCD
+```
+
+**Caveat — dev-only endpoints:** `scripts/dev-login.sh`, `as-bot.sh`, `join-room.sh` (bot login path), and anything else that calls `POST /api/auth/dev` only work when the backend is running the **dev** Spring profile. In production (`SPRING_PROFILES_ACTIVE=prod`) those calls return 404. Confirm the active profile before assuming they'll work:
+
+```bash
+grep SPRING_PROFILES_ACTIVE /opt/werewolf-simple/.env.prod
+sudo docker compose --env-file .env.prod logs backend | grep -i 'active profile' | head -3
+```
+
+If prod is active, use read-only routes (`/api/room/{id}`, `/api/game/{id}/state`) with an existing player's JWT, or the DB for forensics.
+
+### Copying a log excerpt back to local
+
+```bash
+# Single file
+gcloud compute scp werewolf-server:/opt/werewolf-simple/some.log /tmp/ --zone=us-east1-d
+
+# Capture inline (preferred for short snippets — avoids leaving files on the VM)
+gcloud compute ssh werewolf-server --zone=us-east1-d \
+  --command="cd /opt/werewolf-simple && docker compose logs --tail=500 backend" > /tmp/backend-tail.log
+```
+
+## Safety rules (non-negotiable)
+
+These commands affect live players. **Confirm with the user before running:**
+
+- `sudo docker compose --env-file .env.prod down` / `down -v` — stops the stack; `-v` wipes the Postgres volume (all rooms / games gone)
+- `sudo docker compose --env-file .env.prod restart backend` / `restart frontend` — kicks every connected player
+- `sudo docker compose --env-file .env.prod up -d --build` — rebuilds and restarts (same downtime cost)
+- `sudo docker system prune` — can delete images still needed by the compose stack
+- Any `psql` `UPDATE` / `DELETE` / `TRUNCATE` / `DROP` — mutates prod game state
+- `git pull` / `git reset` inside `/opt/werewolf-simple` — changes what the next rebuild deploys
+
+Other rules:
+
+- **Do not edit files on the VM.** Fix in git locally → commit → push → on VM `git pull && docker compose --env-file .env.prod up -d --build`. Deploy flow is documented in `deploy/README.md`.
+- **Do not exfiltrate `.env.prod`, JWT_SECRET, POSTGRES_PASSWORD, or any JWT** back to chat. Read values inline on the VM only.
+- When pasting logs back to the user, **redact anything starting with `eyJ`** (JWT header) and any `POSTGRES_PASSWORD=...` line.
+
+## Quick reference
+
+Prefix every remote command with:
+`gcloud compute ssh werewolf-server --zone=us-east1-d --command="cd /opt/werewolf-simple && ..."`
+
+Inside that, `DC` = `sudo docker compose --env-file .env.prod` (both bits are required on this VM).
+
+| Need | Command tail |
+|---|---|
+| Health check | `curl -sf http://127.0.0.1:8080/api/health` |
+| Container status | `DC ps` |
+| Backend log (recent) | `DC logs --since=10m backend` |
+| Backend log (N lines) | `DC logs --tail=200 backend` |
+| Frontend container log | `DC logs --tail=200 frontend` |
+| Host nginx error log | `sudo tail -n 200 /var/log/nginx/error.log` |
+| DB one-off query | `DC exec -T postgres psql -U werewolf -d werewolf -c '<SQL>'` |
+| List tables | `DC exec -T postgres psql -U werewolf -d werewolf -c '\dt'` |
+| Active Spring profile | `grep SPRING_PROFILES_ACTIVE .env.prod` |
+| Run a debug script | `BACKEND_BASE=http://127.0.0.1:8080/api ./scripts/act.sh STATUS --room ABCD` |
+| Disk space | `df -h /` |
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `gcloud compute ssh` → permission denied | Token expired / wrong project | Re-run `gcloud auth login` and `gcloud config set project werewolf-301709` |
+| `permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock` | User not in `docker` group on this VM | Prefix with `sudo` |
+| `warning: The "POSTGRES_USER" variable is not set. Defaulting to a blank string.` (and friends) | `docker compose` didn't load `.env.prod` | Add `--env-file .env.prod` |
+| `the input device is not a TTY` | Missing `-T` on `docker compose exec` in non-interactive mode | Add `-T` |
+| `column "id" does not exist` on `rooms` / `games` / `users` | PK columns are domain-prefixed, not `id` | Use `room_id`, `game_id`, `user_id` |
+| `dev-login.sh` → 404 on `/api/auth/dev` | Backend running `prod` profile | Expected — use read-only routes or DB instead |
+| SSH command hangs forever | Used `docker compose logs -f` with `--command` | Swap to `--tail=N` or `--since=Xm` |
+| Script works locally, fails on VM with same room code | Different `BACKEND_BASE` — local state file `/tmp/werewolf-*.json` holds tokens from the OTHER backend | Prefer port-forward (Step 2) so local state stays consistent |

--- a/backend/src/main/kotlin/com/werewolf/controller/GameController.kt
+++ b/backend/src/main/kotlin/com/werewolf/controller/GameController.kt
@@ -30,8 +30,14 @@ class GameController(
     ): ResponseEntity<Map<String, Any?>> {
         val userId = authentication.principal as String
         return when (val result = gameService.startGame(userId, body.roomId)) {
-            is GameActionResult.Success -> ResponseEntity.ok(mapOf("success" to true))
-            is GameActionResult.Rejected -> ResponseEntity.badRequest().body(mapOf("success" to false, "error" to result.reason))
+            is GameActionResult.Success -> {
+                log.info("action.startGame user={} room={} -> SUCCESS", userId, body.roomId)
+                ResponseEntity.ok(mapOf("success" to true))
+            }
+            is GameActionResult.Rejected -> {
+                log.warn("action.startGame user={} room={} -> REJECTED reason=\"{}\"", userId, body.roomId, result.reason)
+                ResponseEntity.badRequest().body(mapOf("success" to false, "error" to result.reason))
+            }
         }
     }
 
@@ -49,8 +55,20 @@ class GameController(
             payload = body.payload ?: emptyMap(),
         )
         return when (val result = gameActionDispatcher.dispatch(request)) {
-            is GameActionResult.Success -> ResponseEntity.ok(mapOf("success" to true))
-            is GameActionResult.Rejected -> ResponseEntity.badRequest().body(mapOf("success" to false, "error" to result.reason))
+            is GameActionResult.Success -> {
+                log.info(
+                    "action.submit user={} game={} type={} target={} payload={} -> SUCCESS",
+                    userId, body.gameId, body.actionType, body.targetUserId, body.payload,
+                )
+                ResponseEntity.ok(mapOf("success" to true))
+            }
+            is GameActionResult.Rejected -> {
+                log.warn(
+                    "action.submit user={} game={} type={} target={} payload={} -> REJECTED reason=\"{}\"",
+                    userId, body.gameId, body.actionType, body.targetUserId, body.payload, result.reason,
+                )
+                ResponseEntity.badRequest().body(mapOf("success" to false, "error" to result.reason))
+            }
         }
     }
 

--- a/frontend/src/stores/gameStore.ts
+++ b/frontend/src/stores/gameStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import type { GameEvent, GameState } from '@/types'
+import type { GameEvent, GameState, PlayerRole } from '@/types'
 
 export const useGameStore = defineStore('game', () => {
   const state = ref<GameState | null>(null)
@@ -31,6 +31,11 @@ export const useGameStore = defineStore('game', () => {
     state.value.nightPhase = { ...state.value.nightPhase, selectedTargetId }
   }
 
+  function setMyRole(role: PlayerRole) {
+    if (!state.value) return
+    state.value = { ...state.value, myRole: role }
+  }
+
   return {
     state,
     setState,
@@ -38,5 +43,6 @@ export const useGameStore = defineStore('game', () => {
     incrementConfirmedCount,
     clearGame,
     updateNightPhaseSelection,
+    setMyRole,
   }
 })

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -939,7 +939,9 @@ onMounted(async () => {
       // Private channel for role-specific info (night actions, etc.)
       subscribeToTopic('/user/queue/private', (msg: { body: string }) => {
         const data = JSON.parse(msg.body)
-        if (data.type === 'WolfSelectionChanged') {
+        if (data.type === 'RoleAssigned') {
+          gameStore.setMyRole(data.role)
+        } else if (data.type === 'WolfSelectionChanged') {
           gameStore.updateNightPhaseSelection(data.selectedTargetUserId)
         } else {
           gameStore.addEvent(data)

--- a/scripts/vm-ssh.sh
+++ b/scripts/vm-ssh.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# =============================================================================
+# vm-ssh.sh — run a command on the production VM over a reused SSH connection.
+#
+# First call opens an SSH ControlMaster via `gcloud compute ssh` (handles auth
+# + key propagation). Subsequent calls bypass gcloud and speak ssh directly
+# over the existing socket (~0.5s per call vs. ~3.5s with gcloud every time).
+# Master auto-expires 30 minutes after the last command.
+#
+# Usage:
+#   ./scripts/vm-ssh.sh '<remote command>'
+#
+# Examples:
+#   ./scripts/vm-ssh.sh 'curl -sf http://127.0.0.1:8080/api/health'
+#   ./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && sudo docker compose --env-file .env.prod ps'
+#   ./scripts/vm-ssh.sh "cd /opt/werewolf-simple && sudo docker compose --env-file .env.prod logs --tail=100 backend"
+#
+# Requires gcloud auth + project set. If either is missing:
+#   gcloud auth login
+#   gcloud config set project werewolf-301709
+# =============================================================================
+
+set -euo pipefail
+
+VM="werewolf-server"
+ZONE="us-east1-d"
+PROJECT="werewolf-301709"
+SOCKET="/tmp/ssh-werewolf-cm"
+
+[ $# -eq 0 ] && { echo "usage: $0 '<remote command>'" >&2; exit 1; }
+
+# Fast path: master is alive → direct ssh over the existing socket.
+if ssh -O check -o ControlPath="$SOCKET" werewolf-server 2>/dev/null; then
+  exec ssh \
+    -o ControlPath="$SOCKET" \
+    -o HostKeyAlias=compute.7050235389789579773 \
+    -o UserKnownHostsFile="$HOME/.ssh/google_compute_known_hosts" \
+    -i "$HOME/.ssh/google_compute_engine" \
+    dq@35.243.171.224 "$*"
+fi
+
+# Cold path: bootstrap via gcloud (handles auth + SSH key metadata), leaving
+# behind a ControlMaster the fast path can reuse on subsequent calls.
+exec gcloud compute ssh "$VM" --zone="$ZONE" --project="$PROJECT" \
+  --ssh-flag="-o ControlMaster=auto" \
+  --ssh-flag="-o ControlPath=$SOCKET" \
+  --ssh-flag="-o ControlPersist=30m" \
+  --command="$*"


### PR DESCRIPTION
## Summary

Three changes triggered by a live debugging session against the production VM (games 3 and 4 stuck mid-game):

- **Backend action logging** (`GameController`) — `submitAction` and `startGame` now emit one INFO line per success and one WARN per rejection, with `userId / gameId / actionType / target / payload / reason`. Today the log gives no signal about player actions; when a player reports "the witch button never showed and the game froze" we cannot tell whether the witch even attempted an action or whether the backend rejected it.
- **Role card UI no-update fix** (`GameView.vue` + `gameStore`) — STOMP handler had no case for `RoleAssigned`, so the event fell through into `addEvent()` and `state.myRole` never got set. Players had to manually refresh to see their role. New explicit handler + `setMyRole(role)` store action using the existing object-spread mutation pattern (`pinia-nested-mutation` memory).
- **VM debug tooling** (`.claude/skills/vm-debug/` + `scripts/vm-ssh.sh`) — skill documents how to SSH into `werewolf-server` (us-east1-d / `werewolf-301709`), the docker-compose-on-VM gotchas (`sudo` + `--env-file .env.prod`), and safety rules. `vm-ssh.sh` reuses an SSH ControlMaster so subsequent calls are ~0.5s instead of ~3.5s.

Out of scope, flagged separately:
- Action button loading/disabled UX state (UI-wide change)
- `POST /api/room/leave` 405 (frontend calls a route the backend doesn't expose — 106 hits in nginx)
- Frontend container reporting `unhealthy`

## Test plan

- [x] `gradlew compileKotlin` → BUILD SUCCESSFUL
- [x] `gradlew test --tests '*GameController*' --tests '*GameActionDispatcher*'` → BUILD SUCCESSFUL
- [x] `vue-tsc --noEmit` → no errors
- [x] `vitest run gameStore.test.ts` → 6/6 passing
- [ ] After merge + deploy: tail `docker compose logs --since=5m backend | grep action.submit` on the VM to confirm new log lines appear
- [ ] After merge + deploy: open a new game, confirm role card renders without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)