### PR TITLE
fix(game): reactive redirect to /result on phase=GAME_OVER

### DIFF
--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -596,6 +596,27 @@ watch(
   },
 )
 
+// Reactive redirect to /result when the game ends. There's already a STOMP
+// listener in onMounted that catches `GameOver` events, but that path is
+// event-only — if the event is delayed, dropped, or arrives during a state
+// fetch race, the user (and our E2E tests) can be left on the previous
+// NIGHT/VOTE_RESULT screen indefinitely. A reactive watch on phase=GAME_OVER
+// is the safety net: any source that updates state.phase (STOMP event,
+// initial state fetch on reconnect, refreshState() after VoteTally, etc.)
+// triggers the redirect.
+watch(
+  () => gameStore.state?.phase,
+  (phase) => {
+    if (phase === 'GAME_OVER') {
+      const gameId = route.params.gameId as string
+      // Avoid double-pushing if we're already on /result/<id>
+      if (!route.path.startsWith('/result/')) {
+        router.push({ name: 'result', params: { gameId } })
+      }
+    }
+  },
+)
+
 async function handleSheriffRun() {
   await action({ actionType: 'SHERIFF_CAMPAIGN' })
 }


### PR DESCRIPTION
## Summary

Today the GameOver→`/result/` redirect lives in a single STOMP-event listener (`data.type === 'GameOver'` in `GameView.vue:977`). If the event is delayed, dropped, or arrives during a state-fetch race, the user (and our E2E tests) get stuck on the previous NIGHT / VOTE_RESULT screen.

## Evidence

idiot-flow / revote-flow shard 2 has been failing intermittently with the same pattern — see backend.log on PR #62 run 24946135651:

```
[act rejected] action=VOTING_CONTINUE → state: phase=GAME_OVER, sub=VOTE_RESULT
```

Backend correctly transitioned to `GAME_OVER`. Frontend never redirected → test kept polling for `/result/` and timed out.

## Fix

Add a reactive `watch(() => gameStore.state?.phase, ...)` that pushes to `/result/:gameId` whenever the phase becomes `GAME_OVER`, regardless of how the state update arrived (STOMP event, `refreshState()` after VoteTally, initial state fetch on reconnect).

```ts
watch(
  () => gameStore.state?.phase,
  (phase) => {
    if (phase === 'GAME_OVER') {
      const gameId = route.params.gameId as string
      if (!route.path.startsWith('/result/')) {
        router.push({ name: 'result', params: { gameId } })
      }
    }
  },
)
```

The existing event listener stays as the fast path — this is the safety net.

## Test plan

- [x] `npx vitest run` → 171/171 pass
- [x] `npx vue-tsc --noEmit` → clean
- [x] Prettier clean
- [ ] CI: idiot-flow + revote-flow integration shards no longer "stuck on NIGHT" with backend in GAME_OVER

🤖 Generated with [Claude Code](https://claude.com/claude-code)