### PR TITLE
feat(backend): per-state-change snapshot log with waitingOn derivation

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/service/GameStateLogger.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/GameStateLogger.kt
@@ -1,0 +1,160 @@
+package com.werewolf.service
+
+import com.werewolf.model.*
+import com.werewolf.repository.*
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+/**
+ * Emits a one-line snapshot of a game's current state for server-side debugging.
+ *
+ * Goal: `grep "game.state game=N" backend.log` walks every state transition for
+ * one game in chronological order, so when a game gets stuck the last line tells
+ * you the phase, sub-phase, and (load-bearing) which player(s) the game is
+ * waiting on. Combined with the per-action logs (`action.submit ...`) added in
+ * GameController, the log alone answers "what was done" and "where it's stuck".
+ *
+ * Triggered automatically from StompPublisher whenever a state-change DomainEvent
+ * is broadcast (one site for the whole codebase).
+ */
+@Service
+class GameStateLogger(
+    private val gameRepository: GameRepository,
+    private val gamePlayerRepository: GamePlayerRepository,
+    private val nightPhaseRepository: NightPhaseRepository,
+    private val sheriffElectionRepository: SheriffElectionRepository,
+    private val voteRepository: VoteRepository,
+) {
+    private val log = LoggerFactory.getLogger(GameStateLogger::class.java)
+
+    /**
+     * Emit a snapshot. `context` is a short label describing what just changed
+     * (e.g. "PHASE=NIGHT/-", "NIGHT_SUBPHASE=WITCH_ACT", "GAME_OVER winner=VILLAGER").
+     */
+    fun logSnapshot(gameId: Int, context: String) {
+        try {
+            val game = gameRepository.findById(gameId).orElse(null)
+            if (game == null) {
+                log.warn("game.state game={} ctx={} -> SKIP (game not found)", gameId, context)
+                return
+            }
+
+            val players = gamePlayerRepository.findByGameId(gameId)
+            val alive = players.count { it.alive }
+            val sheriff = players.firstOrNull { it.sheriff }?.userId
+
+            val sub = subPhaseLabel(gameId, game)
+            val details = phaseDetails(gameId, game, players)
+            val waitingOn = computeWaitingOn(gameId, game, players)
+
+            log.info(
+                "game.state game={} ctx={} phase={} subPhase={} day={} alive={}/{} sheriff={} {} waitingOn=[{}]",
+                gameId, context, game.phase, sub, game.dayNumber,
+                alive, players.size, sheriff ?: "null", details,
+                waitingOn.joinToString(","),
+            )
+        } catch (e: Exception) {
+            log.warn("game.state game={} ctx={} -> SKIP (logger error: {})", gameId, context, e.message)
+        }
+    }
+
+    private fun subPhaseLabel(gameId: Int, game: Game): String = when (game.phase) {
+        GamePhase.NIGHT -> nightPhaseRepository
+            .findByGameIdAndDayNumber(gameId, game.dayNumber)
+            .orElse(null)?.subPhase?.name ?: "?"
+        GamePhase.SHERIFF_ELECTION -> sheriffElectionRepository
+            .findByGameId(gameId)
+            .orElse(null)?.subPhase?.name ?: "?"
+        else -> game.subPhase ?: "-"
+    }
+
+    private fun phaseDetails(gameId: Int, game: Game, players: List<GamePlayer>): String = when (game.phase) {
+        GamePhase.NIGHT -> {
+            val np = nightPhaseRepository
+                .findByGameIdAndDayNumber(gameId, game.dayNumber)
+                .orElse(null)
+            if (np == null) "" else "wolfTarget=${np.wolfTargetUserId ?: "null"}" +
+                " seerChecked=${np.seerCheckedUserId ?: "null"}" +
+                " witchAnti=${np.witchAntidoteUsed}" +
+                " witchPoison=${np.witchPoisonTargetUserId ?: "null"}" +
+                " guardTarget=${np.guardTargetUserId ?: "null"}"
+        }
+        GamePhase.DAY_VOTING -> {
+            val votes = voteRepository.findByGameIdAndVoteContextAndDayNumber(
+                gameId, VoteContext.ELIMINATION, game.dayNumber,
+            )
+            val aliveCount = players.count { it.alive }
+            "votes=${votes.size}/$aliveCount"
+        }
+        else -> ""
+    }
+
+    /**
+     * Best-effort "who is the game waiting on" derivation. Returns userIds (not
+     * nicknames — keep log compact and stable). Empty list means no actionable
+     * blocker (typically auto-advancing or game over).
+     */
+    private fun computeWaitingOn(gameId: Int, game: Game, players: List<GamePlayer>): List<String> {
+        val alive = players.filter { it.alive }
+        return when (game.phase) {
+            GamePhase.ROLE_REVEAL -> alive.filter { !it.confirmedRole }.map { it.userId }
+            GamePhase.WAITING -> listOf("host:${game.hostUserId}")
+            GamePhase.SHERIFF_ELECTION -> sheriffWaitingOn(gameId, game, alive)
+            GamePhase.NIGHT -> nightWaitingOn(gameId, game, alive)
+            GamePhase.DAY_PENDING -> listOf("host:${game.hostUserId}")
+            GamePhase.DAY_DISCUSSION -> listOf("host:${game.hostUserId}")
+            GamePhase.DAY_VOTING -> votingWaitingOn(gameId, game, alive)
+            GamePhase.GAME_OVER -> emptyList()
+        }
+    }
+
+    private fun nightWaitingOn(gameId: Int, game: Game, alivePlayers: List<GamePlayer>): List<String> {
+        val np = nightPhaseRepository
+            .findByGameIdAndDayNumber(gameId, game.dayNumber)
+            .orElse(null) ?: return emptyList()
+        return when (np.subPhase) {
+            NightSubPhase.WAITING, NightSubPhase.COMPLETE -> emptyList()  // auto-advance
+            NightSubPhase.WEREWOLF_PICK -> alivePlayers.filter { it.role == PlayerRole.WEREWOLF }.map { it.userId }
+            NightSubPhase.SEER_PICK, NightSubPhase.SEER_RESULT ->
+                alivePlayers.filter { it.role == PlayerRole.SEER }.map { it.userId }
+            NightSubPhase.WITCH_ACT -> alivePlayers.filter { it.role == PlayerRole.WITCH }.map { it.userId }
+            NightSubPhase.GUARD_PICK -> alivePlayers.filter { it.role == PlayerRole.GUARD }.map { it.userId }
+        }
+    }
+
+    private fun votingWaitingOn(gameId: Int, game: Game, alivePlayers: List<GamePlayer>): List<String> {
+        return when (game.subPhase) {
+            // VOTING / RE_VOTING: alive players who haven't cast a vote this round
+            "VOTING", "RE_VOTING" -> {
+                val voted = voteRepository.findByGameIdAndVoteContextAndDayNumber(
+                    gameId, VoteContext.ELIMINATION, game.dayNumber,
+                ).map { it.voterUserId }.toSet()
+                alivePlayers.filter { it.canVote && it.userId !in voted }.map { it.userId }
+            }
+            "VOTE_RESULT" -> listOf("host:${game.hostUserId}")
+            "HUNTER_SHOOT" -> alivePlayers.filter { it.role == PlayerRole.HUNTER }.map { it.userId }
+            "BADGE_HANDOVER" -> alivePlayers.filter { it.sheriff }.map { it.userId }
+            else -> emptyList()
+        }
+    }
+
+    private fun sheriffWaitingOn(gameId: Int, game: Game, alivePlayers: List<GamePlayer>): List<String> {
+        val se = sheriffElectionRepository.findByGameId(gameId).orElse(null) ?: return emptyList()
+        return when (se.subPhase) {
+            // SIGNUP: any alive player can still campaign; host can advance to SPEECH
+            ElectionSubPhase.SIGNUP -> listOf("host:${game.hostUserId}") + alivePlayers.map { it.userId }
+            ElectionSubPhase.SPEECH -> {
+                val order = se.speakingOrder?.split(",")?.filter { it.isNotBlank() } ?: emptyList()
+                val current = order.getOrNull(se.currentSpeakerIdx)
+                if (current != null) listOf(current) else listOf("host:${game.hostUserId}")
+            }
+            ElectionSubPhase.VOTING -> {
+                val voted = voteRepository.findByGameIdAndVoteContextAndDayNumber(
+                    gameId, VoteContext.SHERIFF_ELECTION, game.dayNumber,
+                ).map { it.voterUserId }.toSet()
+                alivePlayers.filter { it.userId !in voted }.map { it.userId }
+            }
+            ElectionSubPhase.RESULT, ElectionSubPhase.TIED -> listOf("host:${game.hostUserId}")
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/werewolf/service/GameStateLogger.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/GameStateLogger.kt
@@ -3,6 +3,7 @@ package com.werewolf.service
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 
 /**
@@ -15,7 +16,8 @@ import org.springframework.stereotype.Service
  * GameController, the log alone answers "what was done" and "where it's stuck".
  *
  * Triggered automatically from StompPublisher whenever a state-change DomainEvent
- * is broadcast (one site for the whole codebase).
+ * is broadcast (one site for the whole codebase). Runs on the shared `taskExecutor`
+ * (see AsyncConfig) so the extra DB reads never delay the STOMP broadcast path.
  */
 @Service
 class GameStateLogger(
@@ -30,7 +32,13 @@ class GameStateLogger(
     /**
      * Emit a snapshot. `context` is a short label describing what just changed
      * (e.g. "PHASE=NIGHT/-", "NIGHT_SUBPHASE=WITCH_ACT", "GAME_OVER winner=VILLAGER").
+     *
+     * `@Async` — the game-logic thread fires-and-forgets; all DB reads below run
+     * on the async executor. Reorders in the log are possible if multiple snapshots
+     * queue for the same game, but sub-second-scale log reordering is acceptable
+     * for debugging (each line still carries its context label).
      */
+    @Async
     fun logSnapshot(gameId: Int, context: String) {
         try {
             val game = gameRepository.findById(gameId).orElse(null)

--- a/backend/src/main/kotlin/com/werewolf/service/StompPublisher.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/StompPublisher.kt
@@ -1,14 +1,21 @@
 package com.werewolf.service
 
+import com.werewolf.game.DomainEvent
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 
 @Service
-class StompPublisher(private val template: SimpMessagingTemplate) {
+class StompPublisher(
+    private val template: SimpMessagingTemplate,
+    private val gameStateLogger: GameStateLogger,
+) {
 
     /** Broadcast a public game event to all subscribers of this game. */
     fun broadcastGame(gameId: Int, event: Any) {
         template.convertAndSend("/topic/game/$gameId", event)
+        // After every state-change broadcast, emit a one-line state snapshot for
+        // server-side debugging. See GameStateLogger for the format.
+        stateChangeContext(event)?.let { ctx -> gameStateLogger.logSnapshot(gameId, ctx) }
     }
 
     /** Broadcast a room event to all subscribers of this room. */
@@ -19,5 +26,24 @@ class StompPublisher(private val template: SimpMessagingTemplate) {
     /** Send a private message to a specific user (role assignment, seer result, etc.). */
     fun sendPrivate(userId: String, event: Any) {
         template.convertAndSendToUser(userId, "/queue/private", event)
+    }
+
+    /**
+     * Map a DomainEvent to a short context label for the state snapshot. Returns
+     * null for events that aren't state changes (audio cues, per-vote/per-confirm
+     * pings) — these would just produce log noise without changing state.
+     */
+    private fun stateChangeContext(event: Any): String? = when (event) {
+        is DomainEvent.PhaseChanged -> "PHASE=${event.phase}/${event.subPhase ?: "-"}"
+        is DomainEvent.NightSubPhaseChanged -> "NIGHT_SUBPHASE=${event.subPhase}"
+        is DomainEvent.NightResult -> "NIGHT_RESULT kills=${event.kills.size}"
+        is DomainEvent.SheriffElected -> "SHERIFF_ELECTED=${event.sheriffUserId ?: "null"}"
+        is DomainEvent.BadgeHandover -> "BADGE=${event.fromUserId}->${event.toUserId ?: "destroyed"}"
+        is DomainEvent.PlayerEliminated -> "ELIMINATED=${event.userId}(${event.role})"
+        is DomainEvent.HunterShot -> "HUNTER_SHOT=${event.hunterUserId}->${event.targetUserId}"
+        is DomainEvent.VoteTally -> "VOTE_TALLY eliminated=${event.eliminatedUserId ?: "null"}"
+        is DomainEvent.IdiotRevealed -> "IDIOT_REVEALED=${event.userId}"
+        is DomainEvent.GameOver -> "GAME_OVER winner=${event.winner}"
+        else -> null  // RoleConfirmed, AudioSequence, OpenEyes, CloseEyes, RoleAction, VoteSubmitted, etc.
     }
 }

--- a/backend/src/main/kotlin/com/werewolf/service/StompPublisher.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/StompPublisher.kt
@@ -13,8 +13,9 @@ class StompPublisher(
     /** Broadcast a public game event to all subscribers of this game. */
     fun broadcastGame(gameId: Int, event: Any) {
         template.convertAndSend("/topic/game/$gameId", event)
-        // After every state-change broadcast, emit a one-line state snapshot for
-        // server-side debugging. See GameStateLogger for the format.
+        // After every state-change broadcast, fire-and-forget a one-line state
+        // snapshot for server-side debugging. logSnapshot is @Async so its DB
+        // reads cannot delay the broadcast path. See GameStateLogger.
         stateChangeContext(event)?.let { ctx -> gameStateLogger.logSnapshot(gameId, ctx) }
     }
 


### PR DESCRIPTION
## Summary

When a player reports "the game is stuck", the prod log today gives no direct answer — we infer the current state from a mix of broadcast events and DB rows. Add a single greppable snapshot line emitted on every state-change broadcast.

Example output:
```
game.state game=3 ctx=NIGHT_SUBPHASE=WITCH_ACT phase=NIGHT subPhase=WITCH_ACT
  day=2 alive=10/12 sheriff=guest:alice
  wolfTarget=guest:bob seerChecked=guest:carol witchAnti=false witchPoison=null guardTarget=null
  waitingOn=[guest:dq-witch]
```

The load-bearing field is `waitingOn`. For each phase/sub-phase the logger derives which players the game is blocked on:

| Phase / sub-phase | `waitingOn` |
|---|---|
| `ROLE_REVEAL` | alive players whose `confirmed_role = false` |
| `SHERIFF_ELECTION/SIGNUP` | host + all alive players (any can sign up) |
| `SHERIFF_ELECTION/SPEECH` | the speaker at `current_speaker_idx` of `speaking_order` |
| `SHERIFF_ELECTION/VOTING` | alive players who haven't cast a sheriff vote |
| `SHERIFF_ELECTION/RESULT` or `TIED` | host (reveal / appoint) |
| `NIGHT/WEREWOLF_PICK` | alive werewolves |
| `NIGHT/SEER_PICK` or `SEER_RESULT` | alive seer |
| `NIGHT/WITCH_ACT` | alive witch |
| `NIGHT/GUARD_PICK` | alive guard |
| `NIGHT/WAITING` or `COMPLETE` | nobody (auto-advance) |
| `DAY_PENDING` / `DAY_DISCUSSION` | host |
| `DAY_VOTING/VOTING` or `RE_VOTING` | alive voters who haven't submitted a vote this round |
| `DAY_VOTING/HUNTER_SHOOT` | alive hunter |
| `DAY_VOTING/BADGE_HANDOVER` | alive sheriff |
| `GAME_OVER` | none |

To debug a stuck game: `grep "game.state game=N" backend.log` and read the last line.

Combined with the per-action lines from #50 (`action.submit user=X type=Y -> SUCCESS|REJECTED reason="..."`) the backend log now answers both "what was done" and "where it's stuck" without a DB query.

## Implementation

- **New** `service/GameStateLogger.kt` — fetches game + players + sub-phase entity + relevant votes, formats the snapshot, derives `waitingOn`. Wrapped in `try/catch` so a bad fetch can never break a broadcast.
- **Edit** `service/StompPublisher.kt` — `broadcastGame` matches each `DomainEvent` to a context label (`PHASE=X`, `NIGHT_SUBPHASE=Y`, `VOTE_TALLY eliminated=Z`, etc.) and calls `logSnapshot`. Per-player pings (`RoleConfirmed`, `VoteSubmitted`, `AudioSequence`, `OpenEyes`/`CloseEyes`, `RoleAction`, `WolfSelectionChanged`) are filtered out — they'd produce noise without adding signal.

No new schema, no API change, no behavior change for clients.

## Test plan

- [x] `gradlew compileKotlin` → BUILD SUCCESSFUL (no warnings)
- [x] `gradlew test` (full backend suite) → BUILD SUCCESSFUL
- [ ] Smoke test on the VM (after deploy): start a game, advance to NIGHT/WITCH_ACT, then `./scripts/vm-ssh.sh "cd /opt/werewolf-simple && sudo docker compose --env-file .env.prod logs --since=5m backend | grep 'game.state'"` — expect one snapshot per state transition with sensible `waitingOn=[...]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)