### PR TITLE
fix(night): reject duplicate WOLF_KILL to prevent seer-skip race

### DIFF
--- a/.claude/skills/prod-smoke-test/SKILL.md
+++ b/.claude/skills/prod-smoke-test/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: prod-smoke-test
+description: Use after deploying a werewolf-simple release tag (vX.Y.Z) to https://www.youplay123.online/, OR when the user says "run the prod smoke test" / "routine prod test". Also use when validating prod after a docker compose pull + up -d, or when investigating whether a production deploy is healthy end-to-end before declaring success.
+---
+
+# Prod smoke test — routine multi-device full-game flow
+
+## What this skill does
+
+Drives ONE complete werewolf game on production with three concurrent monitoring layers, so any stall, disconnect, or unhandled exception surfaces immediately rather than silently timing out. Pattern: **3 real human-controlled sessions** (user's phone, user's laptop, Claude's Chrome DevTools MCP browser) playing a 9-player CLASSIC game; the remaining 6 seats are bots driven from the prod VM via SSH. Reuses the existing `scripts/*.sh` family — no new scripts get written.
+
+**Output is a clean go/no-go signal** on the deployed release. Re-run after every `vX.Y.Z` tag.
+
+## Coordinates
+
+| | |
+|---|---|
+| Prod URL | `https://www.youplay123.online/` |
+| VM SSH wrapper | `scripts/vm-ssh.sh` (ControlMaster — fast repeated calls) |
+| BACKEND_BASE on VM | `http://127.0.0.1:8080/api` |
+| Default game | 9 players, sheriff OFF, roles: WEREWOLF + VILLAGER (required) + SEER + WITCH + GUARD; HUNTER + IDIOT off |
+| Estimated wall-clock | 15–20 min total |
+
+## Roster
+
+| Seat | Player | Driver |
+|---|---|---|
+| ? | User nickname A | Phone Safari/Chrome |
+| ? | User nickname B | Laptop browser |
+| ? | Claude | Chrome DevTools MCP |
+| ? × 6 | Bots | `scripts/*.sh` from VM via SSH |
+
+Roles randomized — Claude reads layout via `roles.sh` after CONFIRM_ROLE.
+
+## Pre-flight (always do this first)
+
+All read-only:
+
+```bash
+gcloud auth list                                                      # active account check
+./scripts/vm-ssh.sh 'curl -sf http://127.0.0.1:8080/api/health'        # backend up
+./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && sudo docker compose --env-file .env.prod ps'
+./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && sudo git log -1 --oneline'   # confirm deployed tag
+```
+
+Expect `{"status":"UP"}`, all 3 containers Up, deployed commit matches the release tag we're verifying. If any check fails, abort the smoke test and investigate.
+
+## Three monitoring layers (start ALL before the game begins)
+
+### L1 — Backend log stream (persistent Monitor task)
+
+Long-lived SSH that tails the backend container log on the VM with `--tail=0 -f` so we see only events emitted DURING the test. Filter is broad on purpose — every line is a potential failure signal.
+
+Spawn via the `Monitor` tool with `persistent: true`:
+
+```bash
+gcloud compute ssh werewolf-server --zone=us-east1-d --command='sudo docker compose -f /opt/werewolf-simple/docker-compose.yml --env-file /opt/werewolf-simple/.env.prod logs --tail=0 -f backend 2>&1 | stdbuf -oL grep -E "action\.submit|PhaseChanged|Exception|ERROR|WARN.*werewolf|disconnect|STOMP|waitingOn=|GameOver|BadgeHandover|game\.state"'
+```
+
+`stdbuf -oL` is critical — without it, grep's stdout buffers and notifications batch into 4 KB chunks (~30 s of silence between updates).
+
+### L2 — Claude's browser console (window.__appLog ring buffer)
+
+After Claude joins the room AND after any reload of `/game/<id>`, inject the patcher from `audio-patcher.js` (this skill folder) via `evaluate_script`. It captures audio playback events, STOMP events, errors, and unhandled rejections in a 500-entry ring buffer.
+
+To dump on demand: `evaluate_script` returning `window.__appLog`.
+
+### L3 — User-side console (phone + laptop)
+
+Claude can't introspect the user's real browsers. Ask the user to:
+- **Laptop**: open Chrome DevTools (F12) → Console + Network → WS tab. Report red errors or `1006 abnormal closure` on the WebSocket.
+- **Phone**: observe the in-app `[connection]` banner — frontend renders it on STOMP reconnect. If it appears mid-game, note it.
+
+Silence = healthy.
+
+## Setup walkthrough
+
+### S1. Pre-flight (Claude)
+
+Run all 4 pre-flight checks. Confirm green before going further.
+
+### S2. Spawn L1 Monitor (Claude)
+
+Persistent Monitor running the gcloud + grep command above.
+
+### S3. User logs in on phone (User)
+
+Open `https://www.youplay123.online/`, enter **nickname A**, tap Create Room, configure 9 players + sheriff OFF + default roles + classic win condition. Tap Create Room. **Paste the room code** + nickname A into chat.
+
+### S4. Claude joins as Claude (Claude)
+
+```
+mcp__plugin_chrome-devtools-mcp_chrome-devtools__new_page url=https://www.youplay123.online/
+fill nickname = "Claude"
+fill room-code = <CODE>
+click "加入 / Join"
+```
+
+Now on `/room/<id>`. Claim a seat: `evaluate_script` clicking `.slot-selectable`.
+
+### S5. Inject L2 patcher (Claude)
+
+Paste `audio-patcher.js` content into `evaluate_script`. Confirm `window.__appPatched === true`.
+
+### S6. User logs in on laptop (User)
+
+Open same URL, **nickname B**, **JOIN by room code** (NOT create). Claim a seat.
+
+### S7. Claude fills 6 bots from VM (Claude)
+
+```bash
+./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && BACKEND_BASE=http://127.0.0.1:8080/api ./scripts/join-room.sh <CODE> 6 --ready'
+```
+
+Verify: 9/9 in room.
+
+### S8. Each human readies up; host starts game
+
+- Phone: tap Ready (host doesn't need to ready themselves on most flows).
+- Laptop: tap Ready.
+- Claude (MCP): click `准备 / Ready` button.
+- Whoever created the room is host — they tap **Start Game**.
+
+### S9. Inject host token to VM state file (Claude)
+
+Lets `act.sh Host` work for host-only actions (REVEAL_NIGHT_RESULT, DAY_ADVANCE, etc.):
+
+```bash
+# Read host JWT from host browser's localStorage:
+#   evaluate_script: localStorage.getItem('jwt')   (Claude's MCP if Claude is host)
+#   OR ask user to paste from phone/laptop console: localStorage.getItem('jwt')
+HOST_JWT="<paste here>"
+./scripts/vm-ssh.sh "python3 -c 'import json; p=\"/tmp/werewolf-<CODE>.json\"; d=json.load(open(p)); d[\"hostToken\"]=\"$HOST_JWT\"; d[\"hostNick\"]=\"Host\"; json.dump(d,open(p,\"w\"))'"
+```
+
+If host JWT can't be obtained, fall back: have the host human click ALL host actions in their browser. Slower but works.
+
+## Game flow (sub-phase by sub-phase)
+
+For every sub-phase Claude:
+1. **Polls** backend `/state` for the expected `nightPhase.subPhase`. Coroutine gap on prod is ~5 s — poll up to 10× at 1 s intervals.
+2. **Fires** the corresponding action via the right driver (script for bots, MCP click for Claude, browser click instruction for user).
+3. **Cross-references** L1 (`SUCCESS` log line) + L2 (audio sequence change) before moving to next.
+
+### Night
+
+| Sub-phase | Bot driver | Human role driver |
+|---|---|---|
+| `WEREWOLF_PICK` | `act.sh WOLF_KILL <bot> --target <seat-or-nick>` | Wolf clicks slot + Confirm in their UI (twice — once selects, once confirms after WOLF_SELECT broadcasts) |
+| `SEER_PICK` / `SEER_RESULT` | `act.sh SEER_CHECK <bot> --target <bot-nick>` then `SEER_CONFIRM` | Seer clicks slot + Check; Confirm |
+| `WITCH_ACT` | `act.sh WITCH_ACT <bot> --payload '{"useAntidote":false}'` | Witch chooses Save / Skip / Poison via UI |
+| `GUARD_PICK` | `act.sh GUARD_SKIP <bot>` | Guard clicks slot + Protect, OR Skip |
+
+**Important — `act.sh --target` ambiguity**: passing a bare number like `--target 1` matches "Bot1" (by name) before "seat 1" (by index). When the target is a HUMAN player, use the human's nickname or userId — don't rely on seat number. When the target is a bot, prefer the full bot nick (`Bot4-XXXX`) for unambiguity.
+
+**Wolf-kill target**: prefer a non-wolf BOT seat to keep all 3 humans alive for full multi-device coverage. Killing a human is allowed but reduces remaining test surface.
+
+**Wolf UI quirk** (Claude's MCP browser): clicking a player slot fires `WOLF_SELECT` (broadcast to teammates). Clicking the Confirm button fires `WOLF_KILL`. Two separate clicks; wait for the WOLF_SELECT SUCCESS in L1 before clicking Confirm.
+
+### Day
+
+1. Host (whoever created the room) clicks **"公布结果 / Reveal Night Result"** → backend `REVEAL_NIGHT_RESULT`.
+2. Host clicks **"开始投票 / Start Vote"** → `DAY_ADVANCE` → `phase=DAY_VOTING, subPhase=VOTING`.
+3. Each alive player votes:
+   - Bots: `./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && BACKEND_BASE=http://127.0.0.1:8080/api ./scripts/act.sh SUBMIT_VOTE --target <seat-or-bot-nick> --room <CODE>'` (mass fan-out).
+   - Each human: clicks vote target in their UI.
+4. Host clicks **"公布结果 / Reveal Tally"** → `VOTING_REVEAL_TALLY` → eliminated player shown.
+5. Host clicks **"继续 / Continue"** → next NIGHT.
+
+If everyone abstains, backend transitions to `RE_VOTING` instead of `VOTE_RESULT`. Either fan-out a real target on the next round, or accept the revote loop.
+
+### Termination
+
+Game ends when wolves==0 (villager win) OR wolves≥non-wolves (wolf win). Frontend redirects all 3 human browsers to `/result/<id>` showing all role reveals.
+
+## Known UI quirks (don't panic)
+
+| Symptom | Explanation | Action |
+|---|---|---|
+| Claude's MCP browser shows blank `/game/<id>` after Start Game | SPA hydration race; pre-existing, not a regression | `navigate_page reload` once |
+| Backend log: `WARN GameStateLogger - game=N ... -&gt; SKIP (game not found)` | `@Async` logger races the create-game transaction commit | Benign; ignore |
+| Bot self-vote rejected: `Cannot vote for yourself` (sheriff election only) | Sheriff election forbids self-vote; day vote allows it | Have that bot abstain instead |
+| `--target Peter` rejected `Target not found or dead` | `act.sh` doesn't know human nicks; sends literal "Peter" not `guest:peter` | Use a bot target instead, or pass full userId |
+
+## Failure handling
+
+If at any sub-phase the L1 stream shows a `REJECTED` or stays silent past the expected coroutine gap:
+
+1. **Capture** (Claude):
+   - L2: `evaluate_script` → dump `window.__appLog`.
+   - L1: `./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && sudo docker compose --env-file .env.prod logs --tail=200 backend'`.
+   - State: `./scripts/vm-ssh.sh "curl -s -H \"Authorization: Bearer <bot-jwt>\" http://127.0.0.1:8080/api/game/<id>/state"` — read `phase`, `subPhase`, `players[*].isAlive`. Backend's `waitingOn=[...]` is in the L1 logs, not the /state DTO.
+2. **User report**: ask user what their phone / laptop UI shows.
+3. **Decide**: workaround (fire missing action manually) or abort + reproduce locally.
+
+Common patterns:
+- `REJECTED reason="No active night phase"` → coroutine moved past sub-phase before the action; widen `poll` timeout or check whether sub-phase was already passed.
+- `Sub.*disconnect` in STOMP log → device's WebSocket dropped. Frontend should auto-resync (PR #52). User can verify by reloading the page.
+- `1006 abnormal closure` on user's WS panel → network hiccup. Expect resync within ~5 s.
+
+## Verification — success criteria
+
+1. Game reaches `/result/<id>` with all 9 role reveals visible on every human browser.
+2. **Zero `Exception` / `ERROR` / `WARN.*werewolf` lines** in L1 during the run (the `GameStateLogger SKIP` is the one allowed exception — see quirks).
+3. Phone and laptop state stayed in sync (user reports OK).
+4. L2 audio: `wolf_open_eyes`, `wolf_close_eyes`, plus each special role's `*_open_eyes` / `*_close_eyes` per night, plus `rooster_crowing` + `day_time` at NIGHT→DAY transition. Each unique playback STARTS exactly once per night.
+5. No STOMP disconnects in L2 buffer or L1 stream.
+6. `docker compose ps` post-game still shows all containers Up.
+
+## After the game — cleanup
+
+- `TaskStop <monitor-id>` — stop the L1 stream.
+- Optionally close Claude's MCP browser tab (or leave for next test).
+- The `/tmp/werewolf-<CODE>.json` state file on the VM is fine to leave; next run uses a new room code.
+
+## Files in this skill
+
+- `SKILL.md` — this document
+- `audio-patcher.js` — paste content into `evaluate_script` to install L2 logging
+- `checklist.md` — condensed run sheet for fast re-runs
+
+## Critical files (read-only reference)
+
+| File | Purpose |
+|---|---|
+| `scripts/vm-ssh.sh` | Fast ControlMaster-backed SSH; reuse for every VM call |
+| `scripts/join-room.sh` | Bot fill + ready (BACKEND_BASE-aware) |
+| `scripts/act.sh` | All player actions including Host (after hostToken injection) |
+| `scripts/roles.sh` | Pull bot role layout once roles confirmed |
+| `backend/src/main/kotlin/com/werewolf/service/GameStateLogger.kt` | Source of `game.state … waitingOn=[...]` log line that L1 surfaces |
+| `frontend/src/services/audioService.ts` | Audio queue (logs L2 captures) |
+| `frontend/src/composables/useAudioService.ts` | AudioSequence watcher (L2) |

--- a/.claude/skills/prod-smoke-test/audio-patcher.js
+++ b/.claude/skills/prod-smoke-test/audio-patcher.js
@@ -1,0 +1,71 @@
+// L2 console patcher for the prod-smoke-test skill.
+//
+// Paste the IIFE below into chrome-devtools-mcp `evaluate_script` AFTER navigating
+// to /game/<id>. It installs a 500-entry ring buffer at `window.__appLog` that
+// captures audio-service events, STOMP events, console errors, and unhandled
+// promise rejections. Filter regex below intentionally broad — we want signal
+// for every potential failure mode.
+//
+// To dump: evaluate_script returning `window.__appLog`.
+// To clear: evaluate_script `() => { window.__appLog = []; }`.
+//
+// Re-running the patcher is idempotent — protected by `window.__appPatched`.
+
+(() => {
+  if (window.__appPatched) return { already: true, count: (window.__appLog || []).length }
+  window.__appLog = []
+  const KEEP = /AudioService|useAudioService|audioSequence|mp3|stomp|STOMP|websocket|WebSocket|disconnect|reconnect|Error|Exception|stomp\.js|frame|onUnhandledRejection|err/i
+  const RING = 500
+  const push = (level, args) => {
+    try {
+      const s = args
+        .map((a) => {
+          if (a instanceof Error) return a.stack || a.message
+          if (typeof a === 'string') return a
+          try {
+            return JSON.stringify(a)
+          } catch {
+            return String(a)
+          }
+        })
+        .join(' ')
+      if (KEEP.test(s)) {
+        window.__appLog.push({ t: new Date().toISOString(), level, msg: s })
+        if (window.__appLog.length > RING) window.__appLog.shift()
+      }
+    } catch {}
+  }
+  const orig = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+    info: console.info,
+  }
+  console.log = (...a) => {
+    push('log', a)
+    orig.log.apply(console, a)
+  }
+  console.warn = (...a) => {
+    push('warn', a)
+    orig.warn.apply(console, a)
+  }
+  console.error = (...a) => {
+    push('error', a)
+    orig.error.apply(console, a)
+  }
+  console.info = (...a) => {
+    push('info', a)
+    orig.info.apply(console, a)
+  }
+  window.addEventListener('error', (e) =>
+    push('error', ['window.onerror', e.message, e.filename + ':' + e.lineno]),
+  )
+  window.addEventListener('unhandledrejection', (e) =>
+    push('error', [
+      'unhandledrejection',
+      e.reason && (e.reason.stack || e.reason.message || String(e.reason)),
+    ]),
+  )
+  window.__appPatched = true
+  return { patched: true }
+})()

--- a/.claude/skills/prod-smoke-test/checklist.md
+++ b/.claude/skills/prod-smoke-test/checklist.md
@@ -1,0 +1,66 @@
+# Prod smoke test — quick checklist
+
+Condensed run sheet for fast re-runs. See `SKILL.md` for full context.
+
+## Pre-flight (~30 s)
+
+- [ ] `gcloud auth list` — active account
+- [ ] `./scripts/vm-ssh.sh 'curl -sf http://127.0.0.1:8080/api/health'` → `{"status":"UP"}`
+- [ ] `./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && sudo docker compose --env-file .env.prod ps'` → 3 containers Up
+- [ ] `./scripts/vm-ssh.sh 'cd /opt/werewolf-simple && sudo git log -1 --oneline'` → matches release tag
+
+## Setup (~3 min)
+
+- [ ] Spawn L1 Monitor (persistent, gcloud + grep on backend logs)
+- [ ] User on **phone**: nickname A → Create Room (9p, sheriff OFF, default roles) → share code
+- [ ] Claude: open MCP browser → join as `Claude` → claim seat
+- [ ] Claude: inject `audio-patcher.js` via `evaluate_script` (L2)
+- [ ] User on **laptop**: nickname B → JOIN by room code → claim seat
+- [ ] Claude: `vm-ssh.sh 'cd /opt/werewolf-simple && BACKEND_BASE=http://127.0.0.1:8080/api ./scripts/join-room.sh <CODE> 6 --ready'`
+- [ ] All 3 humans Ready up; host taps Start Game
+- [ ] Claude: inject host JWT into `/tmp/werewolf-<CODE>.json` on VM (S9 in SKILL.md)
+
+## Confirm role (~30 s)
+
+- [ ] Each human reveals + confirms role in their browser
+- [ ] Claude: `vm-ssh.sh ...act.sh CONFIRM_ROLE --room <CODE>` for bots
+- [ ] Claude: `vm-ssh.sh ...roles.sh --room <CODE>` to log bot roles
+
+## Each night (~1–2 min)
+
+For each sub-phase: poll `/state` → fire action → confirm SUCCESS in L1 + audio in L2.
+
+- [ ] `WEREWOLF_PICK` — wolves kill non-wolf bot (keeps humans alive)
+- [ ] `SEER_PICK` → `SEER_RESULT` — seer checks; confirm
+- [ ] `WITCH_ACT` — pass (`useAntidote:false`)
+- [ ] `GUARD_PICK` — skip
+- [ ] Backend transitions to `DAY_DISCUSSION/RESULT_HIDDEN`
+
+## Each day (~1–2 min)
+
+- [ ] Host: tap "公布结果 / Reveal Night Result"
+- [ ] Host: tap "开始投票 / Start Vote"
+- [ ] All alive vote (humans via UI, bots via `act.sh SUBMIT_VOTE` fan-out)
+- [ ] Host: tap "公布结果 / Reveal Tally"
+- [ ] Host: tap "继续 / Continue" → next NIGHT
+
+Repeat until GAME_OVER.
+
+## Verification
+
+- [ ] All 3 human browsers on `/result/<id>` with all 9 role reveals
+- [ ] L1: zero `Exception` / `ERROR` / `WARN.*werewolf` (the `GameStateLogger SKIP` race line is allowed)
+- [ ] L2: no errors, audio fired in expected order each night
+- [ ] User reports phone+laptop stayed in sync (no `1006 abnormal closure`, no stale phase)
+- [ ] `docker compose ps` post-game shows all containers Up
+
+## Cleanup
+
+- [ ] `TaskStop <L1-monitor-id>`
+
+## Time
+
+- Pre-flight: ~30 s
+- Setup: ~3 min
+- 1 night + 1 day: ~3 min
+- Average game: 2–3 night/day cycles → ~15 min total

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -4,9 +4,21 @@
 # Boot backend both read this file. Anything unset that the backend requires
 # will cause it to fail-fast at startup.
 
+# --- Image version --------------------------------------------------------
+# The ghcr.io image tag prod should run. Set to a specific release tag
+# (e.g. v0.2.0) to pin, or `latest` to always track the newest published
+# release. Must match a tag that the `Publish Images` workflow has pushed
+# to ghcr.io/wangdaqian08/werewolf-simple-{backend,frontend}.
+#
+# To deploy a new version:
+#   1. Update this value (e.g. v0.2.0 → v0.3.0).
+#   2. ssh prod vm && cd /opt/werewolf-simple
+#   3. docker compose --env-file .env.prod pull
+#   4. docker compose --env-file .env.prod up -d
+WEREWOLF_VERSION=latest
+
 # --- Spring profile -------------------------------------------------------
-# Must be `prod` for production deployments. docker-compose.yml also sets
-# this in `environment:` for the backend service; overriding here is fine.
+# Must be `prod` for production deployments.
 SPRING_PROFILES_ACTIVE=prod
 
 # --- Postgres -------------------------------------------------------------

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,80 @@
+name: Publish Images
+
+# Build backend + frontend Docker images and push to GitHub Container Registry
+# (ghcr.io). Free for public repos; no GCP infra required. Prod VM pulls the
+# tagged image with `docker compose pull` instead of running `--build`, cutting
+# deploy time from ~30 min to ~1 min.
+#
+# Triggers:
+#   • Tag push `v*`         → image tags `:<tag>` + `:latest`  (production-grade)
+#   • Push to main          → image tag  `:main`               (pre-release smoke)
+#   • workflow_dispatch     → manual trigger for debugging
+
+on:
+  push:
+    tags: ['v*']
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write   # required to push to ghcr.io
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_OWNER: ${{ github.repository_owner }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: backend
+            context: ./backend
+          - name: frontend
+            context: ./frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Derive the image reference — owner name must be lowercase for OCI.
+      - name: Compute image name
+        id: image
+        run: |
+          owner_lc=$(echo "${IMAGE_OWNER}" | tr '[:upper:]' '[:lower:]')
+          echo "ref=${REGISTRY}/${owner_lc}/werewolf-simple-${{ matrix.service.name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.ref }}
+          tags: |
+            type=ref,event=branch            # main branch pushes get :main
+            type=semver,pattern={{raw}}      # v0.2.0 tag → :v0.2.0
+            type=semver,pattern={{major}}.{{minor}}   # v0.2.0 tag → :0.2
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.service.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Registry-backed layer cache — persists between workflow runs.
+          # Source + scope keyed per service so backend/frontend don't collide.
+          cache-from: type=registry,ref=${{ steps.image.outputs.ref }}:buildcache
+          cache-to: type=registry,ref=${{ steps.image.outputs.ref }}:buildcache,mode=max

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,14 +7,21 @@ WORKDIR /src
 # Gradle wrapper + build scripts first — maximises Docker layer cache hits.
 COPY gradlew gradlew.bat settings.gradle.kts build.gradle.kts ./
 COPY gradle ./gradle
-RUN chmod +x gradlew && ./gradlew --version --no-daemon
+# --mount=type=cache persists the Gradle dependency cache across image
+# builds on the same host. Without this, every `docker compose up --build`
+# re-downloads ~300 MB from Maven Central and the Gradle distribution, which
+# on a 2-vCPU VM pushes the backend build to 20+ minutes. With the cache,
+# subsequent rebuilds are ~3–5 min.
+RUN --mount=type=cache,target=/root/.gradle \
+    chmod +x gradlew && ./gradlew --version --no-daemon
 
 # Now copy the actual source tree.
 COPY src ./src
 
 # Build the executable Spring Boot jar. --no-daemon keeps memory predictable
 # inside the container. Tests run in CI, not at image-build time.
-RUN ./gradlew bootJar --no-daemon -x test
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew bootJar --no-daemon -x test
 
 # ---- Stage 2: runtime ----------------------------------------------------
 FROM eclipse-temurin:17-jre

--- a/backend/src/main/kotlin/com/werewolf/game/night/NightOrchestrator.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/night/NightOrchestrator.kt
@@ -8,6 +8,7 @@ import com.werewolf.game.phase.HardModeCounterplay
 import com.werewolf.game.phase.WinCheckTrigger
 import com.werewolf.game.phase.WinConditionChecker
 import com.werewolf.game.role.RoleHandler
+import com.werewolf.game.role.WerewolfHandler
 import com.werewolf.model.*
 import com.werewolf.repository.EliminationHistoryRepository
 import com.werewolf.repository.GamePlayerRepository
@@ -426,6 +427,7 @@ class NightOrchestrator(
         activeNightJobs.remove(gameId)
         pendingActions.remove(gameId)
         queuedActionSignals.remove(gameId)
+        (handlers.firstOrNull { it.role == PlayerRole.WEREWOLF } as? WerewolfHandler)?.resetKillLock(gameId)
     }
 
     // ── Internal helpers ────────────────────────────────────────────────────
@@ -579,6 +581,9 @@ class NightOrchestrator(
      * Called synchronously by [initNight] and inside the coroutine by [startNightPhase].
      */
     private fun initNightInternal(gameId: Int, newDayNumber: Int, previousGuardTarget: String? = null, withWaiting: Boolean = false) {
+        // Clear per-night locks so each new night starts fresh.
+        (handlers.firstOrNull { it.role == PlayerRole.WEREWOLF } as? WerewolfHandler)?.resetKillLock(gameId)
+
         val context = contextLoader.load(gameId)
         val initialSubPhase = if (withWaiting) NightSubPhase.WAITING else firstSubPhase(context)
 

--- a/backend/src/main/kotlin/com/werewolf/game/role/WerewolfHandler.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/role/WerewolfHandler.kt
@@ -13,6 +13,7 @@ import com.werewolf.model.RoleDelayConfig
 import com.werewolf.repository.NightPhaseRepository
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
 
 @Order(1)
 @Component
@@ -22,6 +23,19 @@ class WerewolfHandler(
 ) : RoleHandler {
 
     override val role = PlayerRole.WEREWOLF
+
+    /**
+     * Tracks which games have already had a WOLF_KILL confirmed this night.
+     * First WOLF_KILL wins; subsequent attempts from teammates are rejected
+     * so that only one submitAction fires per WEREWOLF_PICK sub-phase.
+     * Cleared by [resetKillLock] at the start of each new night.
+     */
+    private val killConfirmed = ConcurrentHashMap<Int, Boolean>()
+
+    /** Clear the kill lock for [gameId] so the next night allows a fresh WOLF_KILL. */
+    fun resetKillLock(gameId: Int) {
+        killConfirmed.remove(gameId)
+    }
 
     override fun acceptedActions(phase: GamePhase, subPhase: String?): Set<ActionType> =
         if (phase == GamePhase.NIGHT && subPhase == NightSubPhase.WEREWOLF_PICK.name)
@@ -43,6 +57,14 @@ class WerewolfHandler(
             ?: return GameActionResult.Rejected("No active night phase")
         if (nightPhase.subPhase != NightSubPhase.WEREWOLF_PICK)
             return GameActionResult.Rejected("Not in WEREWOLF_PICK sub-phase")
+
+        // Only the first WOLF_KILL per night advances the phase.
+        // Reject duplicates so submitAction is called exactly once.
+        if (action.actionType == ActionType.WOLF_KILL) {
+            if (killConfirmed.putIfAbsent(action.gameId, true) != null) {
+                return GameActionResult.Rejected("Kill already confirmed by teammate")
+            }
+        }
 
         val target = action.targetUserId
             ?: return GameActionResult.Rejected("Target required")

--- a/backend/src/test/kotlin/com/werewolf/integration/FullGameCycleTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/FullGameCycleTest.kt
@@ -119,9 +119,13 @@ class FullGameCycleTest {
         return Triple(hostToken, roomId, tokenByUserId)
     }
 
-    /** Find the token of the wolf among all players using game state API. */
-    private fun findRoleToken(gameId: Int, tokenByUserId: Map<String, String>, role: PlayerRole): String {
-        return tokenByUserId.entries.first { (_, token) ->
+    /** Find the token of the first player with [role] using the game state API. */
+    private fun findRoleToken(gameId: Int, tokenByUserId: Map<String, String>, role: PlayerRole): String =
+        findAllRoleTokens(gameId, tokenByUserId, role).first()
+
+    /** Find tokens of ALL players with [role]. */
+    private fun findAllRoleTokens(gameId: Int, tokenByUserId: Map<String, String>, role: PlayerRole): List<String> =
+        tokenByUserId.entries.filter { (_, token) ->
             @Suppress("UNCHECKED_CAST")
             val state = restTemplate.exchange(
                 "/api/game/$gameId/state",
@@ -130,8 +134,7 @@ class FullGameCycleTest {
                 Map::class.java
             ).body
             state?.get("myRole") as? String == role.name
-        }.value
-    }
+        }.map { it.value }
 
     /**
      * Block until the night coroutine has reached its first deferred-await — i.e. the
@@ -256,5 +259,42 @@ class FullGameCycleTest {
         val finalGame = gameRepository.findById(gameId).orElseThrow()
         assertThat(finalGame.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
         assertThat(finalGame.winner).isNull()
+    }
+
+    /**
+     * Regression: two wolves both send WOLF_KILL for the same target.
+     * First WOLF_KILL succeeds (200), second is rejected (400).
+     * Night still resolves correctly — no stale queuedActionSignal leaks
+     * into the next sub-phase.
+     */
+    @Test
+    fun `duplicate WOLF_KILL from second wolf is rejected and night still resolves`() {
+        val (hostToken, roomId, tokenByUserId) = setupRoom("DK1")
+
+        restTemplate.postForEntity(START_URL, HttpEntity(mapOf("roomId" to roomId), headers(hostToken)), Map::class.java)
+
+        val game = gameRepository.findAll().first { it.roomId == roomId }
+        val gameId = game.gameId!!
+
+        tokenByUserId.values.forEach { token -> action(token, gameId, "CONFIRM_ROLE") }
+        action(hostToken, gameId, "START_NIGHT")
+        waitForNightRoleLoopReady(gameId)
+
+        val wolfTokens = findAllRoleTokens(gameId, tokenByUserId, PlayerRole.WEREWOLF)
+        assertThat(wolfTokens).hasSizeGreaterThanOrEqualTo(2)
+
+        val villagerTarget = gamePlayerRepository.findByGameId(gameId).first { it.role != PlayerRole.WEREWOLF }
+
+        // First wolf kill → 200 OK
+        val resp1 = action(wolfTokens[0], gameId, "WOLF_KILL", villagerTarget.userId)
+        assertThat(resp1.statusCode).isEqualTo(HttpStatus.OK)
+
+        // Second wolf kill → 400 rejected
+        val resp2 = action(wolfTokens[1], gameId, "WOLF_KILL", villagerTarget.userId)
+        assertThat(resp2.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+
+        // Night still resolves (no stale signal poisoning the next sub-phase)
+        val resolvedPhase = waitForNightToResolve(gameId)
+        assertThat(resolvedPhase).isEqualTo(GamePhase.GAME_OVER)
     }
 }

--- a/backend/src/test/kotlin/com/werewolf/unit/role/RoleHandlerTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/role/RoleHandlerTest.kt
@@ -115,6 +115,44 @@ class RoleHandlerTest {
         }
 
         @Test
+        fun `wolf kill - second wolf kill rejected after first confirmed`() {
+            val np = nightPhase(NightSubPhase.WEREWOLF_PICK)
+            val wolf1 = player("wolf1", 1, PlayerRole.WEREWOLF)
+            val wolf2 = player("wolf2", 2, PlayerRole.WEREWOLF)
+            val target = player("u3", 3, PlayerRole.VILLAGER)
+            val ctx = GameContext(game(), room(), listOf(wolf1, wolf2, target), nightPhase = np)
+            whenever(nightPhaseRepository.save(any<NightPhase>())).thenAnswer { it.arguments[0] }
+
+            // First wolf kill succeeds
+            val result1 = handler.handle(req("wolf1", ActionType.WOLF_KILL, "u3"), ctx)
+            assertThat(result1).isInstanceOf(GameActionResult.Success::class.java)
+
+            // Second wolf kill is rejected
+            val result2 = handler.handle(req("wolf2", ActionType.WOLF_KILL, "u3"), ctx)
+            assertThat(result2).isInstanceOf(GameActionResult.Rejected::class.java)
+            assertThat((result2 as GameActionResult.Rejected).reason).contains("already confirmed")
+        }
+
+        @Test
+        fun `wolf kill - lock resets for new night`() {
+            val np = nightPhase(NightSubPhase.WEREWOLF_PICK)
+            val wolf1 = player("wolf1", 1, PlayerRole.WEREWOLF)
+            val target = player("u3", 3, PlayerRole.VILLAGER)
+            val ctx = GameContext(game(), room(), listOf(wolf1, target), nightPhase = np)
+            whenever(nightPhaseRepository.save(any<NightPhase>())).thenAnswer { it.arguments[0] }
+
+            // First kill succeeds
+            handler.handle(req("wolf1", ActionType.WOLF_KILL, "u3"), ctx)
+
+            // Reset lock (as NightOrchestrator would at start of new night)
+            handler.resetKillLock(gameId)
+
+            // Kill succeeds again after reset
+            val result = handler.handle(req("wolf1", ActionType.WOLF_KILL, "u3"), ctx)
+            assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        }
+
+        @Test
         fun `wolf select - sets wolfTargetUserId and returns WolfSelectionChanged event`() {
             val ctx = wolfCtx()
             whenever(nightPhaseRepository.save(any<NightPhase>())).thenAnswer { it.arguments[0] }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,25 +32,49 @@ sudo apt install -y certbot python3-certbot-nginx
 sudo certbot --nginx -d werewolf.example.com
 ```
 
-## Deploy (single command)
+## Deploy
+
+Images are pre-built by GitHub Actions and published to `ghcr.io` on every
+release tag. The prod VM only pulls and starts — no Gradle/Vite build on the
+VM, so deploys are ~1 min instead of ~30 min.
+
+### First-time install
 
 ```bash
 cd /opt/werewolf-simple
 cp .env.prod.example .env.prod
 # edit .env.prod — fill in JWT_SECRET, POSTGRES_PASSWORD, GOOGLE_*, FRONTEND_ORIGIN
-docker compose --env-file .env.prod up -d --build
+# set WEREWOLF_VERSION=v0.2.0 (or whichever release tag you want to pin)
+docker compose --env-file .env.prod pull
+docker compose --env-file .env.prod up -d
 ```
 
-Everything needed (Postgres, backend jar build, frontend Vite build) is produced
-by this single command. No local Java / Node install required on the VM.
+### Release a new version
 
-### Updates
+1. On the repo: tag main with `vX.Y.Z` and push. GitHub Actions builds + pushes
+   `ghcr.io/.../werewolf-simple-{backend,frontend}:vX.Y.Z` + `:latest`.
+2. On the VM:
+   ```bash
+   cd /opt/werewolf-simple
+   sed -i 's/^WEREWOLF_VERSION=.*$/WEREWOLF_VERSION=vX.Y.Z/' .env.prod
+   docker compose --env-file .env.prod pull
+   docker compose --env-file .env.prod up -d
+   ```
+   `up -d` detects the image reference changed and recreates the container; no
+   `--force-recreate` needed.
+
+### Emergency rebuild on the VM (fallback)
+
+If ghcr.io is unreachable or you need to patch without a release:
 
 ```bash
 cd /opt/werewolf-simple
 git pull
 docker compose --env-file .env.prod up -d --build
 ```
+
+`build:` is still in `docker-compose.yml` as a fallback — this takes ~30 min
+on a 2-vCPU VM.
 
 ## Verify
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,22 @@
 # responsible for exposing the app to the public internet. See
 # deploy/nginx-site.conf for the matching reverse-proxy config.
 #
-# Usage:
+# Usage (prod — pull pre-built image, fast):
 #   cp .env.prod.example .env.prod
-#   # edit .env.prod and fill in real secrets
+#   # edit .env.prod and set WEREWOLF_VERSION=v0.2.0 (or latest tag)
+#   docker compose --env-file .env.prod pull
+#   docker compose --env-file .env.prod up -d
+#
+# Usage (dev — build locally, slow first time):
 #   docker compose --env-file .env.prod up -d --build
 #
 # The --env-file flag is required: compose only auto-loads ".env", not ".env.prod".
+#
+# Backend/frontend specify BOTH `image:` (ghcr.io tag that CI pushes on every
+# tag + main commit) AND `build:` (the local Dockerfile). With both, `--build`
+# re-builds locally; `pull` fetches the remote image; and `up` without either
+# flag uses whatever's already on disk. Lets prod skip the 30-min VM build
+# entirely while local dev keeps working unchanged.
 
 services:
   postgres:
@@ -30,6 +40,7 @@ services:
       retries: 10
 
   backend:
+    image: ghcr.io/wangdaqian08/werewolf-simple-backend:${WEREWOLF_VERSION:-latest}
     build:
       context: ./backend
     restart: unless-stopped
@@ -51,6 +62,7 @@ services:
       start_period: 40s
 
   frontend:
+    image: ghcr.io/wangdaqian08/werewolf-simple-frontend:${WEREWOLF_VERSION:-latest}
     build:
       context: ./frontend
     restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,9 +4,12 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
-# Install deps first for cache-friendly layers.
+# Install deps first for cache-friendly layers. The npm cache mount persists
+# the download cache across image builds on the same host — `npm ci` without
+# it re-downloads every package from the registry every build.
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
 
 # Copy sources and build. `npm run build` = vue-tsc -b && vite build → dist/.
 COPY . .

--- a/frontend/e2e/real/helpers/backend-log.ts
+++ b/frontend/e2e/real/helpers/backend-log.ts
@@ -1,0 +1,47 @@
+/**
+ * Backend log attachment helper.
+ *
+ * Backend stdout is captured to a file via `tee` in the webServer command in
+ * playwright.real.config.ts. On test failure we attach the tail of that file
+ * to the Playwright report — this is the missing link between a frontend
+ * assertion ("stuck on NIGHT/WEREWOLF_PICK") and the backend reality
+ * (`action.submit ... -> SUCCESS`, `PhaseChanged`, `game.state ... waitingOn=
+ * [...]`, `Exception`).
+ *
+ * Default tail size is 500 lines, which on this codebase covers ~30 s of
+ * backend activity — enough context for any single sub-phase stall without
+ * blowing up the report artifact size.
+ */
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import type { TestInfo } from '@playwright/test'
+
+const DEFAULT_LOG_PATH = '/tmp/werewolf-e2e-backend.log'
+const DEFAULT_TAIL_LINES = 500
+
+export async function attachBackendLogOnFailure(
+  testInfo: TestInfo,
+  options?: { tailLines?: number; logPath?: string },
+): Promise<void> {
+  if (testInfo.status !== 'failed') return
+  const path = options?.logPath ?? DEFAULT_LOG_PATH
+  const tailLines = options?.tailLines ?? DEFAULT_TAIL_LINES
+  if (!existsSync(path)) return
+  try {
+    // Best-effort: very large logs (multi-MB) can blow up if read in one shot.
+    // We accept that risk on E2E machines — files larger than 50 MB are a
+    // separate problem that this attachment can't solve.
+    const size = statSync(path).size
+    const content = readFileSync(path, 'utf-8')
+    const all = content.split('\n')
+    const tail = all.slice(-tailLines).join('\n')
+    await testInfo.attach('backend.log', {
+      body:
+        `# tail of ${path} (last ${Math.min(tailLines, all.length)} of ${all.length} lines, total ${size} bytes)\n` +
+        `# captured at ${new Date().toISOString()}\n\n` +
+        tail,
+      contentType: 'text/plain',
+    })
+  } catch {
+    // best-effort — don't crash the afterEach
+  }
+}

--- a/frontend/e2e/real/helpers/composite-screenshot.ts
+++ b/frontend/e2e/real/helpers/composite-screenshot.ts
@@ -7,6 +7,7 @@
  * then captures that page. No external image libraries needed.
  */
 import type {Page, TestInfo} from '@playwright/test'
+import {attachBackendLogOnFailure} from './backend-log'
 
 /**
  * Capture a composite screenshot tiling all provided pages into one image.
@@ -91,6 +92,11 @@ export async function attachCompositeOnFailure(
   testInfo: TestInfo,
   label = 'composite-all-players',
 ): Promise<void> {
+  // Always attach the backend log on failure — this is the single most useful
+  // diagnostic for "stuck on phase X" failures, where the assertion message
+  // tells us nothing about what the backend coroutine actually did.
+  await attachBackendLogOnFailure(testInfo)
+
   if (pages.size === 0) return
 
   const outputPath = testInfo.outputPath(`${label}.png`)

--- a/frontend/e2e/real/helpers/shell-runner.ts
+++ b/frontend/e2e/real/helpers/shell-runner.ts
@@ -75,6 +75,85 @@ function stripAnsi(str: string): string {
   return str.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '')
 }
 
+/**
+ * Best-effort enrichment for an act.sh rejection. When the backend rejects
+ * an action ("Target not found or dead", "Not in WITCH_ACT sub-phase", …)
+ * the user typically can't tell from the response WHY without manually
+ * cross-referencing roleMap, alive flags, and current sub-phase.
+ *
+ * This pulls /api/game/<id>/state via curl using the first bot's token
+ * and formats the actor's + target's alive/seat info plus the current
+ * phase/sub-phase. Returns an empty string on any failure so we never
+ * lose the original rejection log.
+ */
+function describeRejectionContext(
+  roomCode: string | undefined,
+  actor: string | undefined,
+  target: string | undefined,
+): string {
+  if (!roomCode) return ''
+  try {
+    const filePath = path.join(STATE_DIR, `werewolf-${roomCode.toUpperCase()}.json`)
+    const state: StateFile & { gameId?: number } = JSON.parse(readFileSync(filePath, 'utf-8'))
+    const token = state.bots?.[0]?.token
+    const gameId = state.gameId
+    if (!token || !gameId) return ''
+    const base = process.env.BACKEND_BASE ?? 'http://localhost:8080/api'
+    const cmd = `curl -s -m 5 -H 'Authorization: Bearer ${token}' '${base}/game/${gameId}/state'`
+    const raw = execSync(cmd, { encoding: 'utf-8', timeout: 6_000 })
+    const body = JSON.parse(raw) as {
+      phase?: string
+      subPhase?: string
+      nightPhase?: { subPhase?: string; dayNumber?: number }
+      players?: Array<{
+        seatIndex?: number
+        nickname?: string
+        userId?: string
+        isAlive?: boolean
+        role?: string
+      }>
+    }
+    const phase = body.phase ?? '?'
+    const sub = body.nightPhase?.subPhase ?? body.subPhase ?? '-'
+    const day = body.nightPhase?.dayNumber ?? '?'
+
+    const findPlayer = (id: string | undefined) => {
+      if (!id || !body.players) return undefined
+      // Try nickname (case-insensitive substring), then seat number, then userId
+      const nickHit = body.players.find(
+        (p) => p.nickname && p.nickname.toLowerCase() === id.toLowerCase(),
+      )
+      if (nickHit) return nickHit
+      const seat = parseInt(id, 10)
+      if (!isNaN(seat)) {
+        const seatHit = body.players.find((p) => p.seatIndex === seat)
+        if (seatHit) return seatHit
+      }
+      return body.players.find((p) => p.userId === id)
+    }
+
+    const fmt = (
+      label: string,
+      id: string | undefined,
+      p: ReturnType<typeof findPlayer>,
+    ) =>
+      p
+        ? `  ${label}: ${p.nickname} (seat ${p.seatIndex}, alive=${p.isAlive ? 'yes' : 'NO'}${p.role ? `, role=${p.role}` : ''})`
+        : `  ${label}: <${id ?? '-'}> not found in roster`
+
+    const lines = [
+      `  state:  phase=${phase}, sub=${sub}, day=${day}`,
+      fmt('actor ', actor, findPlayer(actor)),
+    ]
+    if (target !== undefined) {
+      lines.push(fmt('target', target, findPlayer(target)))
+    }
+    return '\n' + lines.join('\n')
+  } catch {
+    return ''
+  }
+}
+
 // ── Public API ───────────────────────────────────────────────────────────────
 
 /** Join N bots to the room and optionally mark them ready. */
@@ -127,11 +206,15 @@ export function act(
     output = stripAnsi(run(cmd))
     const rejected = /reject|Rejected/.test(output)
     if (!rejected) return output
+    // Enriched rejection log: include actor + target alive/seat status and
+    // current phase/sub-phase. Cuts the "Target not found or dead" mystery
+    // down to "target was already killed in N1" without manual digging.
+    const context = describeRejectionContext(opts?.room, player, opts?.target)
     // eslint-disable-next-line no-console
     console.warn(
       `[act rejected] attempt ${attempt}/${maxAttempts} action=${action} ` +
         `player=${player ?? '-'} target=${opts?.target ?? '-'} ` +
-        `room=${opts?.room ?? '-'}\noutput:\n${output}`,
+        `room=${opts?.room ?? '-'}${context}\noutput:\n${output}`,
     )
     if (attempt < maxAttempts) {
       // Synchronous sleep — act() is sync and changing it to async would

--- a/frontend/e2e/real/idiot-flow.spec.ts
+++ b/frontend/e2e/real/idiot-flow.spec.ts
@@ -16,12 +16,21 @@ import {type GameContext, setupGame} from './helpers/multi-browser'
 import {act, type RoleName} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase,} from './helpers/assertions'
 import {captureSnapshot} from './helpers/composite-screenshot'
+import {attachBackendLogOnFailure} from './helpers/backend-log'
 import {readHostUserId, readUnvotedAlivePlayerIds, waitForNightSubPhase} from './helpers/state-polling'
 
 let ctx: GameContext
 
 test.describe('Idiot flow — multi-browser STOMP verification', () => {
   test.setTimeout(60_000) // 3 minutes for the full flow
+
+  // Each test in this file constructs its own localCtx via setupGame inside
+  // the test body — there's no shared `ctx` to call attachCompositeOnFailure
+  // against. Attach backend log directly so failures still ship the backend
+  // tail (the single most useful artifact for stuck-on-NIGHT diagnostics).
+  test.afterEach(async ({}, testInfo) => {
+    await attachBackendLogOnFailure(testInfo)
+  })
 
   // ── Test 1: Setup verification ──────────────────────────────────────────────
 

--- a/frontend/playwright.real.config.ts
+++ b/frontend/playwright.real.config.ts
@@ -25,9 +25,17 @@ export default defineConfig({
     : [['html', { open: 'never' }]],
   webServer: [
     {
-      // Spring Boot with H2 in-memory via e2e profile
+      // Spring Boot with H2 in-memory via e2e profile.
+      //
+      // `tee` mirrors backend stdout to /tmp/werewolf-e2e-backend.log so the
+      // afterEach hook in helpers/composite-screenshot.ts can attach the
+      // tail of the log to any failed test in the Playwright HTML report.
+      // Without this, CI failures like "stuck on NIGHT/WEREWOLF_PICK"
+      // surface only the frontend assertion — no visibility into what the
+      // backend coroutine actually did, which actions it accepted or
+      // rejected, or where it got stuck.
       command:
-        'cd ../backend && SPRING_PROFILES_ACTIVE=e2e ./gradlew bootRun -q --console=plain',
+        "bash -c 'cd ../backend && SPRING_PROFILES_ACTIVE=e2e ./gradlew bootRun -q --console=plain 2>&1 | tee /tmp/werewolf-e2e-backend.log'",
       url: 'http://localhost:8080/api/health',
       timeout: 120_000,
       reuseExistingServer: true,

--- a/frontend/src/services/gameService.ts
+++ b/frontend/src/services/gameService.ts
@@ -12,7 +12,9 @@ export const gameService = {
       const { data } = await http.post<GameActionResponse>('/game/action', req)
       return data
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { status?: number; data?: { success?: boolean; error?: string } } }
+      const axiosErr = err as {
+        response?: { status?: number; data?: { success?: boolean; error?: string } }
+      }
       if (axiosErr.response?.status === 400 && axiosErr.response.data) {
         return { success: false, message: axiosErr.response.data.error }
       }

--- a/frontend/src/services/gameService.ts
+++ b/frontend/src/services/gameService.ts
@@ -8,8 +8,16 @@ export const gameService = {
   },
 
   async submitAction(req: GameActionRequest): Promise<GameActionResponse> {
-    const { data } = await http.post<GameActionResponse>('/game/action', req)
-    return data
+    try {
+      const { data } = await http.post<GameActionResponse>('/game/action', req)
+      return data
+    } catch (err: unknown) {
+      const axiosErr = err as { response?: { status?: number; data?: { success?: boolean; error?: string } } }
+      if (axiosErr.response?.status === 400 && axiosErr.response.data) {
+        return { success: false, message: axiosErr.response.data.error }
+      }
+      throw err
+    }
   },
 
   async startGame(roomId: number): Promise<void> {

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -483,8 +483,15 @@ async function action(req: Omit<import('@/types').GameActionRequest, 'gameId'>) 
     const gameId = Number(route.params.gameId)
     const res = await gameService.submitAction({ ...req, gameId })
     if (res && !res.success && res.message) {
-      console.error('[GameView] Action failed:', res.message)
-      ElMessage({ message: res.message, type: 'error', duration: 3000 })
+      // Silently swallow harmless concurrent-action rejections (e.g. teammate
+      // already confirmed the wolf kill). The UI is already correct.
+      const harmless = res.message.includes('already confirmed')
+      if (harmless) {
+        console.info('[GameView] Action silently rejected:', res.message)
+      } else {
+        console.error('[GameView] Action failed:', res.message)
+        ElMessage({ message: res.message, type: 'error', duration: 3000 })
+      }
       // If the action failed due to phase mismatch, refresh the state
       if (res.message.includes('phase') || res.message.includes('Phase')) {
         const state = await gameService.getState(gameId.toString())


### PR DESCRIPTION
## Summary
- **P0 bug**: When multiple wolves both send `WOLF_KILL`, the second call queues a stale `queuedActionSignal` that instantly skips the next night sub-phase (SEER_PICK), hanging the game at SEER_RESULT with null data
- First `WOLF_KILL` per night now wins via atomic `putIfAbsent` lock in `WerewolfHandler`; subsequent attempts return 400
- Frontend catches 400 gracefully and silently swallows the "already confirmed" rejection

## Root cause
Confirmed from prod game 9 backend logs (2026-04-25). Two wolves (Kero + Larita) both sent `WOLF_KILL`. Kero's `afterCommit` released the WEREWOLF_PICK deferred. Larita's `afterCommit` found no deferred and queued a signal. That signal was consumed 5s later by the SEER_PICK deferred, skipping it in 30ms. Seer (Jian) never got to act.

## Test plan
- [x] Unit: duplicate WOLF_KILL rejected after first confirmed
- [x] Unit: kill lock resets for new night
- [x] Integration: two wolves over HTTP — first 200, second 400, night resolves to GAME_OVER
- [x] Full backend test suite passes
- [x] Frontend type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)