### PR TITLE
test(e2e): filter-out-voted + host helpers, eliminate act() retry cascades

### DIFF
--- a/frontend/e2e/real/flow-12p-sheriff.spec.ts
+++ b/frontend/e2e/real/flow-12p-sheriff.spec.ts
@@ -604,7 +604,7 @@ test.describe('12p sheriff — CLASSIC villager win', () => {
       await startBtn.click()
     } else {
       // sheriff flow sometimes auto-transitions; try scripted fallback
-      tryAct('START_NIGHT', undefined, { room: ctx.roomCode })
+      tryAct('START_NIGHT', 'Host', { room: ctx.roomCode })
     }
     await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 20_000)
     await captureSnapshot(ctx.pages, testInfo, 'classic-03-night-1-entered')
@@ -735,7 +735,7 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     if (await startBtn.isVisible({ timeout: 10_000 }).catch(() => false)) {
       await startBtn.click()
     } else {
-      tryAct('START_NIGHT', undefined, { room: ctx.roomCode })
+      tryAct('START_NIGHT', 'Host', { room: ctx.roomCode })
     }
     await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 20_000)
     await captureSnapshot(ctx.pages, testInfo, 'hard-03-night-1-entered')

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -14,7 +14,7 @@ import {type GameContext, setupGame} from './helpers/multi-browser'
 import {act, type RoleName} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase,} from './helpers/assertions'
 import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
-import {waitForNightSubPhase} from './helpers/state-polling'
+import {readHostUserId, readUnvotedAlivePlayerIds, waitForNightSubPhase} from './helpers/state-polling'
 
 let ctx: GameContext
 
@@ -339,12 +339,20 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     const wolfBots = ctx.roleMap.WEREWOLF ?? []
     const wolfTarget = wolfBots.find((b) => b.nick !== 'Host')
 
-    if (wolfTarget) {
-      // All bots vote for the wolf (host's duplicate vote will be rejected harmlessly)
-      act('SUBMIT_VOTE', undefined, { target: String(wolfTarget.seat), room: ctx.roomCode })
-    } else {
-      // All bots abstain
-      act('SUBMIT_VOTE', undefined, { room: ctx.roomCode })
+    // Fan-out the vote only to bots that are alive, not host, and haven't
+    // voted yet — the host already clicked abstain above so their userId is
+    // in state.votingPhase.votedPlayerIds. Without the filter, act.sh would
+    // iterate every bot (plus host) and the redundant attempts on the
+    // already-voted host would burn act.sh's 3× retry quota on rejection.
+    const unvoted = await readUnvotedAlivePlayerIds(ctx.hostPage, ctx.gameId)
+    const hostId = await readHostUserId(ctx.hostPage)
+    const voteOpts: { target?: string; room: string } = wolfTarget
+      ? { target: String(wolfTarget.seat), room: ctx.roomCode }
+      : { room: ctx.roomCode }
+    for (const bot of ctx.allBots) {
+      if (bot.nick === 'Host' || bot.userId === hostId) continue
+      if (!unvoted.has(bot.userId)) continue
+      act('SUBMIT_VOTE', bot.nick, voteOpts)
     }
 
     // Wait for all votes to register

--- a/frontend/e2e/real/helpers/state-polling.ts
+++ b/frontend/e2e/real/helpers/state-polling.ts
@@ -132,3 +132,50 @@ export async function readAlivePlayerIds(
   }, gameId)
   return new Set(ids)
 }
+
+/**
+ * Return the userIds of alive players who have NOT yet voted in the current
+ * voting round. Combines `state.players[*].isAlive` with
+ * `state.votingPhase.votedPlayerIds` (the backend's per-round voter set).
+ *
+ * Use this to pre-filter bots BEFORE firing `act('SUBMIT_VOTE', ...)`: without
+ * this filter, the retry loop inside `act()` sees the fan-out call's mixed
+ * rejection output ("Already voted this round" / "Dead players cannot vote")
+ * and retries all players up to 3 times — wasting ~6s per redundant call.
+ *
+ * Returns an empty Set when no voting round is active (phase ≠ DAY_VOTING
+ * or state fetch failed) — callers should interpret that as "no candidate
+ * voters" and skip the fan-out entirely.
+ */
+export async function readUnvotedAlivePlayerIds(
+  hostPage: Page,
+  gameId: string,
+): Promise<Set<string>> {
+  const ids = await hostPage.evaluate(async (id: string) => {
+    const token = localStorage.getItem('jwt')
+    if (!token) return [] as string[]
+    const res = await fetch(`/api/game/${id}/state`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!res.ok) return [] as string[]
+    const state = await res.json()
+    const voted = new Set<string>(state?.votingPhase?.votedPlayerIds ?? [])
+    return ((state?.players ?? []) as Array<{ isAlive: boolean; userId: string }>)
+      .filter((p) => p.isAlive && !voted.has(p.userId))
+      .map((p) => p.userId)
+  }, gameId)
+  return new Set(ids)
+}
+
+/**
+ * Return the host's userId — read from localStorage on the host page. Use
+ * this together with `readAlivePlayerIds` / `readUnvotedAlivePlayerIds` to
+ * exclude the host from bulk bot-action fan-outs, since the host's JWT is
+ * stored in the browser (not the shell state file) and host-only actions
+ * (START_NIGHT, DAY_ADVANCE, VOTING_REVEAL_TALLY, VOTING_CONTINUE) must be
+ * driven either through the UI or via a dedicated host-token `act.sh` call
+ * rather than through the default "all bots" fan-out.
+ */
+export async function readHostUserId(hostPage: Page): Promise<string | null> {
+  return hostPage.evaluate(() => localStorage.getItem('userId'))
+}

--- a/frontend/e2e/real/idiot-flow.spec.ts
+++ b/frontend/e2e/real/idiot-flow.spec.ts
@@ -16,7 +16,7 @@ import {type GameContext, setupGame} from './helpers/multi-browser'
 import {act, type RoleName} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase,} from './helpers/assertions'
 import {captureSnapshot} from './helpers/composite-screenshot'
-import {waitForNightSubPhase} from './helpers/state-polling'
+import {readHostUserId, readUnvotedAlivePlayerIds, waitForNightSubPhase} from './helpers/state-polling'
 
 let ctx: GameContext
 
@@ -132,7 +132,7 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
         
         // Try to use script to start night phase
         try {
-          act('START_NIGHT', undefined, { room: localCtx.roomCode })
+          act('START_NIGHT', 'Host', { room: localCtx.roomCode })
           testInfo.attach('night-start-triggered', { body: 'Start night action triggered' })
           await hostPage.waitForTimeout(5_000)
         } catch (error) {
@@ -309,10 +309,19 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
       
       const idiotBot = idiotBots[0]
       testInfo.attach('idiot-info', { body: JSON.stringify(idiotBot, null, 2) })
-      
-      // All players vote for the idiot to trigger idiot reveal
-      act('SUBMIT_VOTE', undefined, { target: String(idiotBot.seat), room: localCtx.roomCode })
-      testInfo.attach('votes-submitted', { body: `All players voted for idiot at seat ${idiotBot.seat}` })
+
+      // Fan-out vote only to alive, non-host, unvoted bots — skips
+      // already-voted and dead players to avoid act.sh's 3× retry cascade.
+      {
+        const unvoted = await readUnvotedAlivePlayerIds(hostPage, localCtx.gameId)
+        const hostId = await readHostUserId(hostPage)
+        for (const bot of localCtx.allBots) {
+          if (bot.nick === 'Host' || bot.userId === hostId) continue
+          if (!unvoted.has(bot.userId)) continue
+          act('SUBMIT_VOTE', bot.nick, { target: String(idiotBot.seat), room: localCtx.roomCode })
+        }
+        testInfo.attach('votes-submitted', { body: `Fan-out vote for idiot at seat ${idiotBot.seat}` })
+      }
       
       // Wait for all votes to register
       await hostPage.waitForTimeout(2_000)
@@ -382,7 +391,7 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
       
       // Use script to start night phase
       try {
-        act('START_NIGHT', undefined, { room: localCtx.roomCode })
+        act('START_NIGHT', 'Host', { room: localCtx.roomCode })
         testInfo.attach('night-start-triggered', { body: 'Start night action triggered' })
         await hostPage.waitForTimeout(5_000)
       } catch (error) {
@@ -513,7 +522,17 @@ test.describe('Idiot flow — multi-browser STOMP verification', () => {
       }
       
       const idiotBot = idiotBots[0]
-      act('SUBMIT_VOTE', undefined, { target: String(idiotBot.seat), room: localCtx.roomCode })
+      // Fan-out vote only to alive, non-host, unvoted bots (same rationale
+      // as test 2's vote step).
+      {
+        const unvoted = await readUnvotedAlivePlayerIds(hostPage, localCtx.gameId)
+        const hostId = await readHostUserId(hostPage)
+        for (const bot of localCtx.allBots) {
+          if (bot.nick === 'Host' || bot.userId === hostId) continue
+          if (!unvoted.has(bot.userId)) continue
+          act('SUBMIT_VOTE', bot.nick, { target: String(idiotBot.seat), room: localCtx.roomCode })
+        }
+      }
       await hostPage.waitForTimeout(2_000)
       act('VOTING_REVEAL_TALLY', 'HOST', { room: localCtx.roomCode })
       await hostPage.waitForTimeout(3_000)

--- a/frontend/e2e/real/revote-flow.spec.ts
+++ b/frontend/e2e/real/revote-flow.spec.ts
@@ -13,7 +13,7 @@ import {type GameContext, setupGame} from './helpers/multi-browser'
 import {act, type RoleName} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase} from './helpers/assertions'
 import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
-import {readAlivePlayerIds, waitForNightSubPhase} from './helpers/state-polling'
+import {readAlivePlayerIds, readHostUserId, readUnvotedAlivePlayerIds, waitForNightSubPhase} from './helpers/state-polling'
 
 let ctx: GameContext
 
@@ -464,9 +464,18 @@ test.describe('Voting tie → revote → game proceeds', () => {
           room: ctx.roomCode,
         })
       }
-      // Fan-out abstain; "Already voted" / "Dead players cannot vote" here
-      // are terminal rejections and expected noise per the backend rules.
-      tryAct('SUBMIT_VOTE', undefined, { room: ctx.roomCode })
+      // Fan-out abstain — only to bots that are alive, not host, and haven't
+      // voted yet. Replaces the old `act('SUBMIT_VOTE', undefined)` call which
+      // iterated every bot (including the already-voted decisive and dead
+      // bots), producing "Already voted" / "Dead players cannot vote"
+      // rejections that tripped act.sh's 3× retry and wasted ~6s per call.
+      const unvoted = await readUnvotedAlivePlayerIds(ctx.hostPage, ctx.gameId)
+      const hostId = await readHostUserId(ctx.hostPage)
+      for (const bot of ctx.allBots) {
+        if (bot.nick === 'Host' || bot.userId === hostId) continue
+        if (!unvoted.has(bot.userId)) continue
+        tryAct('SUBMIT_VOTE', bot.nick, { room: ctx.roomCode })
+      }
       // Host abstains via the skip-btn click so the host's vote counts toward
       // allVoted (voting-reveal button is disabled until allVoted=true).
       const abstainBtn = ctx.hostPage.locator('.skip-btn').first()

--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -170,7 +170,7 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
     } else {
       // Use script
       try {
-        act('START_NIGHT', undefined, { room: ctx.roomCode })
+        act('START_NIGHT', 'Host', { room: ctx.roomCode })
       } catch {
         // Might auto-advance
       }

--- a/frontend/e2e/real/werewolf-win.spec.ts
+++ b/frontend/e2e/real/werewolf-win.spec.ts
@@ -13,7 +13,7 @@ import {type GameContext, setupGame} from './helpers/multi-browser'
 import {act, type RoleName} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase} from './helpers/assertions'
 import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
-import {readAlivePlayerIds, waitForNightSubPhase} from './helpers/state-polling'
+import {readAlivePlayerIds, readHostUserId, readUnvotedAlivePlayerIds, waitForNightSubPhase} from './helpers/state-polling'
 
 let ctx: GameContext
 
@@ -260,7 +260,17 @@ test.describe('Werewolf win — result screen shows all roles', () => {
         await hostPage.waitForTimeout(500)
       }
 
-      tryAct('SUBMIT_VOTE', undefined, { room: ctx.roomCode })
+      // Fan-out abstain to alive, non-host, unvoted bots only. Avoids the
+      // "Already voted" / "Dead players cannot vote" retry cascade in
+      // act.sh when some bots have already abstained via the host-browser
+      // click above.
+      const unvoted = await readUnvotedAlivePlayerIds(ctx.hostPage, ctx.gameId)
+      const hostId = await readHostUserId(ctx.hostPage)
+      for (const bot of ctx.allBots) {
+        if (bot.nick === 'Host' || bot.userId === hostId) continue
+        if (!unvoted.has(bot.userId)) continue
+        tryAct('SUBMIT_VOTE', bot.nick, { room: ctx.roomCode })
+      }
       await hostPage.waitForTimeout(2_000)
 
       tryAct('VOTING_REVEAL_TALLY', 'HOST', { room: ctx.roomCode })


### PR DESCRIPTION
## Summary

CI log analysis on the post-PR-#56 main run showed two big sources of wasted time + log noise, both caused by `act.sh` being called with `undefined` player (the "all bots" default). Fixed by pre-filtering call sites with two new helpers.

## New helpers in `frontend/e2e/real/helpers/state-polling.ts`

- **`readUnvotedAlivePlayerIds(hostPage, gameId)`** — returns `Set<userId>` of alive players who haven't voted yet (alive-minus-`state.votingPhase.votedPlayerIds`).
- **`readHostUserId(hostPage)`** — pulls host's userId from localStorage.

Built on the same pattern as `readAlivePlayerIds` from the last branch.

## Call-site updates

**`act('START_NIGHT', undefined, …)` → `act('START_NIGHT', 'Host', …)`** (4 specs)

Previously iterated every bot + host, generating "Only the host can start the night" × N bots, then "Cannot start night from current phase" on the host — and act.sh retried all of that 3× on rejection. Observed ~6s waste + 18+ log lines per call.

**`act('SUBMIT_VOTE', undefined, …)` → per-bot fan-out filtered by `readUnvotedAlivePlayerIds` ∩ non-host** (5 call sites across 4 specs)

Previously iterated every bot after the host had voted or some bots had died, generating "Already voted this round" / "Dead players cannot vote" cascades. Now only bots that actually need to vote are called.

## Expected impact on CI

- Shard 2 (the one that flakes most) should no longer burn ~6s per retry cascade.
- Backend log noise drops from hundreds of `rejected:` lines per run to near-zero.
- Flakes caused by cumulative wasted time pushing into test timeouts should resolve.

## Test plan

- [x] vue-tsc clean
- [ ] CI all 10 jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)