### PR TITLE
feat(ux): Chrome/Chromium gate + visual loading-state on action buttons

### DIFF
--- a/frontend/src/__tests__/actionPendingDisable.test.ts
+++ b/frontend/src/__tests__/actionPendingDisable.test.ts
@@ -74,28 +74,31 @@ describe('actionPending disables all confirm buttons', () => {
     })
   }
 
-  it('werewolf confirm button disabled when actionPending=true', () => {
+  it('werewolf confirm button disabled + has is-loading when actionPending=true', () => {
     const w = mountNight('WEREWOLF_PICK', 'wolf1', 'WEREWOLF', true)
     const btn = w.find('button.btn-danger')
     expect(btn.exists()).toBe(true)
     expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.classes()).toContain('is-loading')
   })
 
-  it('werewolf confirm button enabled when actionPending=false and target selected', () => {
+  it('werewolf confirm button enabled + no is-loading when actionPending=false', () => {
     const w = mountNight('WEREWOLF_PICK', 'wolf1', 'WEREWOLF', false)
     const btn = w.find('button.btn-danger')
     expect(btn.exists()).toBe(true)
     expect(btn.attributes('disabled')).toBeUndefined()
+    expect(btn.classes()).not.toContain('is-loading')
   })
 
-  it('seer check button disabled when actionPending=true', () => {
+  it('seer check button disabled + has is-loading when actionPending=true', () => {
     const w = mountNight('SEER_PICK', 'seer1', 'SEER', true)
     const btn = w.find('button.btn-danger')
     expect(btn.exists()).toBe(true)
     expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.classes()).toContain('is-loading')
   })
 
-  it('seer done button disabled when actionPending=true', () => {
+  it('seer done button disabled + has is-loading when actionPending=true', () => {
     const w = mountNight('SEER_RESULT', 'seer1', 'SEER', true, {
       seerResult: {
         checkedPlayerId: 'villager1',
@@ -108,16 +111,18 @@ describe('actionPending disables all confirm buttons', () => {
     const btn = w.find('button.btn-secondary')
     expect(btn.exists()).toBe(true)
     expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.classes()).toContain('is-loading')
   })
 
-  it('guard confirm button disabled when actionPending=true', () => {
+  it('guard confirm button disabled + has is-loading when actionPending=true', () => {
     const w = mountNight('GUARD_PICK', 'guard1', 'GUARD', true)
     const btn = w.find('button.btn-danger')
     expect(btn.exists()).toBe(true)
     expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.classes()).toContain('is-loading')
   })
 
-  it('witch antidote/pass buttons disabled when actionPending=true', () => {
+  it('witch antidote/pass buttons disabled + have is-loading when actionPending=true', () => {
     mountNight('WITCH_ACT', 'witch1', 'WITCH', true, {
       hasAntidote: true,
       attackedPlayerId: 'villager1',
@@ -160,6 +165,7 @@ describe('actionPending disables all confirm buttons', () => {
     expect(buttons.length).toBeGreaterThanOrEqual(2)
     buttons.forEach((btn) => {
       expect(btn.attributes('disabled')).toBeDefined()
+      expect(btn.classes()).toContain('is-loading')
     })
   })
 })

--- a/frontend/src/__tests__/useBrowserCompat.test.ts
+++ b/frontend/src/__tests__/useBrowserCompat.test.ts
@@ -148,9 +148,7 @@ describe('isSupportedBrowser', () => {
 
   it('Firefox desktop', () => {
     stubNavigator({
-      ua:
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 ' +
-        'Firefox/120.0',
+      ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 ' + 'Firefox/120.0',
     })
     expect(isSupportedBrowser()).toBe(false)
   })

--- a/frontend/src/__tests__/useBrowserCompat.test.ts
+++ b/frontend/src/__tests__/useBrowserCompat.test.ts
@@ -1,0 +1,193 @@
+/**
+ * UA-table-driven coverage for `isSupportedBrowser`.
+ *
+ * Each row stubs `navigator.userAgent` and (optionally) `navigator.userAgentData`
+ * and asserts the expected supported/blocked verdict. Real-world UA strings
+ * captured 2026-04-26.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isSupportedBrowser } from '@/composables/useBrowserCompat'
+
+interface Stub {
+  ua: string
+  uaData?: { brands: Array<{ brand: string; version: string }> } | undefined
+}
+
+const ORIGINAL = {
+  ua: navigator.userAgent,
+  data: (navigator as { userAgentData?: unknown }).userAgentData,
+}
+
+function stubNavigator({ ua, uaData }: Stub) {
+  Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true })
+  Object.defineProperty(navigator, 'userAgentData', {
+    value: uaData,
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe('isSupportedBrowser', () => {
+  beforeEach(() => {
+    // start each case from a clean slate
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: ORIGINAL.ua,
+      configurable: true,
+    })
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: ORIGINAL.data,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  // ── SUPPORTED ─────────────────────────────────────────────────────────
+
+  it('Chrome desktop (UA-CH)', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+        '(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+      uaData: {
+        brands: [
+          { brand: 'Chromium', version: '119' },
+          { brand: 'Google Chrome', version: '119' },
+        ],
+      },
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  it('Edge Chromium (UA-CH)', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, ' +
+        'like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0',
+      uaData: {
+        brands: [
+          { brand: 'Chromium', version: '119' },
+          { brand: 'Microsoft Edge', version: '119' },
+        ],
+      },
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  it('Chrome Android (UA fallback, no UA-CH)', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (Linux; Android 10; SM-G960U) AppleWebKit/537.36 (KHTML, ' +
+        'like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36',
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  it('Brave (UA fallback — Chrome/ in UA)', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+        '(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  it('Opera (UA fallback — Chrome/ in UA)', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, ' +
+        'like Gecko) Chrome/119.0.0.0 Safari/537.36 OPR/105.0.0.0',
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  it('Samsung Internet (UA fallback)', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (Linux; Android 13; SAMSUNG SM-S918U) AppleWebKit/537.36 ' +
+        '(KHTML, like Gecko) SamsungBrowser/22.0 Chrome/115.0.0.0 Mobile Safari/537.36',
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  it('iOS Safari iPhone', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/' +
+        '605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  it('iOS Safari iPad', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 ' +
+        '(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  it('iOS Chrome (CriOS — still WebKit)', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/' +
+        '605.1.15 (KHTML, like Gecko) CriOS/119.0.6045.169 Mobile/15E148 Safari/604.1',
+    })
+    expect(isSupportedBrowser()).toBe(true)
+  })
+
+  // ── BLOCKED ───────────────────────────────────────────────────────────
+
+  it('Firefox desktop', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 ' +
+        'Firefox/120.0',
+    })
+    expect(isSupportedBrowser()).toBe(false)
+  })
+
+  it('Firefox Android', () => {
+    stubNavigator({
+      ua: 'Mozilla/5.0 (Android 13; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0',
+    })
+    expect(isSupportedBrowser()).toBe(false)
+  })
+
+  it('Desktop Safari (Mac)', () => {
+    stubNavigator({
+      ua:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 ' +
+        '(KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    })
+    expect(isSupportedBrowser()).toBe(false)
+  })
+
+  it('UA-CH present but no Chromium brand → blocked', () => {
+    stubNavigator({
+      ua: '(spoofed-ua)',
+      uaData: {
+        brands: [
+          { brand: 'NotABrand', version: '99' },
+          { brand: 'Some Other Engine', version: '1' },
+        ],
+      },
+    })
+    expect(isSupportedBrowser()).toBe(false)
+  })
+
+  it('SSR / no navigator → permissive (returns true)', () => {
+    // Cover the early-return when running outside a browser. We can't easily
+    // delete `navigator` in jsdom, so just sanity-check the function doesn't
+    // throw — the SSR branch is exercised via direct logic review.
+    expect(() => isSupportedBrowser()).not.toThrow()
+  })
+})

--- a/frontend/src/components/DayPhase.vue
+++ b/frontend/src/components/DayPhase.vue
@@ -106,6 +106,7 @@
           <button
             class="btn btn-primary vote-btn"
             data-testid="day-reveal-result"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('revealResult')"
           >
@@ -116,6 +117,7 @@
           <button
             class="btn btn-gold vote-btn"
             data-testid="day-start-vote"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('startVote')"
           >

--- a/frontend/src/components/NightPhase.vue
+++ b/frontend/src/components/NightPhase.vue
@@ -70,6 +70,7 @@
         <button
           class="btn btn-danger nf-btn"
           data-testid="wolf-confirm-kill"
+          :class="{ 'is-loading': actionPending }"
           :disabled="!effectivePhase.selectedTargetId || actionPending"
           @click="confirmWolfKill"
         >
@@ -105,6 +106,7 @@
         <button
           class="btn btn-danger nf-btn"
           data-testid="seer-check"
+          :class="{ 'is-loading': actionPending }"
           :disabled="!effectivePhase.selectedTargetId || actionPending"
           @click="emit('confirm', localSelected)"
         >
@@ -158,6 +160,7 @@
           <button
             class="btn btn-secondary nf-btn"
             data-testid="seer-done"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="confirmSeerDone"
           >
@@ -190,6 +193,7 @@
           <button
             class="btn btn-primary ws-btn"
             data-testid="witch-antidote"
+            :class="{ 'is-loading': actionPending }"
             :disabled="!!nightPhase.antidoteDecided || actionPending"
             @click="confirmWitchAntidote"
           >
@@ -198,6 +202,7 @@
           <button
             class="btn btn-secondary ws-btn"
             data-testid="switch-pass-antidote"
+            :class="{ 'is-loading': actionPending }"
             :disabled="!!nightPhase.antidoteDecided || actionPending"
             @click="confirmWitchPassAntidote"
           >
@@ -240,6 +245,7 @@
             <button
               class="btn btn-primary ws-btn"
               data-testid="witch-poison-confirm"
+              :class="{ 'is-loading': actionPending }"
               :disabled="!effectivePhase.selectedTargetId || actionPending"
               @click="confirmWitchPoison(effectivePhase.selectedTargetId!)"
             >
@@ -258,6 +264,7 @@
           <button
             class="btn btn-danger ws-btn"
             data-testid="use-poison"
+            :class="{ 'is-loading': actionPending }"
             :disabled="!!nightPhase.poisonDecided || actionPending"
             @click="poisonMode = true"
           >
@@ -266,6 +273,7 @@
           <button
             class="btn btn-secondary ws-btn"
             data-testid="switch-pass-poison"
+            :class="{ 'is-loading': actionPending }"
             :disabled="!!nightPhase.poisonDecided || actionPending"
             @click="confirmWitchPassPoison"
           >
@@ -284,6 +292,7 @@
           <button
             class="btn btn-primary ws-btn"
             data-testid="witch-skip"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="confirmWitchSkip"
           >
@@ -330,6 +339,7 @@
         <button
           class="btn btn-danger nf-btn"
           data-testid="guard-confirm-protect"
+          :class="{ 'is-loading': actionPending }"
           :disabled="!effectivePhase.selectedTargetId || actionPending"
           @click="confirmGuardProtect"
         >

--- a/frontend/src/components/SheriffElection.vue
+++ b/frontend/src/components/SheriffElection.vue
@@ -31,6 +31,7 @@
           <button
             class="btn btn-danger-outline"
             data-testid="sheriff-withdraw"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('withdraw')"
           >
@@ -41,6 +42,7 @@
           <button
             class="btn btn-gold"
             data-testid="sheriff-run"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('run')"
           >
@@ -50,6 +52,7 @@
             v-if="!election.hasPassed"
             class="btn btn-outline"
             data-testid="sheriff-pass"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('pass')"
           >
@@ -61,6 +64,7 @@
           <button
             class="btn btn-primary"
             data-testid="sheriff-start-campaign"
+            :class="{ 'is-loading': actionPending }"
             :disabled="runningCandidates.length === 0 || actionPending"
             @click="emit('startCampaign')"
           >
@@ -103,6 +107,7 @@
           <button
             class="btn btn-danger-outline"
             data-testid="sheriff-quit"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('quit')"
           >
@@ -113,6 +118,7 @@
             <button
               class="btn btn-primary"
               data-testid="sheriff-advance-speech"
+              :class="{ 'is-loading': actionPending }"
               :disabled="actionPending"
               @click="emit('advanceSpeech')"
             >
@@ -126,6 +132,7 @@
           <button
             class="btn btn-primary"
             data-testid="sheriff-advance-speech"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('advanceSpeech')"
           >
@@ -168,6 +175,7 @@
           <button
             class="btn btn-danger-outline"
             data-testid="sheriff-quit"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('quit')"
           >
@@ -180,6 +188,7 @@
           <button
             class="btn btn-primary"
             data-testid="sheriff-advance-speech"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('advanceSpeech')"
           >
@@ -251,6 +260,7 @@
           <button
             class="btn btn-gold"
             data-testid="sheriff-vote"
+            :class="{ 'is-loading': actionPending }"
             :disabled="!selectedId || actionPending"
             @click="selectedId && emit('vote', selectedId)"
           >
@@ -259,6 +269,7 @@
           <button
             class="btn btn-outline"
             data-testid="sheriff-abstain"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             @click="emit('abstain')"
           >
@@ -276,6 +287,7 @@
           <button
             class="btn btn-primary"
             data-testid="sheriff-reveal-result"
+            :class="{ 'is-loading': actionPending }"
             :disabled="!election.allVoted || actionPending"
             @click="emit('revealResult')"
           >
@@ -371,6 +383,7 @@
           <button
             class="btn btn-primary"
             data-testid="sheriff-appoint"
+            :class="{ 'is-loading': actionPending }"
             :disabled="!appointTarget || actionPending"
             @click="emit('appoint', appointTarget!)"
           >
@@ -463,6 +476,7 @@
         <div class="action-footer">
           <button
             class="btn btn-primary"
+            :class="{ 'is-loading': actionPending }"
             :disabled="actionPending"
             data-testid="start-night"
             @click="emit('startNight')"

--- a/frontend/src/components/VotingPhase.vue
+++ b/frontend/src/components/VotingPhase.vue
@@ -152,6 +152,7 @@
                 <button
                   class="btn btn-secondary"
                   data-testid="voting-unvote"
+                  :class="{ 'is-loading': actionPending }"
                   :disabled="actionPending"
                   @click="emit('unvote')"
                 >
@@ -163,6 +164,7 @@
                   <button
                     class="btn btn-primary vote-btn"
                     data-testid="voting-vote"
+                    :class="{ 'is-loading': actionPending }"
                     :disabled="!effectiveSelected || actionPending"
                     @click="effectiveSelected && emit('vote', effectiveSelected)"
                   >
@@ -171,6 +173,7 @@
                   <button
                     class="btn btn-secondary skip-btn"
                     data-testid="voting-skip"
+                    :class="{ 'is-loading': actionPending }"
                     :disabled="actionPending"
                     @click="emit('skip')"
                   >
@@ -184,6 +187,7 @@
               v-if="votingPhase.subPhase === 'VOTING' || votingPhase.subPhase === 'RE_VOTING'"
               class="btn btn-gold"
               data-testid="voting-reveal"
+              :class="{ 'is-loading': actionPending }"
               :disabled="!allVotesIn || actionPending"
               @click="emit('revealVoting')"
             >
@@ -205,6 +209,7 @@
               <button
                 class="btn btn-secondary"
                 data-testid="voting-unvote"
+                :class="{ 'is-loading': actionPending }"
                 :disabled="actionPending"
                 @click="emit('unvote')"
               >
@@ -216,6 +221,7 @@
                 <button
                   class="btn btn-primary vote-btn"
                   data-testid="voting-vote"
+                  :class="{ 'is-loading': actionPending }"
                   :disabled="!effectiveSelected || actionPending"
                   @click="effectiveSelected && emit('vote', effectiveSelected)"
                 >
@@ -224,6 +230,7 @@
                 <button
                   class="btn btn-secondary skip-btn"
                   data-testid="voting-skip"
+                  :class="{ 'is-loading': actionPending }"
                   :disabled="actionPending"
                   @click="emit('skip')"
                 >
@@ -383,6 +390,7 @@
           <div class="vote-actions">
             <button
               class="btn btn-danger vote-btn"
+              :class="{ 'is-loading': actionPending }"
               :disabled="!effectiveSelected || actionPending"
               @click="effectiveSelected && emit('hunterShoot', effectiveSelected)"
             >
@@ -390,6 +398,7 @@
             </button>
             <button
               class="btn btn-secondary skip-btn"
+              :class="{ 'is-loading': actionPending }"
               :disabled="actionPending"
               @click="emit('hunterPass')"
             >
@@ -472,6 +481,7 @@
             <div class="vote-actions">
               <button
                 class="btn btn-primary vote-btn"
+                :class="{ 'is-loading': actionPending }"
                 :disabled="actionPending"
                 @click="emit('continueVoting')"
               >
@@ -489,6 +499,7 @@
             <div class="vote-actions">
               <button
                 class="btn btn-gold vote-btn"
+                :class="{ 'is-loading': actionPending }"
                 :disabled="!effectiveSelected || actionPending"
                 @click="effectiveSelected && emit('passBadge', effectiveSelected)"
               >
@@ -496,6 +507,7 @@
               </button>
               <button
                 class="btn btn-secondary skip-btn"
+                :class="{ 'is-loading': actionPending }"
                 :disabled="actionPending"
                 @click="emit('destroyBadge')"
               >

--- a/frontend/src/composables/useBrowserCompat.ts
+++ b/frontend/src/composables/useBrowserCompat.ts
@@ -1,0 +1,57 @@
+/**
+ * Browser compatibility detection.
+ *
+ * Allowed list:
+ *   - Chromium-based browsers (Chrome, Edge, Brave, Opera, Samsung Internet, …)
+ *   - iOS Safari and any iOS browser (all forced through WebKit by Apple, so
+ *     they all behave the same — we'd rather have iOS users than not).
+ *
+ * Blocked list:
+ *   - Desktop Safari, Firefox, legacy IE, anything else.
+ *
+ * Detection precedence:
+ *   1. UA Client Hints (`navigator.userAgentData`) — modern Chromium only.
+ *      Decisive: if present and brand list mentions any Chromium variant,
+ *      allow; if present but no Chromium brand (rare, theoretical), block.
+ *   2. iOS WebKit by `userAgent` (covers Safari, CriOS, FxiOS, EdgiOS).
+ *   3. UA-string fallback for Chromium-based browsers that don't ship UA-CH.
+ *   4. Otherwise blocked.
+ *
+ * Pure client-side defense — not a security boundary. Goal is to avoid users
+ * landing on a UI that doesn't work for them, not to enforce policy.
+ */
+
+interface UserAgentBrand {
+  brand: string
+  version: string
+}
+
+interface UserAgentData {
+  brands?: UserAgentBrand[]
+}
+
+export function isSupportedBrowser(): boolean {
+  if (typeof navigator === 'undefined') return true // SSR / non-browser env
+
+  const ua = navigator.userAgent ?? ''
+
+  // 1. UA Client Hints — present on modern Chromium, absent on Firefox/Safari.
+  const uaData = (navigator as { userAgentData?: UserAgentData }).userAgentData
+  if (uaData?.brands && uaData.brands.length > 0) {
+    const brandStr = uaData.brands
+      .map((b) => String(b.brand ?? '').toLowerCase())
+      .join('|')
+    return /chromium|chrome|edge|brave|opera/.test(brandStr)
+  }
+
+  // 2. iOS — every browser is WebKit; allow them all.
+  if (/iPhone|iPad|iPod/.test(ua) && /AppleWebKit/.test(ua)) return true
+
+  // 3. UA-string fallback for Chromium variants without UA-CH (older Android
+  //    Chrome, custom WebViews). Edg/ catches Edge Chromium; Chrome/ catches
+  //    Chrome, Brave, Opera, Samsung Internet, etc.
+  if (/Chrome\/\d+/.test(ua) || /Edg\//.test(ua)) return true
+
+  // 4. Firefox, desktop Safari, anything else.
+  return false
+}

--- a/frontend/src/composables/useBrowserCompat.ts
+++ b/frontend/src/composables/useBrowserCompat.ts
@@ -38,9 +38,7 @@ export function isSupportedBrowser(): boolean {
   // 1. UA Client Hints — present on modern Chromium, absent on Firefox/Safari.
   const uaData = (navigator as { userAgentData?: UserAgentData }).userAgentData
   if (uaData?.brands && uaData.brands.length > 0) {
-    const brandStr = uaData.brands
-      .map((b) => String(b.brand ?? '').toLowerCase())
-      .join('|')
+    const brandStr = uaData.brands.map((b) => String(b.brand ?? '').toLowerCase()).join('|')
     return /chromium|chrome|edge|brave|opera/.test(brandStr)
   }
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,9 +1,15 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useUserStore } from '@/stores/userStore'
+import { isSupportedBrowser } from '@/composables/useBrowserCompat'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
+    {
+      path: '/unsupported',
+      name: 'unsupported',
+      component: () => import('@/views/BrowserUnsupportedView.vue'),
+    },
     {
       path: '/',
       name: 'lobby',
@@ -47,6 +53,18 @@ const router = createRouter({
 })
 
 router.beforeEach((to) => {
+  // Browser compatibility check first — short-circuits before any auth /
+  // STOMP / store work. Skip if the user is already on the unsupported page
+  // (avoids redirect loops) and skip the dev `/dev/*` routes so contributors
+  // can still preview those in any browser.
+  if (
+    to.name !== 'unsupported' &&
+    !String(to.name ?? '').startsWith('dev-') &&
+    !isSupportedBrowser()
+  ) {
+    return { name: 'unsupported' }
+  }
+
   const userStore = useUserStore()
   if (to.meta.requiresAuth && !userStore.isLoggedIn) {
     return { name: 'lobby' }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -71,6 +71,47 @@ h3,
   cursor: not-allowed;
 }
 
+/* Loading state — applied alongside :disabled while a backend action is in
+ * flight. The disabled attribute already prevents re-clicks; this class adds
+ * a visual cue (spinner overlay + dim) so players see "click registered,
+ * waiting on backend" instead of looking identical to "not yet clickable".
+ *
+ * The label is hidden via visibility (not display: none) so the button keeps
+ * its width and the spinner stays centered. Outline-style buttons get a
+ * darker spinner so it's visible against light backgrounds.
+ */
+.btn.is-loading {
+  position: relative;
+  opacity: 0.85 !important;
+  cursor: wait !important;
+  pointer-events: none;
+}
+.btn.is-loading > * {
+  visibility: hidden;
+}
+.btn.is-loading::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: rgba(255, 255, 255, 0.95);
+  border-radius: 50%;
+  animation: btn-spin 0.6s linear infinite;
+}
+.btn-secondary.is-loading::after,
+.btn-outline.is-loading::after {
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-top-color: rgba(0, 0, 0, 0.7);
+}
+@keyframes btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .btn-primary {
   background: var(--red);
   color: #fff;

--- a/frontend/src/views/BrowserUnsupportedView.vue
+++ b/frontend/src/views/BrowserUnsupportedView.vue
@@ -6,12 +6,12 @@
       <p class="subtitle">Browser not supported</p>
 
       <p class="body">
-        这个游戏需要使用 <strong>Chrome 浏览器</strong>（或其他基于 Chromium 的浏览器，例如 Edge、Brave）。
-        iPhone / iPad 用户也可以使用 Safari。
+        这个游戏需要使用 <strong>Chrome 浏览器</strong>（或其他基于 Chromium 的浏览器，例如
+        Edge、Brave）。 iPhone / iPad 用户也可以使用 Safari。
       </p>
       <p class="body en">
-        This game runs on <strong>Chrome</strong> or other Chromium-based browsers
-        (Edge, Brave). iOS Safari is also supported.
+        This game runs on <strong>Chrome</strong> or other Chromium-based browsers (Edge, Brave).
+        iOS Safari is also supported.
       </p>
 
       <div class="hint">
@@ -27,9 +27,7 @@
 import { computed } from 'vue'
 
 // Show the user the URL they should re-open in Chrome.
-const currentUrl = computed(() =>
-  typeof window === 'undefined' ? '' : window.location.href,
-)
+const currentUrl = computed(() => (typeof window === 'undefined' ? '' : window.location.href))
 </script>
 
 <style scoped>

--- a/frontend/src/views/BrowserUnsupportedView.vue
+++ b/frontend/src/views/BrowserUnsupportedView.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="unsupported-wrap">
+    <div class="unsupported-card">
+      <div class="icon" aria-hidden="true">🌐</div>
+      <h1 class="title">浏览器不兼容</h1>
+      <p class="subtitle">Browser not supported</p>
+
+      <p class="body">
+        这个游戏需要使用 <strong>Chrome 浏览器</strong>（或其他基于 Chromium 的浏览器，例如 Edge、Brave）。
+        iPhone / iPad 用户也可以使用 Safari。
+      </p>
+      <p class="body en">
+        This game runs on <strong>Chrome</strong> or other Chromium-based browsers
+        (Edge, Brave). iOS Safari is also supported.
+      </p>
+
+      <div class="hint">
+        <p class="hint-line">在 Chrome 中打开：</p>
+        <p class="hint-line en">Open this URL in Chrome:</p>
+        <code class="url">{{ currentUrl }}</code>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+
+// Show the user the URL they should re-open in Chrome.
+const currentUrl = computed(() =>
+  typeof window === 'undefined' ? '' : window.location.href,
+)
+</script>
+
+<style scoped>
+.unsupported-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100dvh;
+  padding: 1.5rem;
+  background: var(--bg);
+}
+
+.unsupported-card {
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 2rem 1.5rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+}
+
+.icon {
+  font-size: 2.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.title {
+  font-family: 'Noto Serif SC', serif;
+  font-size: 1.625rem;
+  color: var(--red);
+  margin: 0 0 0.25rem;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 0.875rem;
+  margin: 0 0 1.5rem;
+  letter-spacing: 0.1em;
+}
+
+.body {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text);
+  margin: 0 0 0.75rem;
+}
+
+.body strong {
+  color: var(--red);
+}
+
+.body.en {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-bottom: 1.5rem;
+}
+
+.hint {
+  background: var(--card);
+  border: 1px dashed var(--border-l);
+  border-radius: 0.5rem;
+  padding: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+.hint-line {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0 0 0.25rem;
+}
+
+.hint-line.en {
+  font-size: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.url {
+  display: block;
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: var(--text);
+  word-break: break-all;
+  background: var(--paper);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+}
+</style>

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -33,6 +33,7 @@
           "
           class="btn btn-primary"
           style="margin-top: 1.5rem"
+          :class="{ 'is-loading': actionPending }"
           :disabled="actionPending"
           data-testid="start-night"
           @click="handleStartNight"

--- a/frontend/src/views/LobbyView.vue
+++ b/frontend/src/views/LobbyView.vue
@@ -21,6 +21,7 @@
       <!-- Actions -->
       <div class="actions">
         <button
+          :class="{ 'is-loading': loading }"
           :disabled="loading || !nickname.trim()"
           class="btn btn-primary"
           @click="handleCreateRoom"
@@ -37,6 +38,7 @@
             type="text"
           />
           <button
+            :class="{ 'is-loading': loading }"
             :disabled="loading || !nickname.trim() || !roomCode.trim()"
             class="btn btn-secondary join-btn"
             @click="handleJoinRoom"


### PR DESCRIPTION
## Summary

Two UX hardening wins shipped together:

1. **Browser compatibility gate** — block browsers that don't reliably play (Firefox + desktop Safari have STOMP issues). Allow Chromium-based + iOS Safari (preserves mobile target since iOS forces all browsers through WebKit anyway). Blocked browsers see a friendly bilingual reminder page; never reach the lobby, never open STOMP.
2. **Visual loading-state on action buttons** — `:disabled="actionPending"` was already there, but visually identical to "disabled because not clickable". Add a `.is-loading` class with a spinner overlay so players see "click registered, waiting on backend" and stop double-clicking.

## Behaviour matrix — browser gate

| Browser | Verdict |
|---|---|
| Chrome desktop / Android | ✅ allow |
| Edge / Brave / Opera / Samsung Internet | ✅ allow |
| iOS Safari (iPhone/iPad/iPod) | ✅ allow |
| iOS Chrome (CriOS) | ✅ allow (also WebKit) |
| Desktop Safari | ❌ block → /unsupported |
| Firefox (any platform) | ❌ block → /unsupported |

Detection precedence: UA Client Hints → iOS WebKit → UA fallback (`Chrome/` or `Edg/`) → block.

## Files changed

- **NEW** `frontend/src/composables/useBrowserCompat.ts` — `isSupportedBrowser()` 
- **NEW** `frontend/src/views/BrowserUnsupportedView.vue` — Ink & Paper bilingual reminder page
- **NEW** `frontend/src/__tests__/useBrowserCompat.test.ts` — 14 UA-table cases
- `frontend/src/router/index.ts` — `/unsupported` route + extended `beforeEach`
- `frontend/src/style.css` — `.btn.is-loading` spinner class
- ~39 buttons across `NightPhase` / `DayPhase` / `VotingPhase` / `SheriffElection` / `GameView` / `LobbyView` — one-line `:class="{ 'is-loading': actionPending }"` addition
- `frontend/src/__tests__/actionPendingDisable.test.ts` — extended to assert `is-loading` class alongside `disabled`

## Test plan

- [x] `npx vitest run` → 171/171 pass (was 157)
- [x] `npx vue-tsc --noEmit` → clean
- [ ] Manual smoke: Chrome → reaches lobby; Firefox → /unsupported; iOS Safari (real device) → reaches lobby
- [ ] Manual smoke: throttle network in DevTools, click a vote button, verify spinner appears + clears on response
- [ ] CI: all UI + Integration shards green

## Out of scope

- `GameView.onPlayerTap` calls `action()` without `await` for `SELECT_PLAYER` — informational, not gameplay-critical. Separate trivial PR if desired.
- No telemetry on browser-block; no opt-out flag; pure redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)