### PR TITLE
test(e2e): un-quarantine flaky tests one by one

### DIFF
--- a/frontend/e2e/real/helpers/multi-browser.ts
+++ b/frontend/e2e/real/helpers/multi-browser.ts
@@ -116,27 +116,28 @@ export async function setupGame(
     const requiredRoles = ['WEREWOLF', 'VILLAGER']
     const allOptionalRoles = ['SEER', 'WITCH', 'HUNTER', 'GUARD', 'IDIOT']
     
-    // For each optional role, toggle to match desired state
+    // For each optional role, toggle to match desired state. Retry up to
+    // 3 times if the click didn't register — on slow CI the first click
+    // is occasionally swallowed and the role ends up in the wrong state,
+    // which then causes the backend to skip that role during game-start
+    // assignment (observed failure: "IDIOT bots not found" across all
+    // idiot-flow tests when the IDIOT toggle stayed off).
     for (const role of allOptionalRoles) {
       const shouldBeEnabled = opts.roles.includes(<"WEREWOLF" | "SEER" | "WITCH" | "GUARD" | "HUNTER" | "IDIOT" | "VILLAGER">role)
-      
-      // Find the role row
+
       const roleRow = hostPage.locator('.role-row').filter({ hasText: new RegExp(role, 'i') })
-      
-      // Check current state - if has toggle-on, it's enabled; toggle-off means disabled
-      const toggleOn = roleRow.locator('.toggle-on')
-      const toggleOff = roleRow.locator('.toggle-off')
-      
-      const isCurrentlyEnabled = (await toggleOn.count()) > 0
-      
-      // Toggle if state doesn't match
-      if (isCurrentlyEnabled !== shouldBeEnabled) {
-        // Click the appropriate toggle
-        const toggleToClick = isCurrentlyEnabled ? toggleOn : toggleOff
-        if ((await toggleToClick.count()) > 0) {
-          await toggleToClick.click()
-          await hostPage.waitForTimeout(300)
-        }
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const isEnabled = (await roleRow.locator('.toggle-on').count()) > 0
+        if (isEnabled === shouldBeEnabled) break
+
+        const toggle = isEnabled
+          ? roleRow.locator('.toggle-on')
+          : roleRow.locator('.toggle-off')
+        if ((await toggle.count()) === 0) break
+
+        await toggle.click()
+        await hostPage.waitForTimeout(300)
       }
     }
   }

--- a/frontend/e2e/real/helpers/multi-browser.ts
+++ b/frontend/e2e/real/helpers/multi-browser.ts
@@ -260,7 +260,20 @@ export async function setupGame(
 
   // ── Step 7: Discover roles ─────────────────────────────────────────────
 
-  const roleMap = getRoles(roomCode)
+  // Role assignment is async on the backend — on loaded CI runners the
+  // 2s wait above is sometimes not enough and roles.sh returns an empty
+  // or partial mapping. Poll up to 8 extra seconds; exit early on the
+  // first non-empty result. Fixes observed flake where roleMap.IDIOT was
+  // undefined even though IDIOT was in the requested roles list.
+  let roleMap = getRoles(roomCode)
+  const expectedRoles = (opts.roles ?? []) as RoleName[]
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const haveAllRequested = expectedRoles.length === 0
+      || expectedRoles.every((r) => (roleMap[r]?.length ?? 0) > 0)
+    if (Object.keys(roleMap).length > 0 && haveAllRequested) break
+    await hostPage.waitForTimeout(1_000)
+    roleMap = getRoles(roomCode)
+  }
   const state = readStateFile(roomCode)
 
   // Detect the host's role from the roleMap

--- a/frontend/e2e/real/idiot-flow.spec.ts
+++ b/frontend/e2e/real/idiot-flow.spec.ts
@@ -25,12 +25,7 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
 
   // ── Test 1: Setup verification ──────────────────────────────────────────────
 
-  // QUARANTINED 2026-04-24: same random-role-assignment issue as tests 2 and 3.
-  // `expect(idiotBots).toBeDefined()` fails when the backend's random role
-  // assignment lands IDIOT on the host seat (so roleMap.IDIOT is empty).
-  // Memory e2e-ci-vs-local-env-differences item 4. Fix = branch on
-  // ctx.hostRole and either skip or route the check through the host.
-  test.fixme('1. Setup — idiot role assigned correctly', async ({ browser }, testInfo) => {
+  test('1. Setup — idiot role assigned correctly', async ({ browser }, testInfo) => {
     testInfo.setTimeout(120_000)
     const localCtx = await setupGame(browser, {
       totalPlayers: 6,
@@ -40,17 +35,26 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
     })
 
     try {
-      // Verify that IDIOT role is assigned
-      const idiotBots = localCtx.roleMap['IDIOT']
-      expect(idiotBots).toBeDefined()
-      expect(idiotBots?.length).toBeGreaterThan(0)
-      
-      // Verify that IDIOT browser page exists
+      // Verify that IDIOT is assigned. roleMap only tracks non-host bots, so
+      // when the backend's random role-assignment lands IDIOT on the host
+      // seat `roleMap.IDIOT` is empty and the verification has to go through
+      // localCtx.hostRole instead.
+      if (localCtx.isHostRole('IDIOT')) {
+        expect(localCtx.hostRole).toBe('IDIOT')
+      } else {
+        const idiotBots = localCtx.roleMap['IDIOT']
+        expect(idiotBots).toBeDefined()
+        expect(idiotBots?.length).toBeGreaterThan(0)
+      }
+
+      // IDIOT browser page exists either way — setupGame maps the host's page
+      // under hostRole's key when hostRole is one of the browserRoles.
       const idiotPage = localCtx.pages.get('IDIOT')
       expect(idiotPage).toBeDefined()
-      
+
       testInfo.attach('idiot-info', { body: JSON.stringify({
-        idiotBots: idiotBots,
+        hostRole: localCtx.hostRole,
+        idiotBots: localCtx.roleMap['IDIOT'],
         hasIdiotPage: !!idiotPage,
         totalBots: localCtx.allBots.length
       }, null, 2) })

--- a/frontend/e2e/real/idiot-flow.spec.ts
+++ b/frontend/e2e/real/idiot-flow.spec.ts
@@ -65,13 +65,7 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
 
   // ── Test 2: Night → Day → Voting → Idiot Reveal ─────────────────────────────────
 
-  // QUARANTINED 2026-04-24: Same random-role-assignment issue as test 3 —
-  // "IDIOT bots not found" when backend assigns IDIOT to the host seat, then
-  // `localCtx.roleMap.IDIOT` is empty. Memory: e2e-ci-vs-local-env-differences
-  // item 4. Also exposes the NIGHT→DAY phase-transition stall from revote-
-  // flow test 2. Fix needs both a host-as-IDIOT branch + the UI-reactivity
-  // fix for the phase transition.
-  test.fixme('2. Idiot reveal — all browsers show idiot reveal banner', async ({ browser }, testInfo) => {
+  test('2. Idiot reveal — all browsers show idiot reveal banner', async ({ browser }, testInfo) => {
     testInfo.setTimeout(120_000)
     const localCtx = await setupGame(browser, {
       totalPlayers: 6,
@@ -81,6 +75,17 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
     })
 
     try {
+      // When random role assignment lands IDIOT on the host seat, the existing
+      // "all bots vote for idiot" path via act.sh doesn't apply — the host
+      // isn't in the bot state file. Test 1 still covers this case via its
+      // isHostRole('IDIOT') branch; skip here with a clear rationale.
+      // Memory: e2e-ci-vs-local-env-differences item 4.
+      if (localCtx.isHostRole('IDIOT')) {
+        testInfo.attach('skip-reason', { body: 'Host rolled IDIOT — idiot-reveal voting flow requires a bot IDIOT. Test 1 covers host-as-IDIOT.' })
+        test.skip(true, 'Host rolled IDIOT — covered by test 1')
+        return
+      }
+
       const hostPage = localCtx.hostPage
 
       // Check initial game state after setup
@@ -348,14 +353,9 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
     }
   })
 
-  // ── Test 2: Phase Transition after Idiot Reveal ──────────────────────────────
+  // ── Test 3: Phase Transition after Idiot Reveal ──────────────────────────────
 
-  // QUARANTINED 2026-04-24: "IDIOT bots not found" when the random role
-  // assignment puts IDIOT on the host (seat 9). Memory: e2e-ci-vs-local-env-
-  // differences item 4 ("Random role assignment breaks spec assumptions").
-  // Fix is either test.skip(ctx.hostRole === 'IDIOT') at the top of the test
-  // OR route the idiot-reveal through the host browser when host is the idiot.
-  test.fixme('3. Phase transition — VOTE_RESULT to NIGHT', async ({ browser }, testInfo) => {
+  test('3. Phase transition — VOTE_RESULT to NIGHT', async ({ browser }, testInfo) => {
     testInfo.setTimeout(120_000)
     const localCtx = await setupGame(browser, {
       totalPlayers: 6,
@@ -365,6 +365,15 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
     })
 
     try {
+      // Same host-as-IDIOT skip as test 2 — the idiot-reveal voting path
+      // requires a bot IDIOT so act.sh can drive it. Memory:
+      // e2e-ci-vs-local-env-differences item 4.
+      if (localCtx.isHostRole('IDIOT')) {
+        testInfo.attach('skip-reason', { body: 'Host rolled IDIOT — VOTE_RESULT→NIGHT path needs a bot IDIOT.' })
+        test.skip(true, 'Host rolled IDIOT — covered by test 1')
+        return
+      }
+
       const hostPage = localCtx.hostPage
 
       // ── Phase 0: Start Night Phase ──

--- a/frontend/e2e/real/revote-flow.spec.ts
+++ b/frontend/e2e/real/revote-flow.spec.ts
@@ -322,11 +322,7 @@ test.describe('Voting tie → revote → game proceeds', () => {
 
   // ── Test 3: Create a tied vote ───────────────────────────────────────
 
-  // QUARANTINED 2026-04-24: depends on state set up by test 2 (which is
-  // also fixme'd). If test 2 is restored, re-enable this. The failure we
-  // see here is a cascade — `revealBtn.waitFor` times out because the game
-  // is still on NIGHT from test 2's stall.
-  test.fixme('3. Tied vote triggers RE_VOTING', async ({}, testInfo) => {
+  test('3. Tied vote triggers RE_VOTING', async ({}, testInfo) => {
     const hostPage = ctx.hostPage
 
     // Host reveals night result
@@ -418,12 +414,7 @@ test.describe('Voting tie → revote → game proceeds', () => {
 
   // ── Test 4: Complete the game after revote ───────────────────────────
 
-  // QUARANTINED 2026-04-24: intermittent — this test runs a full multi-round
-  // game loop and is inherently timing-sensitive. Passed on commit c44c014's
-  // local run but flaked on CI retry. Depends on tests 2 and 3 (both
-  // fixme'd) having set up a RE_VOTING state. With the previous tests
-  // quarantined, this test's preconditions are unreliable too.
-  test.fixme('4. Game proceeds to completion after revote', async ({}, testInfo) => {
+  test('4. Game proceeds to completion after revote', async ({}, testInfo) => {
     // 600s gives headroom for an uncapped round loop under shrunk e2e timings.
     // The prior 300s + 15-round cap hit both limits simultaneously on CI.
     testInfo.setTimeout(600_000)

--- a/frontend/e2e/real/revote-flow.spec.ts
+++ b/frontend/e2e/real/revote-flow.spec.ts
@@ -312,13 +312,7 @@ test.describe('Voting tie → revote → game proceeds', () => {
     }
   }
 
-  // QUARANTINED 2026-04-24: intermittent NIGHT→DAY transition stall not
-  // resolved by the Category A sub-phase gates added in this PR. Likely the
-  // same class of product/spec bug quarantined in `guard-audio-sequence` and
-  // `flow-12p-sheriff` (memory: quarantined-e2e-tests-2026-04-19). Needs its
-  // own reproducer + fix — probably UI-reactivity lag on the role-owned
-  // browser page, or a phase-transition event that isn't being awaited.
-  test.fixme('2. Complete night — wolf kills, witch saves', async ({}, testInfo) => {
+  test('2. Complete night — wolf kills, witch saves', async ({}, testInfo) => {
     await completeNight({ witchUseAntidote: true })
 
     // Wait for DAY

--- a/frontend/e2e/real/werewolf-win.spec.ts
+++ b/frontend/e2e/real/werewolf-win.spec.ts
@@ -286,14 +286,7 @@ test.describe('Werewolf win — result screen shows all roles', () => {
     await captureSnapshot(ctx.pages, testInfo, '01-night-start')
   })
 
-  // QUARANTINED 2026-04-24: the multi-round "play until wolves win" loop is
-  // sensitive to random role assignment and day-vote dynamics. With maxRounds=6
-  // and a naive abstain strategy, some role-layouts let the village win by
-  // accident (voting eliminates a wolf without coordinated information) — or
-  // the 6-round cap is reached before wolves have parity. Same class of test
-  // as flow-12p-sheriff (quarantined) — needs a host-role-aware voting
-  // strategy, or a deterministic role assignment mode in e2e profile.
-  test.fixme('2. Play rounds until werewolf wins, verify result screen', async ({}, testInfo) => {
+  test('2. Play rounds until werewolf wins, verify result screen', async ({}, testInfo) => {
     const villagerBots = ctx.roleMap.VILLAGER ?? []
     const seerBots = ctx.roleMap.SEER ?? []
     const guardBots = ctx.roleMap.GUARD ?? []


### PR DESCRIPTION
## Summary

Addresses the 7+ `test.fixme`'d tests one-by-one to bring each back to the green suite.

Each fix gets its own commit with the root-cause analysis + approach in the commit body.

## Progress

- [x] `idiot-flow.spec.ts` test 1 — host-as-IDIOT branch (commit `bc0ddc0`)
- [ ] `idiot-flow.spec.ts` test 2
- [ ] `idiot-flow.spec.ts` test 3
- [ ] `revote-flow.spec.ts` test 2
- [ ] `revote-flow.spec.ts` test 3
- [ ] `revote-flow.spec.ts` test 4
- [ ] `werewolf-win.spec.ts` test 2

Will rebase + land incrementally as each passes CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)