### PR TITLE
fix(frontend): resync state on STOMP reconnect + handle 4 missed events

### DIFF
--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -826,17 +826,40 @@ function onPlayerTap(player: GamePlayer) {
 
 onMounted(async () => {
   const gameId = route.params.gameId as string
-  try {
+
+  async function refreshState(): Promise<void> {
     const state = await gameService.getState(gameId)
     gameStore.setState(state)
+  }
+
+  try {
+    await refreshState()
   } catch {
     router.push({ name: 'lobby' })
     return
   }
 
+  // If the game ended before we mounted (or the player reloaded after GameOver),
+  // jump to the result screen instead of rendering the blank fallback view.
+  if (gameStore.state?.phase === 'GAME_OVER') {
+    router.push({ name: 'result', params: { gameId } })
+    return
+  }
+
   if (userStore.token) {
     const client = createStompClient(userStore.token)
-    client.onConnect = () => {
+    let isFirstConnect = true
+    client.onConnect = async () => {
+      if (isFirstConnect) {
+        isFirstConnect = false
+      } else {
+        // STOMP auto-reconnects after ~3s but the broker does not replay
+        // events broadcast during the disconnect window. Resync once on
+        // every reconnect so the UI catches up to whatever the player
+        // missed (sub-phase advances, deaths, sheriff handover, etc.).
+        try { await refreshState() } catch { /* user can still recover via refresh */ }
+      }
+
       subscribeToTopic(`/topic/game/${gameId}`, async (msg: { body: string }) => {
         const data = JSON.parse(msg.body)
         // Mock sends full state snapshots; real backend sends typed domain events
@@ -907,29 +930,36 @@ onMounted(async () => {
         }
         // Real backend: night result (kills) → re-fetch state
         if (data.type === 'NightResult') {
-          const state = await gameService.getState(gameId)
-          gameStore.setState(state)
+          await refreshState()
+        }
+        // A player died (vote / hunter / poison / etc.) → re-fetch so isAlive flips
+        if (data.type === 'PlayerEliminated') {
+          await refreshState()
+        }
+        // Hunter fired → target death + chain reactions land in state
+        if (data.type === 'HunterShot') {
+          await refreshState()
+        }
+        // Sheriff badge transferred or destroyed → re-fetch updated sheriff state
+        if (data.type === 'BadgeHandover') {
+          await refreshState()
         }
         // Sheriff elected (winner or host appointment) → re-fetch to get updated sheriff state
         if (data.type === 'SheriffElected') {
-          const state = await gameService.getState(gameId)
-          gameStore.setState(state)
+          await refreshState()
         }
         // Idiot revealed → re-fetch to get updated canVote/idiotRevealed player state
         if (data.type === 'IdiotRevealed') {
-          const state = await gameService.getState(gameId)
-          gameStore.setState(state)
+          await refreshState()
         }
         // Vote cast → re-fetch so votedPlayerIds/votesSubmitted updates for all viewers
         if (data.type === 'VoteSubmitted') {
-          const state = await gameService.getState(gameId)
-          gameStore.setState(state)
+          await refreshState()
         }
         // Vote tally revealed → re-fetch to get updated subPhase and tally
         // This is the main event that should trigger UI update; PhaseChanged is also sent but VoteTally is more complete
         if (data.type === 'VoteTally') {
-          const state = await gameService.getState(gameId)
-          gameStore.setState(state)
+          await refreshState()
         }
         // Both mock (GAME_OVER) and real backend (GameOver) navigate to result
         if (data.type === 'GAME_OVER' || data.type === 'GameOver') {
@@ -937,10 +967,13 @@ onMounted(async () => {
         }
       })
       // Private channel for role-specific info (night actions, etc.)
-      subscribeToTopic('/user/queue/private', (msg: { body: string }) => {
+      subscribeToTopic('/user/queue/private', async (msg: { body: string }) => {
         const data = JSON.parse(msg.body)
         if (data.type === 'WolfSelectionChanged') {
           gameStore.updateNightPhaseSelection(data.selectedTargetUserId)
+        } else if (data.type === 'SeerResult') {
+          // Refetch picks up nightPhase.seerCheckedUserId + seerResultIsWerewolf
+          await refreshState()
         } else {
           gameStore.addEvent(data)
         }

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -857,7 +857,11 @@ onMounted(async () => {
         // events broadcast during the disconnect window. Resync once on
         // every reconnect so the UI catches up to whatever the player
         // missed (sub-phase advances, deaths, sheriff handover, etc.).
-        try { await refreshState() } catch { /* user can still recover via refresh */ }
+        try {
+          await refreshState()
+        } catch {
+          /* user can still recover via refresh */
+        }
       }
 
       subscribeToTopic(`/topic/game/${gameId}`, async (msg: { body: string }) => {


### PR DESCRIPTION
## Summary

The STOMP client auto-reconnects after a drop (3s delay, `stompClient.ts:24`) but the broker does not replay events broadcast during the disconnect window. Today, `GameView`'s `onConnect` only re-subscribes — any phase advance, sub-phase transition, death, or sheriff handover that happened during the gap is lost forever and the UI sits stale until the player thinks to refresh. The role-card race fixed in #50 was one symptom of this same class.

Three changes in `GameView.vue`:

1. **Auto-resync on every STOMP reconnect.** Extract the state fetch into a `refreshState()` helper; call it on every `onConnect` (skipped on the very first connect since `onMounted` already fetched). Closes the entire "stale UI after reconnect" class in one place.
2. **Explicit handlers for 4 events** that previously had no case and were updated only as a side-effect of a sibling event firing: `PlayerEliminated`, `HunterShot`, `BadgeHandover` (public topic) and `SeerResult` (private queue). Each refetches state.
3. **GameOver recovery on mount.** If a player loads the game page after the game already ended, redirect to `/result` instead of rendering the blank fallback view.

## Out of scope (deferred)

- `AudioSequence` resync after reconnect (cosmetic; missed audio cue acceptable)
- `RoleAction` event-driven prompts (placeholder for future UI)
- 3 missing audio files (`villager_close_eyes.mp3`, `idiot_close_eyes.mp3`, `hunter_close_eyes.mp3`) — referenced by backend `*AudioConfig.kt` but absent from `static/audio/`. Cosmetic 404s in console.
- A separate witch-stuck-after-refresh bug whose root cause is **not** STOMP timing — needs its own reproducer.

## Test plan

- [x] `npx vue-tsc --noEmit` → no errors
- [x] `npx vitest run gameStore.test.ts` → 6/6 passing
- [ ] Mock smoke test: `VITE_MOCK=true npm run dev`, open game, toggle DevTools "Offline" for 5s, reconnect → console shows refetch, UI matches mock state.
- [ ] Real backend smoke test on the VM (after deploy + with #50 merged): join a game in progress, drop wifi 10s, reconnect → UI catches up without manual refresh; backend log shows a fresh `GET /api/game/{id}/state` after reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)