### PR TITLE
fix(room): resilient room-to-game navigation for Safari/iOS

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/dto/RoomDtos.kt
+++ b/backend/src/main/kotlin/com/werewolf/dto/RoomDtos.kt
@@ -35,4 +35,5 @@ data class RoomDto(
     val status: String,
     val players: List<RoomPlayerDto>,
     val config: RoomConfigDto,
+    val activeGameId: Int? = null,
 )

--- a/backend/src/main/kotlin/com/werewolf/service/RoomService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/RoomService.kt
@@ -7,6 +7,7 @@ import com.werewolf.dto.RoomConfigRequest
 import com.werewolf.dto.RoomDto
 import com.werewolf.dto.RoomPlayerDto
 import com.werewolf.model.*
+import com.werewolf.repository.GameRepository
 import com.werewolf.repository.RoomPlayerRepository
 import com.werewolf.repository.RoomRepository
 import com.werewolf.repository.UserRepository
@@ -18,6 +19,7 @@ class RoomService(
     private val roomRepository: RoomRepository,
     private val roomPlayerRepository: RoomPlayerRepository,
     private val userRepository: UserRepository,
+    private val gameRepository: GameRepository,
     private val authService: AuthService,
     private val stompPublisher: StompPublisher,
     private val timing: GameTimingProperties,
@@ -132,6 +134,10 @@ class RoomService(
             if (room.hasIdiot) add(PlayerRole.IDIOT)
         }
 
+        val activeGameId = if (room.status == RoomStatus.IN_GAME) {
+            gameRepository.findByRoomIdAndEndedAtIsNull(room.roomId!!).map { it.gameId }.orElse(null)
+        } else null
+
         return RoomDto(
             roomId = room.roomId.toString(),
             roomCode = room.roomCode,
@@ -139,6 +145,7 @@ class RoomService(
             status = room.status.name,
             players = playerDtos,
             config = RoomConfigDto(totalPlayers = room.totalPlayers, roles = roles, hasSheriff = room.hasSheriff, winCondition = room.winCondition),
+            activeGameId = activeGameId,
         )
     }
 

--- a/backend/src/test/kotlin/com/werewolf/unit/service/RoomServiceReadyTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/RoomServiceReadyTest.kt
@@ -5,6 +5,7 @@ import com.werewolf.model.ReadyStatus
 import com.werewolf.model.Room
 import com.werewolf.model.RoomPlayer
 import com.werewolf.model.RoomStatus
+import com.werewolf.repository.GameRepository
 import com.werewolf.repository.RoomPlayerRepository
 import com.werewolf.repository.RoomRepository
 import com.werewolf.repository.UserRepository
@@ -24,6 +25,7 @@ class RoomServiceReadyTest {
     @Mock lateinit var roomRepository: RoomRepository
     @Mock lateinit var roomPlayerRepository: RoomPlayerRepository
     @Mock lateinit var userRepository: UserRepository
+    @Mock lateinit var gameRepository: GameRepository
     @Mock lateinit var authService: AuthService
     @Mock lateinit var stompPublisher: StompPublisher
     @org.mockito.Spy val timing: com.werewolf.config.GameTimingProperties = com.werewolf.config.GameTimingProperties()

--- a/backend/src/test/kotlin/com/werewolf/unit/service/RoomServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/RoomServiceTest.kt
@@ -3,6 +3,7 @@ package com.werewolf.unit.service
 import com.werewolf.auth.AuthService
 import com.werewolf.dto.RoomConfigRequest
 import com.werewolf.model.*
+import com.werewolf.repository.GameRepository
 import com.werewolf.repository.RoomPlayerRepository
 import com.werewolf.repository.RoomRepository
 import com.werewolf.repository.UserRepository
@@ -23,6 +24,7 @@ class RoomServiceTest {
     @Mock lateinit var roomRepository: RoomRepository
     @Mock lateinit var roomPlayerRepository: RoomPlayerRepository
     @Mock lateinit var userRepository: UserRepository
+    @Mock lateinit var gameRepository: GameRepository
     @Mock lateinit var authService: AuthService
     @Mock lateinit var stompPublisher: StompPublisher
     @org.mockito.Spy val timing: com.werewolf.config.GameTimingProperties = com.werewolf.config.GameTimingProperties()

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,6 +40,7 @@ export interface Room {
   status: RoomStatus
   players: RoomPlayer[]
   config: RoomConfig
+  activeGameId?: number
 }
 
 export interface CreateRoomRequest {

--- a/frontend/src/views/RoomView.vue
+++ b/frontend/src/views/RoomView.vue
@@ -210,6 +210,27 @@ async function handleStartGame() {
   await gameService.startGame(Number(roomStore.room.roomId))
 }
 
+// Re-fetch room status and redirect if a game is already in progress.
+// Does NOT update the room store — avoids resetting local UI state
+// (selected seat, pending ready toggle, etc.).
+async function checkActiveGame() {
+  if (!roomStore.room) return
+  try {
+    const room = await roomService.getRoom(roomStore.room.roomId)
+    if (room.status === 'IN_GAME' && room.activeGameId) {
+      router.push({ name: 'game', params: { gameId: room.activeGameId } })
+    }
+  } catch {
+    /* room may have been deleted — ignore, user can still leave manually */
+  }
+}
+
+function onVisibilityChange() {
+  if (document.visibilityState === 'visible') {
+    checkActiveGame()
+  }
+}
+
 onMounted(async () => {
   const roomId = route.params.roomId as string
   if (!roomStore.room) {
@@ -223,9 +244,28 @@ onMounted(async () => {
   }
   loading.value = false
 
+  // Trigger 1 — on mount: if the room already has an active game (page refresh
+  // after missing the GAME_STARTED event), redirect immediately.
+  if (roomStore.room?.status === 'IN_GAME' && roomStore.room.activeGameId) {
+    router.push({ name: 'game', params: { gameId: roomStore.room.activeGameId } })
+    return
+  }
+
+  // Trigger 3 — visibility change: Safari suspends background tabs, killing the
+  // WebSocket. When the tab returns to foreground, re-check room status.
+  document.addEventListener('visibilitychange', onVisibilityChange)
+
   if (userStore.token && roomStore.room) {
     const client = createStompClient(userStore.token)
+    let isFirstConnect = true
     client.onConnect = () => {
+      // Trigger 2 — STOMP reconnect: broker does not replay missed events.
+      // Re-check room status on every reconnect to catch a GAME_STARTED we missed.
+      if (!isFirstConnect) {
+        checkActiveGame()
+      }
+      isFirstConnect = false
+
       subscribeToTopic(`/topic/room/${roomStore.room!.roomId}`, (msg: { body: string }) => {
         const data = JSON.parse(msg.body)
         if (data.type === 'ROOM_UPDATE') {
@@ -241,6 +281,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  document.removeEventListener('visibilitychange', onVisibilityChange)
   disconnectStomp()
 })
 </script>


### PR DESCRIPTION
## Summary
- **P0 bug**: iOS/Safari players miss the STOMP `GAME_STARTED` event (background tab suspension, WiFi glitch) and get stuck on the room page forever — no recovery path
- Adds three event-driven re-fetch triggers in RoomView to detect an active game and redirect:
  1. **On mount** — catches page refresh
  2. **On STOMP reconnect** — catches WiFi drops (`isFirstConnect` pattern from GameView)
  3. **On `visibilitychange`** — catches Safari background tab suspension
- Backend adds `activeGameId` to `RoomDto` (populated when `status=IN_GAME`)

## Root cause
Confirmed from prod game 8 nginx logs (2026-04-25): 3 iOS players (Safari 26.2, CriOS) repeatedly loaded `/room/9` every 2-10s after game start, never navigating to `/game/8`. They missed the one-shot `GAME_STARTED` STOMP broadcast.

## Test plan
- [x] Backend compiles, all 522 tests pass (added `@Mock GameRepository` to unit tests)
- [x] Frontend type-check passes
- [ ] Manual: start game → open room URL in new tab → should redirect to game
- [ ] Manual: background Safari tab during game start → tab should redirect on foreground

🤖 Generated with [Claude Code](https://claude.com/claude-code)