### PR TITLE
test(e2e): drive special-role + host actions through DOM in game-flow

### DIFF
--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -9,12 +9,16 @@
  *   - STOMP event sent → UI not updated in other browsers
  *   - Phase transition → browser stuck on old phase
  */
-import {expect, test} from '@playwright/test'
-import {type GameContext, setupGame} from './helpers/multi-browser'
-import {act, actName, type RoleName} from './helpers/shell-runner'
-import {verifyAllBrowsersPhase,} from './helpers/assertions'
-import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
-import {readHostUserId, readUnvotedAlivePlayerIds, waitForNightSubPhase} from './helpers/state-polling'
+import { expect, test } from '@playwright/test'
+import { type GameContext, setupGame } from './helpers/multi-browser'
+import { act, actName, type RoleName } from './helpers/shell-runner'
+import { verifyAllBrowsersPhase } from './helpers/assertions'
+import { attachCompositeOnFailure, captureSnapshot } from './helpers/composite-screenshot'
+import {
+  readHostUserId,
+  readUnvotedAlivePlayerIds,
+  waitForNightSubPhase,
+} from './helpers/state-polling'
 
 let ctx: GameContext
 
@@ -108,32 +112,22 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       await expect(page.locator('.game-wrap.night-mode')).toBeVisible({ timeout: 10_000 })
     }
 
-    // Wolf kill via script — target first villager (non-host)
-    const villagerBots = ctx.roleMap.VILLAGER ?? []
-    const nonHostVillager = villagerBots.find((b) => b.nick !== 'Host') ?? villagerBots[0]
-    const target = nonHostVillager?.seat ?? 1
-    const wolfBots = ctx.roleMap.WEREWOLF ?? []
-    const wolfBot = wolfBots[0]
-
-    if (wolfBot) {
-      // Wolf is a bot — use script. Gate on WEREWOLF_PICK so the act lands
-      // in the right sub-phase (Category A race guard).
-      await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 15_000)
-      act('WOLF_KILL', actName(wolfBot), { target: String(target), room: ctx.roomCode })
-    } else {
-      // Wolf is the host — use browser clicks
-      const targetSlot = wolfPage.locator(`.player-grid .slot-alive`).first()
-      await targetSlot.click()
-      const confirmBtn = wolfPage.getByTestId('wolf-confirm-kill')
-      await confirmBtn.click()
-    }
+    // Wolf kill — DOM-driven via the wolf's browser regardless of whether
+    // the wolf is a bot or the host. This catches UI/STOMP bugs the API
+    // path would mask (button render, click handler wiring, target-grid
+    // filter). Gate on WEREWOLF_PICK so the click lands in the right
+    // sub-phase (Category A race guard).
+    await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 15_000)
+    const wolfTargetSlot = wolfPage.locator('.player-grid .slot-alive').first()
+    await wolfTargetSlot.waitFor({ state: 'visible', timeout: 10_000 })
+    await wolfTargetSlot.click()
+    await wolfPage.getByTestId('wolf-confirm-kill').click()
 
     // STOMP verify: seer browser should transition to SEER_PICK
+    // (seer-check button is rendered inside the SEER_PICK template)
     const seerPage = ctx.pages.get('SEER')
     if (seerPage && seerPage !== wolfPage) {
-      await expect(
-        seerPage.getByText(/选择查验目标|Select a player to check/i).first(),
-      ).toBeVisible({ timeout: 15_000 })
+      await expect(seerPage.getByTestId('seer-check')).toBeVisible({ timeout: 15_000 })
     }
 
     await captureSnapshot(ctx.pages, testInfo, '03-wolf-kill')
@@ -142,44 +136,23 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
   // ── Test 4: Complete night via scripts, verify DAY transition ─────────
 
   test('4. Night — seer/witch/guard complete night, all browsers show DAY', async ({}, testInfo) => {
-    const seerBots = ctx.roleMap.SEER ?? []
-    const guardBots = ctx.roleMap.GUARD ?? []
-    const villagerBots = ctx.roleMap.VILLAGER ?? []
+    // ── Seer ── DOM-driven via seer's browser regardless of bot vs host.
+    // Gate on SEER_PICK before clicking — without this we race the Kotlin
+    // role-loop coroutine (memory: e2e-ci-vs-local-env-differences item 1).
+    const seerPage = ctx.pages.get('SEER')!
+    await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'SEER_PICK', 15_000)
+    const seerCheckBtn = seerPage.getByTestId('seer-check')
+    await expect(seerCheckBtn).toBeVisible({ timeout: 10_000 })
 
-    // ── Seer ──
-    // Gate on SEER_PICK before firing the bot-script action — without this,
-    // act.sh races the Kotlin role-loop coroutine. See memory item 1 of
-    // e2e-ci-vs-local-env-differences.
-    const seerBot = seerBots[0]
-    if (seerBot) {
-      // Seer is a bot — use script
-      const checkTarget = guardBots[0]?.seat ?? villagerBots[1]?.seat ?? 1
-      await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'SEER_PICK', 15_000)
-      act('SEER_CHECK', actName(seerBot), { target: String(checkTarget), room: ctx.roomCode })
+    const seerTargetSlot = seerPage.locator('.player-grid .slot-alive').first()
+    await seerTargetSlot.waitFor({ state: 'visible', timeout: 5_000 })
+    await seerTargetSlot.click()
+    await seerCheckBtn.click()
 
-      const seerPage = ctx.pages.get('SEER')
-      if (seerPage) {
-        await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
-        // Screenshot: seer sees check result
-        await captureSnapshot(ctx.pages, testInfo, '04-seer-check-result')
-      }
-
-      await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'SEER_RESULT', 10_000)
-      act('SEER_CONFIRM', actName(seerBot), { room: ctx.roomCode })
-    } else if (ctx.isHostRole('SEER')) {
-      // Seer is the host — use browser clicks
-      const seerPage = ctx.pages.get('SEER')!
-      await expect(seerPage.getByText(/选择查验目标 · Select a player to check:/i).first()).toBeVisible({ timeout: 10_000 })
-      const targetSlot = seerPage.locator('.player-grid .slot-alive').first()
-      await targetSlot.waitFor({ state: 'visible', timeout: 5_000 })
-      await targetSlot.click()
-      await seerPage.getByTestId('seer-check').click()
-      // Wait for result and confirm
-      await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
-      // Screenshot: seer sees check result
-      await captureSnapshot(ctx.pages, testInfo, '04-seer-check-result')
-      await seerPage.getByTestId('seer-done').click()
-    }
+    // Result screen appears, then confirm
+    await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
+    await captureSnapshot(ctx.pages, testInfo, '04-seer-check-result')
+    await seerPage.getByTestId('seer-done').click()
 
     // ── Witch (always via browser to capture UI at each step) ──
     // Both antidote and poison sections are visible simultaneously.
@@ -245,31 +218,19 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       await doneBtn.click()
     }
 
-    // ── Guard ──
-    // Same Category A gate as seer above — wait for backend to reach GUARD_PICK
-    // before firing the bot action.
-    const guardBot = guardBots[0]
-    if (guardBot) {
-      // Guard is a bot — use script
-      const guardPage = ctx.pages.get('GUARD')
-      if (guardPage) {
-        // Screenshot: guard UI is shown before action
-        await expect(guardPage.getByText(/选择守护目标|Protect a player/i).first()).toBeVisible({ timeout: 10_000 })
-        await captureSnapshot(ctx.pages, testInfo, '04-guard-ui')
-      }
-      await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'GUARD_PICK', 15_000)
-      act('GUARD_SKIP', actName(guardBot), { room: ctx.roomCode })
-    } else if (ctx.isHostRole('GUARD')) {
-      // Guard is the host — use browser clicks to protect someone
-      const guardPage = ctx.pages.get('GUARD')!
-      await expect(guardPage.getByText(/选择守护目标|Protect a player/i).first()).toBeVisible({ timeout: 10_000 })
-      // Screenshot: guard UI is shown
-      await captureSnapshot(ctx.pages, testInfo, '04-guard-ui')
-      const targetSlot = guardPage.locator('.player-grid .slot-alive').first()
-      await targetSlot.waitFor({ state: 'visible', timeout: 5_000 })
-      await targetSlot.click()
-      await guardPage.getByTestId('guard-confirm-protect').click()
-    }
+    // ── Guard ── DOM-driven via guard's browser. The UI has no "skip" button
+    // (memory: game-rules-clarifications — guard self-protect is allowed),
+    // so we always pick a target and confirm. Gate on GUARD_PICK first.
+    const guardPage = ctx.pages.get('GUARD')!
+    await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'GUARD_PICK', 15_000)
+    const guardConfirmBtn = guardPage.getByTestId('guard-confirm-protect')
+    await expect(guardConfirmBtn).toBeVisible({ timeout: 10_000 })
+    await captureSnapshot(ctx.pages, testInfo, '04-guard-ui')
+
+    const guardTargetSlot = guardPage.locator('.player-grid .slot-alive').first()
+    await guardTargetSlot.waitFor({ state: 'visible', timeout: 5_000 })
+    await guardTargetSlot.click()
+    await guardConfirmBtn.click()
 
     // STOMP verify: ALL browsers should transition to DAY phase
     await verifyAllBrowsersPhase(ctx.pages, 'DAY', 20_000)
@@ -358,8 +319,11 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // Wait for all votes to register
     await hostPage.waitForTimeout(2_000)
 
-    // Host reveals tally via script
-    act('VOTING_REVEAL_TALLY', 'HOST', { room: ctx.roomCode })
+    // Host reveals tally via DOM — exercises the host's reveal button
+    // wiring + STOMP fan-out, not just the API path.
+    const revealTallyBtn = hostPage.getByTestId('voting-reveal')
+    await revealTallyBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await revealTallyBtn.click()
 
     // Wait for the UI to update — could be "继续", "进入夜晚", or a hunter/badge action
     // The reveal may transition through multiple sub-phases
@@ -367,11 +331,11 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
 
     await captureSnapshot(ctx.pages, testInfo, '07-vote-tally')
 
-    // Try continuing via script (may fail if already auto-advanced)
-    try {
-      act('VOTING_CONTINUE', 'HOST', { room: ctx.roomCode })
-    } catch {
-      // May already have auto-continued or transitioned
+    // Host continues via DOM (auto-advance may have already fired the
+    // transition — only click if the button is still present).
+    const continueBtn = hostPage.getByTestId('voting-continue')
+    if (await continueBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await continueBtn.click()
     }
 
     // Should transition to NIGHT for next round (or GAME_OVER)
@@ -395,15 +359,15 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       return
     }
 
-    // Night 2: some players may be dead from previous rounds.
-    // Use browser clicks for roles where the host has the role,
-    // and try scripts with fallback for bots (which may be dead).
+    // Night 2: some browser-bound role bots may have been voted out on
+    // Day 1. Each role tries DOM-first via its browser; if that browser's
+    // bot is dead (no actor UI), fall back to the API on remaining alive
+    // bots of the same role.
 
     // Helper: try script, return false if rejected (dead player, etc.)
     const tryAct = (...args: Parameters<typeof act>): boolean => {
       try {
         const output = act(...args)
-        // Script exits 0 even on rejection — check output for "rejected"
         const rejected = output.includes('rejected')
         if (rejected) {
           // eslint-disable-next-line no-console
@@ -423,95 +387,129 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     const guardBots = ctx.roleMap.GUARD ?? []
     const villagerBots = ctx.roleMap.VILLAGER ?? []
 
-    // ── Wolf kill — try each alive wolf bot with each alive non-wolf target ──
+    const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots].filter(
+      (b) => b.nick !== 'Host',
+    )
+
+    // ── Wolf kill — DOM-first via wolf browser ──
     const wolfPage = ctx.pages.get('WEREWOLF')
     let wolfDone = false
-
-    // Collect all non-wolf potential targets
-    const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots]
-      .filter((b) => b.nick !== 'Host')
-
-    for (const wb of wolfBots) {
-      for (const tgt of allTargets) {
-        if (tryAct('WOLF_KILL', actName(wb), { target: String(tgt.seat), room: ctx.roomCode })) {
+    if (wolfPage) {
+      const wolfConfirm = wolfPage.getByTestId('wolf-confirm-kill')
+      if (await wolfConfirm.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        const targetSlot = wolfPage.locator('.player-grid .slot-alive').first()
+        if (await targetSlot.isVisible({ timeout: 2_000 }).catch(() => false)) {
+          await targetSlot.click()
+          await wolfConfirm.click()
           wolfDone = true
-          // Wait for wolf action to be processed
+          await ctx.hostPage.waitForTimeout(1_000)
+        }
+      }
+    }
+    if (!wolfDone) {
+      // Browser-wolf is dead or UI didn't render. Try API on remaining wolf bots.
+      for (const wb of wolfBots) {
+        for (const tgt of allTargets) {
+          if (tryAct('WOLF_KILL', actName(wb), { target: String(tgt.seat), room: ctx.roomCode })) {
+            wolfDone = true
+            await ctx.hostPage.waitForTimeout(1_000)
+            break
+          }
+        }
+        if (wolfDone) break
+      }
+    }
+
+    // ── Seer — DOM-first via seer browser ──
+    const seerPage = ctx.pages.get('SEER')
+    let seerDone = false
+    if (seerPage) {
+      const seerCheck = seerPage.getByTestId('seer-check')
+      if (await seerCheck.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        const targetSlot = seerPage.locator('.player-grid .slot-alive').first()
+        if (await targetSlot.isVisible({ timeout: 2_000 }).catch(() => false)) {
+          await targetSlot.click()
+          await seerCheck.click()
+          await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
+          await seerPage.getByTestId('seer-done').click()
+          seerDone = true
+        }
+      }
+    }
+    if (!seerDone) {
+      // Browser-seer is dead. Try API on remaining seer bots.
+      for (const sb of seerBots) {
+        for (const tgt of allTargets) {
+          if (tryAct('SEER_CHECK', actName(sb), { target: String(tgt.seat), room: ctx.roomCode })) {
+            await ctx.hostPage.waitForTimeout(2_000)
+            tryAct('SEER_CONFIRM', actName(sb), { room: ctx.roomCode })
+            seerDone = true
+            break
+          }
+        }
+        if (seerDone) break
+      }
+    }
+
+    // ── Witch — DOM-first via witch browser (pass on both items) ──
+    const witchPage = ctx.pages.get('WITCH')
+    let witchDone = false
+    if (witchPage) {
+      const witchSection = witchPage.locator('.w-section').first()
+      if (await witchSection.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        const passAntidote = witchPage.getByTestId('switch-pass-antidote')
+        if (await passAntidote.isVisible({ timeout: 2_000 }).catch(() => false)) {
+          await passAntidote.click()
+          await witchPage.waitForTimeout(500)
+        }
+        const passPoison = witchPage.getByTestId('switch-pass-poison')
+        if (await passPoison.isVisible({ timeout: 2_000 }).catch(() => false)) {
+          await passPoison.click()
+        }
+        const witchSkip = witchPage.getByTestId('witch-skip')
+        if (await witchSkip.isVisible({ timeout: 2_000 }).catch(() => false)) {
+          await witchSkip.click()
+        }
+        witchDone = true
+        await ctx.hostPage.waitForTimeout(1_000)
+      }
+    }
+    if (!witchDone) {
+      // Browser-witch is dead. Try API on remaining witch bots.
+      for (const wb of witchBots) {
+        if (
+          tryAct('WITCH_ACT', actName(wb), { payload: '{"useAntidote":false}', room: ctx.roomCode })
+        ) {
+          witchDone = true
           await ctx.hostPage.waitForTimeout(1_000)
           break
         }
       }
-      if (wolfDone) break
     }
 
-    // Fall back to browser clicks if no bot succeeded (host is wolf or all wolf bots dead)
-    if (!wolfDone && wolfPage) {
-      const playerGrid = wolfPage.locator('.player-grid')
-      if (await playerGrid.first().isVisible({ timeout: 10_000 }).catch(() => false)) {
-        const targetSlot = wolfPage.locator('.player-grid .slot-alive').first()
-        await targetSlot.click()
-        await wolfPage.getByTestId('wolf-confirm-kill').click()
-      }
-    }
-
-    // ── Seer ──
-    const seerBot = seerBots[0]
-    let seerDone = false
-    if (seerBot) {
-      // Try multiple targets in case some are dead
-      for (const tgt of allTargets) {
-        if (tryAct('SEER_CHECK', actName(seerBot), { target: String(tgt.seat), room: ctx.roomCode })) {
-          seerDone = true
-          // Wait for SEER result to be displayed before confirming
-          await ctx.hostPage.waitForTimeout(2_000)
-          tryAct('SEER_CONFIRM', actName(seerBot), { room: ctx.roomCode })
-          break
+    // ── Guard — DOM-first via guard browser ──
+    const guardPage = ctx.pages.get('GUARD')
+    let guardDone = false
+    if (guardPage) {
+      const guardConfirm = guardPage.getByTestId('guard-confirm-protect')
+      if (await guardConfirm.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        const targetSlot = guardPage.locator('.player-grid .slot-alive').first()
+        if (await targetSlot.isVisible({ timeout: 2_000 }).catch(() => false)) {
+          await targetSlot.click()
+          await guardConfirm.click()
+          guardDone = true
+          await ctx.hostPage.waitForTimeout(1_000)
         }
       }
     }
-    if (!seerDone && ctx.isHostRole('SEER')) {
-      const seerPage = ctx.pages.get('SEER')!
-      if (await seerPage.getByText(/选择查验目标|Select a player to check/i).first().isVisible({ timeout: 10_000 }).catch(() => false)) {
-        await seerPage.locator('.player-grid .slot-alive').first().click()
-        await seerPage.getByTestId('seer-check').click()
-        await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
-        await seerPage.getByTestId('seer-done').click()
-      }
-    }
-
-    // ── Witch ──
-    const witchBot = witchBots[0]
-    let witchDone = false
-    if (witchBot) {
-      witchDone = tryAct('WITCH_ACT', actName(witchBot), { payload: '{"useAntidote":false}', room: ctx.roomCode })
-      // Wait for Witch action to be submitted
-      await ctx.hostPage.waitForTimeout(1_000)
-    }
-    if (!witchDone && ctx.isHostRole('WITCH')) {
-      const witchPage = ctx.pages.get('WITCH')!
-      if (await witchPage.locator('.w-section').first().isVisible({ timeout: 10_000 }).catch(() => false)) {
-        const passBtn = witchPage.getByTestId('switch-pass-antidote')
-        if (await passBtn.isVisible().catch(() => false)) await passBtn.click()
-        await witchPage.waitForTimeout(500)
-        const skipBtn = witchPage.getByTestId('switch-pass-poison')
-        if (await skipBtn.isVisible().catch(() => false)) await skipBtn.click()
-        const doneBtn = witchPage.getByTestId('witch-skip')
-        if (await doneBtn.isVisible().catch(() => false)) await doneBtn.click()
-      }
-    }
-
-    // ── Guard ──
-    const guardBot = guardBots[0]
-    let guardDone = false
-    if (guardBot) {
-      guardDone = tryAct('GUARD_SKIP', actName(guardBot), { room: ctx.roomCode })
-      // Wait for guard action to be submitted
-      await ctx.hostPage.waitForTimeout(1_000)
-    }
-    if (!guardDone && ctx.isHostRole('GUARD')) {
-      const guardPage = ctx.pages.get('GUARD')!
-      if (await guardPage.getByText(/选择守护目标|Protect a player/i).first().isVisible({ timeout: 10_000 }).catch(() => false)) {
-        await guardPage.locator('.player-grid .slot-alive').first().click()
-        await guardPage.getByTestId('guard-confirm-protect').click()
+    if (!guardDone) {
+      // Browser-guard is dead. Try API on remaining guard bots (skip protect).
+      for (const gb of guardBots) {
+        if (tryAct('GUARD_SKIP', actName(gb), { room: ctx.roomCode })) {
+          guardDone = true
+          await ctx.hostPage.waitForTimeout(1_000)
+          break
+        }
       }
     }
 

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -19,6 +19,7 @@ import {
   readUnvotedAlivePlayerIds,
   waitForNightSubPhase,
 } from './helpers/state-polling'
+import { assertNoBrowserErrors } from './helpers/error-sentinel'
 
 let ctx: GameContext
 
@@ -38,9 +39,20 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     await ctx?.cleanup()
   })
 
+  // Reset the per-test error/log buffers BEFORE each test so the post-test
+  // assertions only see what happened during this test's window.
+  test.beforeEach(async () => {
+    ctx?.resetErrors()
+  })
+
   test.afterEach(async ({}, testInfo) => {
     if (testInfo.status === 'failed' && ctx?.pages) {
       await attachCompositeOnFailure(ctx.pages, testInfo)
+    }
+    // Sentinel #3: any uncaught JS exception or 5xx in any browser fails
+    // the test, even if the gameplay-level assertions otherwise passed.
+    if (ctx) {
+      await assertNoBrowserErrors(ctx.errors, testInfo)
     }
   })
 

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -43,17 +43,21 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
   // assertions only see what happened during this test's window.
   test.beforeEach(async () => {
     ctx?.resetErrors()
+    ctx?.markBackendLogPosition()
   })
 
   test.afterEach(async ({}, testInfo) => {
     if (testInfo.status === 'failed' && ctx?.pages) {
       await attachCompositeOnFailure(ctx.pages, testInfo)
     }
+    if (!ctx) return
     // Sentinel #3: any uncaught JS exception or 5xx in any browser fails
     // the test, even if the gameplay-level assertions otherwise passed.
-    if (ctx) {
-      await assertNoBrowserErrors(ctx.errors, testInfo)
-    }
+    await assertNoBrowserErrors(ctx.errors, testInfo)
+    // Sentinel #6: any ERROR/FATAL backend log line during the test window
+    // fails the test. Catches backend bugs that retried/recovered and were
+    // therefore invisible to the frontend.
+    await ctx.assertNoBackendErrors(testInfo)
   })
 
   // ── Test 1: Role reveal ──────────────────────────────────────────────

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -62,9 +62,18 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
 
   test.beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(120_000) // setup can take a while with shell scripts
+    // Explicit `roles` is required: setupGame's role-toggle block is only
+    // entered when opts.roles is non-empty (multi-browser.ts:152). Without
+    // this, the room defaults to CreateRoomView's enabledOptional set
+    // {SEER, WITCH, HUNTER} — GUARD is OFF, no guard bot is assigned, and
+    // ctx.pages.get('GUARD') returns undefined, crashing Test 4 with
+    // "Cannot read properties of undefined (reading 'getByTestId')".
+    // Verified locally: roles.sh on a fresh game showed
+    // WEREWOLF×3 + SEER + WITCH + HUNTER + VILLAGER, no GUARD.
     ctx = await setupGame(browser, {
       totalPlayers: 9,
       hasSheriff: false,
+      roles: ['WEREWOLF', 'SEER', 'WITCH', 'GUARD', 'HUNTER', 'VILLAGER'] as RoleName[],
       browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'GUARD', 'VILLAGER'] as RoleName[],
     })
     invariants = newInvariantState()
@@ -273,41 +282,39 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       }
     }
 
-    // -- Antidote decision --
+    // -- Antidote decision: clicking antidote submits a COMPLETE WITCH_ACT
+    //    (useAntidote=true, poisonTargetUserId=null) — the witch turn ends
+    //    on the backend with this single click. Do NOT click skip-poison
+    //    afterwards: that would send a second WITCH_ACT during the
+    //    inter-role-gap window, race the role-loop's queuedActionSignal
+    //    map, and auto-complete GUARD_PICK in 2 ms before the guard's
+    //    browser can render guard-confirm-protect.
+    //
+    //    The witch UI's antidote/poison panels are independent visually —
+    //    after antidote, skip-poison is still rendered (poisonDecided
+    //    only flips when poison-specific action arrives). That's a
+    //    frontend display nuance; under the hood the night is already
+    //    advancing.
     const useAntidoteBtn = witchPage.getByTestId('witch-antidote')
+    const passAntidoteBtn = witchPage.getByTestId('switch-pass-antidote')
+    const witchSkipBtn = witchPage.getByTestId('witch-skip')
+
     if (await useAntidoteBtn.isVisible().catch(() => false)) {
       await captureSnapshot(ctx.pages, testInfo, '04-witch-antidote-choice')
-
       await useAntidoteBtn.click()
-      // Action observability: witch saved the wolf's target. Test 5
-      // asserts the day banner is the peaceful variant.
       nightOneOutcome.witchSavedTarget = true
-      // After antidote click, the antidote section is consumed — the
-      // skip-poison or witch-skip button should surface as the next
-      // decision. Wait for either rather than for a fixed 500ms.
-      await expect(
-        witchPage.locator('[data-testid="switch-pass-poison"], [data-testid="witch-skip"]'),
-      ).toBeVisible({ timeout: 5_000 })
-
-      await captureSnapshot(ctx.pages, testInfo, '04-witch-after-antidote')
-    }
-
-    // -- Skip poison (if still available after antidote) --
-    const skipPoisonBtn = witchPage.getByTestId('switch-pass-poison')
-    if (await skipPoisonBtn.isVisible().catch(() => false)) {
-      await skipPoisonBtn.click()
-      // Skipping poison ends the witch turn — wait for the night
-      // sub-phase to advance past WITCH_ACT (proves the backend
-      // received the action) before continuing.
+      // Confirm WITCH_ACT actually advanced server-side before moving on
+      // to the guard block — otherwise the test races the night loop.
       await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 8_000)
-      await captureSnapshot(ctx.pages, testInfo, '04-witch-after-action')
-    }
-
-    // If no items at all (rare: both antidote+poison already consumed
-    // in earlier rounds), click the done button.
-    const doneBtn = witchPage.getByTestId('witch-skip')
-    if (await doneBtn.isVisible().catch(() => false)) {
-      await doneBtn.click()
+      await captureSnapshot(ctx.pages, testInfo, '04-witch-after-antidote')
+    } else if (await passAntidoteBtn.isVisible().catch(() => false)) {
+      // Witch has antidote but no kill happened (or witch already used
+      // antidote in a prior round). Pass cleanly with one click.
+      await passAntidoteBtn.click()
+      await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 8_000)
+    } else if (await witchSkipBtn.isVisible().catch(() => false)) {
+      // No items at all (both consumed earlier rounds): single done click.
+      await witchSkipBtn.click()
       await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 8_000)
     }
 
@@ -621,7 +628,14 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       }
     }
 
-    // ── Witch — DOM-first via witch browser (pass on both items) ──
+    // ── Witch — DOM-first via witch browser. ONE click only.
+    //   Each witch button submits a complete WITCH_ACT (useAntidote +
+    //   poisonTargetUserId in one payload). Clicking a second button
+    //   sends a SECOND WITCH_ACT during the inter-role-gap window,
+    //   which races queuedActionSignals[gameId] and auto-completes
+    //   the next role's sub-phase in 2 ms — the bug that was failing
+    //   GUARD_PICK on Night 1. Pick whichever pass button is visible
+    //   and stop there.
     const witchPage = ctx.pages.get('WITCH')
     let witchDone = false
     if (witchPage) {
@@ -633,30 +647,19 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
         .catch(() => false)
       if (sectionReady) {
         const passAntidote = witchPage.getByTestId('switch-pass-antidote')
-        if (
-          await passAntidote
-            .waitFor({ state: 'visible', timeout: 2_000 })
-            .then(() => true)
-            .catch(() => false)
-        ) {
-          await passAntidote.click()
-        }
         const passPoison = witchPage.getByTestId('switch-pass-poison')
-        if (
-          await passPoison
-            .waitFor({ state: 'visible', timeout: 2_000 })
-            .then(() => true)
-            .catch(() => false)
-        ) {
-          await passPoison.click()
-        }
         const witchSkip = witchPage.getByTestId('witch-skip')
-        if (
-          await witchSkip
+        const visibleSoon = (loc: ReturnType<typeof witchPage.getByTestId>) =>
+          loc
             .waitFor({ state: 'visible', timeout: 2_000 })
             .then(() => true)
             .catch(() => false)
-        ) {
+
+        if (await visibleSoon(passAntidote)) {
+          await passAntidote.click()
+        } else if (await visibleSoon(passPoison)) {
+          await passPoison.click()
+        } else if (await visibleSoon(witchSkip)) {
           await witchSkip.click()
         }
         await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 8_000)

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -38,6 +38,25 @@ let ctx: GameContext
 // state to the previous step's. Initialized in beforeAll.
 let invariants: GameInvariantState = newInvariantState()
 
+// Action-observability ledger: each gameplay action records its
+// expected DOM/state side-effect, and a later step asserts the
+// expectation matches reality. Without this the test could "succeed"
+// even when the action targeted the wrong seat or its result was lost.
+interface ExpectedNightOutcome {
+  wolfTargetSeat: number | null
+  witchSavedTarget: boolean
+}
+let nightOneOutcome: ExpectedNightOutcome = { wolfTargetSeat: null, witchSavedTarget: false }
+
+/** Look up the role of a player by seat. Reads from ctx.roleMap (built
+ *  at game start by roles.sh). Returns null if no bot/host has that seat. */
+function roleOfSeat(seat: number): RoleName | null {
+  for (const [role, bots] of Object.entries(ctx.roleMap) as [RoleName, typeof ctx.allBots][]) {
+    if (bots.some((b) => b.seat === seat)) return role
+  }
+  return null
+}
+
 test.describe('Game flow — multi-browser STOMP verification', () => {
   test.setTimeout(60_000) // 3 minutes for the full flow
 
@@ -49,6 +68,7 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'GUARD', 'VILLAGER'] as RoleName[],
     })
     invariants = newInvariantState()
+    nightOneOutcome = { wolfTargetSeat: null, witchSavedTarget: false }
   })
 
   test.afterAll(async () => {
@@ -161,6 +181,15 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 15_000)
     const wolfTargetSlot = wolfPage.locator('.player-grid .slot-alive').first()
     await wolfTargetSlot.waitFor({ state: 'visible', timeout: 10_000 })
+    // Action observability: capture the wolf's target seat from the slot's
+    // data-seat attribute BEFORE clicking. Test 5 asserts the day-result
+    // banner is consistent with this target (witch-saved → peaceful).
+    const wolfSeatAttr = await wolfTargetSlot.getAttribute('data-seat')
+    nightOneOutcome.wolfTargetSeat = wolfSeatAttr ? Number(wolfSeatAttr) : null
+    expect(
+      nightOneOutcome.wolfTargetSeat,
+      'wolf target slot must expose data-seat',
+    ).not.toBeNull()
     await wolfTargetSlot.click()
     await wolfPage.getByTestId('wolf-confirm-kill').click()
 
@@ -187,11 +216,33 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
 
     const seerTargetSlot = seerPage.locator('.player-grid .slot-alive').first()
     await seerTargetSlot.waitFor({ state: 'visible', timeout: 5_000 })
+    // Action observability: record which seat the seer is about to check
+    // so we can verify the result card shows the correct alignment for
+    // that seat's actual role (cross-referenced via ctx.roleMap).
+    const seerCheckedSeatAttr = await seerTargetSlot.getAttribute('data-seat')
+    expect(
+      seerCheckedSeatAttr,
+      'seer target slot must expose data-seat',
+    ).not.toBeNull()
+    const seerCheckedSeat = Number(seerCheckedSeatAttr)
     await seerTargetSlot.click()
     await seerCheckBtn.click()
 
-    // Result screen appears, then confirm
-    await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
+    // Result card surfaces with data-alignment ('wolf' | 'village') and
+    // data-checked-seat. Verify those match the actual role of the
+    // checked player. A bug here means the seer is being LIED to.
+    const resultCard = seerPage.getByTestId('seer-result-card')
+    await expect(resultCard).toBeVisible({ timeout: 10_000 })
+    const resultSeat = Number(await resultCard.getAttribute('data-checked-seat'))
+    const resultAlignment = await resultCard.getAttribute('data-alignment')
+    expect(resultSeat).toBe(seerCheckedSeat)
+    const actualRole = roleOfSeat(seerCheckedSeat)
+    const expectedAlignment = actualRole === 'WEREWOLF' ? 'wolf' : 'village'
+    expect(
+      resultAlignment,
+      `seer-result-card alignment for seat ${seerCheckedSeat} (role=${actualRole})`,
+    ).toBe(expectedAlignment)
+
     await captureSnapshot(ctx.pages, testInfo, '04-seer-check-result')
     await seerPage.getByTestId('seer-done').click()
 
@@ -239,6 +290,9 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       await captureSnapshot(ctx.pages, testInfo, '04-witch-antidote-choice')
 
       await useAntidoteBtn.click()
+      // Action observability: witch saved the wolf's target. Test 5
+      // asserts the day banner is the peaceful variant.
+      nightOneOutcome.witchSavedTarget = true
       // After antidote click, the antidote section is consumed — the
       // skip-poison or witch-skip button should surface as the next
       // decision. Wait for either rather than for a fixed 500ms.
@@ -302,16 +356,40 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // Click reveal — verify all browsers see the kill banner
     await revealBtn.click()
 
-    // All browsers should see a result banner (.banner is the parent class
-    // shared by the kill banner and the peaceful-night banner; both only
-    // render after dayPhase.subPhase becomes RESULT_REVEALED). Wait in
-    // parallel so a single laggy STOMP delivery does not serialize.
+    // Action observability: in Night 1 the wolf killed seat
+    // `nightOneOutcome.wolfTargetSeat` and the witch antidoted. The
+    // expected banner is therefore the PEACEFUL variant on every
+    // browser, AND the wolf's target seat must NOT appear in any
+    // kill list. If the witch save was lost we'd see the kill banner
+    // here — exactly the kind of bug the existing "phase advanced"
+    // check would have masked.
+    const expectedPeaceful = nightOneOutcome.witchSavedTarget
+    const wolfTarget = nightOneOutcome.wolfTargetSeat
+
     await Promise.all(
-      Array.from(ctx.pages.values()).map((page) =>
-        expect(page.locator('.day-wrap .banner').first()).toBeVisible({
-          timeout: 10_000,
-        }),
-      ),
+      Array.from(ctx.pages.values()).map(async (page) => {
+        if (expectedPeaceful) {
+          await expect(page.getByTestId('day-banner-peaceful')).toBeVisible({
+            timeout: 10_000,
+          })
+          if (wolfTarget !== null) {
+            // Even though the kill banner shouldn't be present, double-check
+            // the wolf's saved target is NOT listed as killed anywhere.
+            await expect(
+              page.getByTestId(`day-killed-seat-${wolfTarget}`),
+            ).toHaveCount(0)
+          }
+        } else if (wolfTarget !== null) {
+          // No witch save → the wolf's target should appear in the kill list.
+          await expect(
+            page.getByTestId(`day-killed-seat-${wolfTarget}`),
+          ).toBeVisible({ timeout: 10_000 })
+        } else {
+          await expect(page.locator('.day-wrap .banner').first()).toBeVisible({
+            timeout: 10_000,
+          })
+        }
+      }),
     )
 
     await captureSnapshot(ctx.pages, testInfo, '05-day-reveal')
@@ -509,9 +587,31 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
         .then(() => true)
         .catch(() => false)
       if (slotReady) {
+        // Action observability: capture the checked seat and verify the
+        // alignment matches actual role — same contract as Night 1, so a
+        // Night-2 seer-result regression is caught the same way.
+        const seatAttr = await targetSlot.getAttribute('data-seat')
+        const checkedSeat = seatAttr ? Number(seatAttr) : null
         await targetSlot.click()
         await seerPage.getByTestId('seer-check').click()
-        await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
+        const card = seerPage.getByTestId('seer-result-card')
+        await expect(card).toBeVisible({ timeout: 10_000 })
+        if (checkedSeat !== null) {
+          const resultSeat = Number(await card.getAttribute('data-checked-seat'))
+          expect(resultSeat).toBe(checkedSeat)
+          const resultAlignment = await card.getAttribute('data-alignment')
+          const actualRole = roleOfSeat(checkedSeat)
+          // actualRole may be null if the seer happened to check the
+          // host without a bot entry; in that case skip the strict
+          // alignment check rather than fail noisily.
+          if (actualRole) {
+            const expectedAlignment = actualRole === 'WEREWOLF' ? 'wolf' : 'village'
+            expect(
+              resultAlignment,
+              `night-2 seer alignment for seat ${checkedSeat} (role=${actualRole})`,
+            ).toBe(expectedAlignment)
+          }
+        }
         await seerPage.getByTestId('seer-done').click()
         // Seer-done advances backend from SEER_RESULT to next role.
         await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'SEER_RESULT', 8_000)

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -26,8 +26,17 @@ import {
   waitForVotingSubPhase,
 } from './helpers/state-polling'
 import { assertNoBrowserErrors } from './helpers/error-sentinel'
+import {
+  assertGameInvariants,
+  type GameInvariantState,
+  newInvariantState,
+} from './helpers/invariants'
 
 let ctx: GameContext
+// Shared across the describe block — assertGameInvariants returns the
+// updated snapshot after each call so we can compare every step's
+// state to the previous step's. Initialized in beforeAll.
+let invariants: GameInvariantState = newInvariantState()
 
 test.describe('Game flow — multi-browser STOMP verification', () => {
   test.setTimeout(60_000) // 3 minutes for the full flow
@@ -39,6 +48,7 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       hasSheriff: false,
       browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'GUARD', 'VILLAGER'] as RoleName[],
     })
+    invariants = newInvariantState()
   })
 
   test.afterAll(async () => {
@@ -64,6 +74,16 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // fails the test. Catches backend bugs that retried/recovered and were
     // therefore invisible to the frontend.
     await ctx.assertNoBackendErrors(testInfo)
+    // Invariant guard #4: cheap state read after every step — phase rank
+    // monotonic, alive count never grows, sub-phase belongs to parent,
+    // sheriff alive (or in BADGE_HANDOVER / GAME_OVER). The returned
+    // state threads into the next test step.
+    invariants = await assertGameInvariants(
+      ctx.hostPage,
+      ctx.gameId,
+      invariants,
+      testInfo.title,
+    )
   })
 
   // ── Test 1: Role reveal ──────────────────────────────────────────────

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -98,12 +98,7 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // monotonic, alive count never grows, sub-phase belongs to parent,
     // sheriff alive (or in BADGE_HANDOVER / GAME_OVER). The returned
     // state threads into the next test step.
-    invariants = await assertGameInvariants(
-      ctx.hostPage,
-      ctx.gameId,
-      invariants,
-      testInfo.title,
-    )
+    invariants = await assertGameInvariants(ctx.hostPage, ctx.gameId, invariants, testInfo.title)
   })
 
   // ── Test 1: Role reveal ──────────────────────────────────────────────
@@ -186,10 +181,7 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // banner is consistent with this target (witch-saved → peaceful).
     const wolfSeatAttr = await wolfTargetSlot.getAttribute('data-seat')
     nightOneOutcome.wolfTargetSeat = wolfSeatAttr ? Number(wolfSeatAttr) : null
-    expect(
-      nightOneOutcome.wolfTargetSeat,
-      'wolf target slot must expose data-seat',
-    ).not.toBeNull()
+    expect(nightOneOutcome.wolfTargetSeat, 'wolf target slot must expose data-seat').not.toBeNull()
     await wolfTargetSlot.click()
     await wolfPage.getByTestId('wolf-confirm-kill').click()
 
@@ -220,10 +212,7 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // so we can verify the result card shows the correct alignment for
     // that seat's actual role (cross-referenced via ctx.roleMap).
     const seerCheckedSeatAttr = await seerTargetSlot.getAttribute('data-seat')
-    expect(
-      seerCheckedSeatAttr,
-      'seer target slot must expose data-seat',
-    ).not.toBeNull()
+    expect(seerCheckedSeatAttr, 'seer target slot must expose data-seat').not.toBeNull()
     const seerCheckedSeat = Number(seerCheckedSeatAttr)
     await seerTargetSlot.click()
     await seerCheckBtn.click()
@@ -297,9 +286,7 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       // skip-poison or witch-skip button should surface as the next
       // decision. Wait for either rather than for a fixed 500ms.
       await expect(
-        witchPage.locator(
-          '[data-testid="switch-pass-poison"], [data-testid="witch-skip"]',
-        ),
+        witchPage.locator('[data-testid="switch-pass-poison"], [data-testid="witch-skip"]'),
       ).toBeVisible({ timeout: 5_000 })
 
       await captureSnapshot(ctx.pages, testInfo, '04-witch-after-antidote')
@@ -375,15 +362,13 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
           if (wolfTarget !== null) {
             // Even though the kill banner shouldn't be present, double-check
             // the wolf's saved target is NOT listed as killed anywhere.
-            await expect(
-              page.getByTestId(`day-killed-seat-${wolfTarget}`),
-            ).toHaveCount(0)
+            await expect(page.getByTestId(`day-killed-seat-${wolfTarget}`)).toHaveCount(0)
           }
         } else if (wolfTarget !== null) {
           // No witch save → the wolf's target should appear in the kill list.
-          await expect(
-            page.getByTestId(`day-killed-seat-${wolfTarget}`),
-          ).toBeVisible({ timeout: 10_000 })
+          await expect(page.getByTestId(`day-killed-seat-${wolfTarget}`)).toBeVisible({
+            timeout: 10_000,
+          })
         } else {
           await expect(page.locator('.day-wrap .banner').first()).toBeVisible({
             timeout: 10_000,

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -9,7 +9,7 @@
  *   - STOMP event sent → UI not updated in other browsers
  *   - Phase transition → browser stuck on old phase
  */
-import { expect, test } from '@playwright/test'
+import { expect, type Page, test } from '@playwright/test'
 import { type GameContext, setupGame } from './helpers/multi-browser'
 import { act, actName, type RoleName } from './helpers/shell-runner'
 import { verifyAllBrowsersPhase } from './helpers/assertions'
@@ -17,7 +17,13 @@ import { attachCompositeOnFailure, captureSnapshot } from './helpers/composite-s
 import {
   readHostUserId,
   readUnvotedAlivePlayerIds,
+  waitForAllVotesRegistered,
+  waitForCondition,
   waitForNightSubPhase,
+  waitForNightSubPhaseChange,
+  waitForPhase,
+  waitForVoteRegistered,
+  waitForVotingSubPhase,
 } from './helpers/state-polling'
 import { assertNoBrowserErrors } from './helpers/error-sentinel'
 
@@ -79,7 +85,6 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
         const revealBtnVisible = await revealBtn.isVisible().catch(() => false)
         expect(revealBtnVisible).toBe(true)
         await revealBtn.click()
-        await page.waitForTimeout(300)
         const gotItBtn = page.getByTestId('confirm-role-btn')
         await gotItBtn.waitFor({ state: 'visible', timeout: 2_000 })
         await gotItBtn.click()
@@ -183,38 +188,46 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     const usePoisonBtn = witchPage.getByTestId('use-poison')
     if (await usePoisonBtn.isVisible().catch(() => false)) {
       await usePoisonBtn.click()
-      await witchPage.waitForTimeout(500)
+      // Wait for the poison grid to render — use-poison click should
+      // surface poison-mode-cancel and the small target grid.
+      const cancelBtn = witchPage.getByTestId('poison-mode-cancel')
+      await expect(cancelBtn).toBeVisible({ timeout: 5_000 })
 
-      // Screenshot: poison target selection grid shown
       await captureSnapshot(ctx.pages, testInfo, '04-witch-poison-select')
 
-      // Select a target — poison grid uses 'alive' variant (slot-alive class)
       const poisonTarget = witchPage.locator('.player-grid-sm .slot-alive').first()
       if (await poisonTarget.isVisible().catch(() => false)) {
         await poisonTarget.click()
-        await witchPage.waitForTimeout(300)
+        // Confirm button only enables after a target is selected — its
+        // enabled state proves the click was registered.
+        await expect(witchPage.getByTestId('witch-poison-confirm')).toBeEnabled({
+          timeout: 5_000,
+        })
 
-        // Screenshot: poison target selected (before confirm)
         await captureSnapshot(ctx.pages, testInfo, '04-witch-poison-selected')
 
-        // Cancel — we don't actually want to poison in round 1
-        const cancelBtn = witchPage.getByTestId('poison-mode-cancel')
+        // Cancel — we don't actually want to poison in round 1.
         await cancelBtn.click()
-        await witchPage.waitForTimeout(300)
+        // Cancelling exits poison mode — use-poison button reappears.
+        await expect(usePoisonBtn).toBeVisible({ timeout: 5_000 })
       }
     }
 
     // -- Antidote decision --
     const useAntidoteBtn = witchPage.getByTestId('witch-antidote')
     if (await useAntidoteBtn.isVisible().catch(() => false)) {
-      // Screenshot: antidote choice visible
       await captureSnapshot(ctx.pages, testInfo, '04-witch-antidote-choice')
 
-      // Use antidote to save the attacked player
       await useAntidoteBtn.click()
-      await witchPage.waitForTimeout(500)
+      // After antidote click, the antidote section is consumed — the
+      // skip-poison or witch-skip button should surface as the next
+      // decision. Wait for either rather than for a fixed 500ms.
+      await expect(
+        witchPage.locator(
+          '[data-testid="switch-pass-poison"], [data-testid="witch-skip"]',
+        ),
+      ).toBeVisible({ timeout: 5_000 })
 
-      // Screenshot: after using antidote
       await captureSnapshot(ctx.pages, testInfo, '04-witch-after-antidote')
     }
 
@@ -222,16 +235,19 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     const skipPoisonBtn = witchPage.getByTestId('switch-pass-poison')
     if (await skipPoisonBtn.isVisible().catch(() => false)) {
       await skipPoisonBtn.click()
-      await witchPage.waitForTimeout(500)
-
-      // Screenshot: after skipping poison (witch turn complete)
+      // Skipping poison ends the witch turn — wait for the night
+      // sub-phase to advance past WITCH_ACT (proves the backend
+      // received the action) before continuing.
+      await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 8_000)
       await captureSnapshot(ctx.pages, testInfo, '04-witch-after-action')
     }
 
-    // If no items at all, click done
+    // If no items at all (rare: both antidote+poison already consumed
+    // in earlier rounds), click the done button.
     const doneBtn = witchPage.getByTestId('witch-skip')
     if (await doneBtn.isVisible().catch(() => false)) {
       await doneBtn.click()
+      await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 8_000)
     }
 
     // ── Guard ── DOM-driven via guard's browser. The UI has no "skip" button
@@ -266,19 +282,17 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // Click reveal — verify all browsers see the kill banner
     await revealBtn.click()
 
-    // All browsers should see the result (kill banner or "peaceful night")
-    for (const [_, page] of Array.from(ctx.pages.entries())) {
-      // Wait for the button to change or kill info to appear
-      await page.waitForTimeout(2_000)
-      // After reveal, the sub-phase changes to RESULT_REVEALED
-      // Either a kill banner or "平安夜 / Peaceful night" should be visible
-      const hasContent = await page
-        .locator('.day-wrap')
-        .first()
-        .isVisible()
-        .catch(() => false)
-      expect(hasContent).toBe(true)
-    }
+    // All browsers should see a result banner (.banner is the parent class
+    // shared by the kill banner and the peaceful-night banner; both only
+    // render after dayPhase.subPhase becomes RESULT_REVEALED). Wait in
+    // parallel so a single laggy STOMP delivery does not serialize.
+    await Promise.all(
+      Array.from(ctx.pages.values()).map((page) =>
+        expect(page.locator('.day-wrap .banner').first()).toBeVisible({
+          timeout: 10_000,
+        }),
+      ),
+    )
 
     await captureSnapshot(ctx.pages, testInfo, '05-day-reveal')
   })
@@ -304,13 +318,19 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
 
   test('7. Voting — players vote, tally revealed, continue to night', async ({}, testInfo) => {
     const hostPage = ctx.hostPage
+    const hostId = await readHostUserId(ctx.hostPage)
 
     // Host votes FIRST via browser — abstain
     // (Must do this BEFORE bot votes, since act() now includes host in "all" players)
     const abstainBtn = hostPage.locator('.skip-btn').first()
     await abstainBtn.waitFor({ state: 'visible', timeout: 10_000 })
     await abstainBtn.click()
-    await hostPage.waitForTimeout(500)
+    // Confirm the abstain registered before bots fan out — otherwise the
+    // backend may still see the host as "unvoted" and accept the bot
+    // SUBMIT_VOTE that act.sh fans out on the host's behalf.
+    if (hostId) {
+      await waitForVoteRegistered(ctx.hostPage, ctx.gameId, hostId, 5_000)
+    }
 
     // Find a wolf target to vote for (use the first alive wolf bot)
     const wolfBots = ctx.roleMap.WEREWOLF ?? []
@@ -322,18 +342,23 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // iterate every bot (plus host) and the redundant attempts on the
     // already-voted host would burn act.sh's 3× retry quota on rejection.
     const unvoted = await readUnvotedAlivePlayerIds(ctx.hostPage, ctx.gameId)
-    const hostId = await readHostUserId(ctx.hostPage)
     const voteOpts: { target?: string; room: string } = wolfTarget
       ? { target: String(wolfTarget.seat), room: ctx.roomCode }
       : { room: ctx.roomCode }
+    const expectedVoterIds: string[] = []
     for (const bot of ctx.allBots) {
       if (bot.nick === 'Host' || bot.userId === hostId) continue
       if (!unvoted.has(bot.userId)) continue
       act('SUBMIT_VOTE', bot.nick, voteOpts)
+      expectedVoterIds.push(bot.userId)
     }
 
-    // Wait for all votes to register
-    await hostPage.waitForTimeout(2_000)
+    // Wait until every fan-out vote is registered before revealing the
+    // tally — without this, the reveal can race the last vote and produce
+    // an inconsistent count.
+    if (expectedVoterIds.length > 0) {
+      await waitForAllVotesRegistered(ctx.hostPage, ctx.gameId, expectedVoterIds, 10_000)
+    }
 
     // Host reveals tally via DOM — exercises the host's reveal button
     // wiring + STOMP fan-out, not just the API path.
@@ -341,22 +366,27 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     await revealTallyBtn.waitFor({ state: 'visible', timeout: 10_000 })
     await revealTallyBtn.click()
 
-    // Wait for the UI to update — could be "继续", "进入夜晚", or a hunter/badge action
-    // The reveal may transition through multiple sub-phases
-    await hostPage.waitForTimeout(3_000)
+    // The reveal click should advance the voting sub-phase to VOTE_RESULT
+    // (or HUNTER_SHOOT / BADGE_HANDOVER if the eliminated player triggers
+    // those). Either way, the sub-phase changes from VOTING.
+    await waitForVotingSubPhase(ctx.hostPage, ctx.gameId, 'VOTE_RESULT', 6_000)
 
     await captureSnapshot(ctx.pages, testInfo, '07-vote-tally')
 
     // Host continues via DOM (auto-advance may have already fired the
     // transition — only click if the button is still present).
     const continueBtn = hostPage.getByTestId('voting-continue')
-    if (await continueBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    const continueVisible = await continueBtn
+      .waitFor({ state: 'visible', timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false)
+    if (continueVisible) {
       await continueBtn.click()
     }
 
-    // Should transition to NIGHT for next round (or GAME_OVER)
-    await hostPage.waitForTimeout(3_000)
-
+    // Should transition to NIGHT for next round (or GAME_OVER). The
+    // verifyAllBrowsersPhase below has its own internal wait — no
+    // separate buffer needed here.
     const isGameOver = hostPage.url().includes('/result/')
     if (!isGameOver) {
       await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 15_000)
@@ -407,19 +437,32 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       (b) => b.nick !== 'Host',
     )
 
+    // Locator visibility helper — Playwright's isVisible() does NOT retry,
+    // so wrapping waitFor lets us return a boolean after a real wait.
+    const isVisibleSoon = async (page: Page, testId: string, timeoutMs = 5_000) =>
+      page
+        .getByTestId(testId)
+        .waitFor({ state: 'visible', timeout: timeoutMs })
+        .then(() => true)
+        .catch(() => false)
+
     // ── Wolf kill — DOM-first via wolf browser ──
     const wolfPage = ctx.pages.get('WEREWOLF')
     let wolfDone = false
-    if (wolfPage) {
-      const wolfConfirm = wolfPage.getByTestId('wolf-confirm-kill')
-      if (await wolfConfirm.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        const targetSlot = wolfPage.locator('.player-grid .slot-alive').first()
-        if (await targetSlot.isVisible({ timeout: 2_000 }).catch(() => false)) {
-          await targetSlot.click()
-          await wolfConfirm.click()
-          wolfDone = true
-          await ctx.hostPage.waitForTimeout(1_000)
-        }
+    if (wolfPage && (await isVisibleSoon(wolfPage, 'wolf-confirm-kill'))) {
+      const targetSlot = wolfPage.locator('.player-grid .slot-alive').first()
+      const slotReady = await targetSlot
+        .waitFor({ state: 'visible', timeout: 2_000 })
+        .then(() => true)
+        .catch(() => false)
+      if (slotReady) {
+        await targetSlot.click()
+        await wolfPage.getByTestId('wolf-confirm-kill').click()
+        wolfDone = true
+        // Confirm backend processed the kill before moving to seer/witch
+        // — otherwise the sub-phase polling for the next role can race
+        // against the wolf's coroutine commit.
+        await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 8_000)
       }
     }
     if (!wolfDone) {
@@ -428,7 +471,7 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
         for (const tgt of allTargets) {
           if (tryAct('WOLF_KILL', actName(wb), { target: String(tgt.seat), room: ctx.roomCode })) {
             wolfDone = true
-            await ctx.hostPage.waitForTimeout(1_000)
+            await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 8_000)
             break
           }
         }
@@ -439,17 +482,20 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // ── Seer — DOM-first via seer browser ──
     const seerPage = ctx.pages.get('SEER')
     let seerDone = false
-    if (seerPage) {
-      const seerCheck = seerPage.getByTestId('seer-check')
-      if (await seerCheck.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        const targetSlot = seerPage.locator('.player-grid .slot-alive').first()
-        if (await targetSlot.isVisible({ timeout: 2_000 }).catch(() => false)) {
-          await targetSlot.click()
-          await seerCheck.click()
-          await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
-          await seerPage.getByTestId('seer-done').click()
-          seerDone = true
-        }
+    if (seerPage && (await isVisibleSoon(seerPage, 'seer-check'))) {
+      const targetSlot = seerPage.locator('.player-grid .slot-alive').first()
+      const slotReady = await targetSlot
+        .waitFor({ state: 'visible', timeout: 2_000 })
+        .then(() => true)
+        .catch(() => false)
+      if (slotReady) {
+        await targetSlot.click()
+        await seerPage.getByTestId('seer-check').click()
+        await expect(seerPage.locator('.sr-wrap').first()).toBeVisible({ timeout: 10_000 })
+        await seerPage.getByTestId('seer-done').click()
+        // Seer-done advances backend from SEER_RESULT to next role.
+        await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'SEER_RESULT', 8_000)
+        seerDone = true
       }
     }
     if (!seerDone) {
@@ -457,8 +503,11 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       for (const sb of seerBots) {
         for (const tgt of allTargets) {
           if (tryAct('SEER_CHECK', actName(sb), { target: String(tgt.seat), room: ctx.roomCode })) {
-            await ctx.hostPage.waitForTimeout(2_000)
+            // Backend transitions SEER_PICK → SEER_RESULT after CHECK,
+            // then SEER_RESULT → next sub-phase after CONFIRM.
+            await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'SEER_RESULT', 5_000)
             tryAct('SEER_CONFIRM', actName(sb), { room: ctx.roomCode })
+            await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'SEER_RESULT', 8_000)
             seerDone = true
             break
           }
@@ -471,23 +520,42 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     const witchPage = ctx.pages.get('WITCH')
     let witchDone = false
     if (witchPage) {
-      const witchSection = witchPage.locator('.w-section').first()
-      if (await witchSection.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      const sectionReady = await witchPage
+        .locator('.w-section')
+        .first()
+        .waitFor({ state: 'visible', timeout: 5_000 })
+        .then(() => true)
+        .catch(() => false)
+      if (sectionReady) {
         const passAntidote = witchPage.getByTestId('switch-pass-antidote')
-        if (await passAntidote.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        if (
+          await passAntidote
+            .waitFor({ state: 'visible', timeout: 2_000 })
+            .then(() => true)
+            .catch(() => false)
+        ) {
           await passAntidote.click()
-          await witchPage.waitForTimeout(500)
         }
         const passPoison = witchPage.getByTestId('switch-pass-poison')
-        if (await passPoison.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        if (
+          await passPoison
+            .waitFor({ state: 'visible', timeout: 2_000 })
+            .then(() => true)
+            .catch(() => false)
+        ) {
           await passPoison.click()
         }
         const witchSkip = witchPage.getByTestId('witch-skip')
-        if (await witchSkip.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        if (
+          await witchSkip
+            .waitFor({ state: 'visible', timeout: 2_000 })
+            .then(() => true)
+            .catch(() => false)
+        ) {
           await witchSkip.click()
         }
+        await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 8_000)
         witchDone = true
-        await ctx.hostPage.waitForTimeout(1_000)
       }
     }
     if (!witchDone) {
@@ -496,8 +564,8 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
         if (
           tryAct('WITCH_ACT', actName(wb), { payload: '{"useAntidote":false}', room: ctx.roomCode })
         ) {
+          await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 8_000)
           witchDone = true
-          await ctx.hostPage.waitForTimeout(1_000)
           break
         }
       }
@@ -506,35 +574,36 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // ── Guard — DOM-first via guard browser ──
     const guardPage = ctx.pages.get('GUARD')
     let guardDone = false
-    if (guardPage) {
-      const guardConfirm = guardPage.getByTestId('guard-confirm-protect')
-      if (await guardConfirm.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        const targetSlot = guardPage.locator('.player-grid .slot-alive').first()
-        if (await targetSlot.isVisible({ timeout: 2_000 }).catch(() => false)) {
-          await targetSlot.click()
-          await guardConfirm.click()
-          guardDone = true
-          await ctx.hostPage.waitForTimeout(1_000)
-        }
+    if (guardPage && (await isVisibleSoon(guardPage, 'guard-confirm-protect'))) {
+      const targetSlot = guardPage.locator('.player-grid .slot-alive').first()
+      const slotReady = await targetSlot
+        .waitFor({ state: 'visible', timeout: 2_000 })
+        .then(() => true)
+        .catch(() => false)
+      if (slotReady) {
+        await targetSlot.click()
+        await guardPage.getByTestId('guard-confirm-protect').click()
+        await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'GUARD_PICK', 8_000)
+        guardDone = true
       }
     }
     if (!guardDone) {
       // Browser-guard is dead. Try API on remaining guard bots (skip protect).
       for (const gb of guardBots) {
         if (tryAct('GUARD_SKIP', actName(gb), { room: ctx.roomCode })) {
+          await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'GUARD_PICK', 8_000)
           guardDone = true
-          await ctx.hostPage.waitForTimeout(1_000)
           break
         }
       }
     }
 
-    // After night, should transition to DAY (or GAME_OVER)
-    // Wait longer for backend to process all actions and trigger phase transition
-    await ctx.hostPage.waitForTimeout(10_000)
-
+    // After night, the backend transitions NIGHT → DAY_PENDING → DAY_DISCUSSION.
+    // Poll the backend rather than guess a 10-second buffer; if the game
+    // ended (GAME_OVER), the page URL will already be /result/...
     const isOver = ctx.hostPage.url().includes('/result/')
     if (!isOver) {
+      await waitForPhase(ctx.hostPage, ctx.gameId, 'DAY_DISCUSSION', 20_000)
       await verifyAllBrowsersPhase(ctx.pages, 'DAY', 20_000)
     }
 

--- a/frontend/e2e/real/helpers/assertions.ts
+++ b/frontend/e2e/real/helpers/assertions.ts
@@ -6,7 +6,7 @@
  *   - STOMP event sent but UI not updated
  *   - Phase transition not reflected in a browser
  */
-import {expect, type Page} from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
 
 // Phase transitions occasionally take 2-3× longer on GH ubuntu-latest runners
 // than on local dev hardware. Rather than hard-code larger waits at every call
@@ -59,14 +59,13 @@ export const PHASE_DATA_VALUES: Readonly<Record<string, readonly string[]>> = Ob
  * Wait until a page shows the expected game phase.
  * Throws (P0) if the phase doesn't appear within timeout.
  */
-export async function waitForPhase(
-  page: Page,
-  phase: string,
-  timeout = 15_000,
-): Promise<void> {
+export async function waitForPhase(page: Page, phase: string, timeout = 15_000): Promise<void> {
   const selector = PHASE_SELECTORS[phase]
   if (!selector) throw new Error(`Unknown phase: ${phase}`)
-  await page.locator(selector).first().waitFor({ state: 'visible', timeout: scale(timeout) })
+  await page
+    .locator(selector)
+    .first()
+    .waitFor({ state: 'visible', timeout: scale(timeout) })
 }
 
 /**
@@ -172,9 +171,7 @@ export async function verifyAllBrowsersPhase(
   // same field every other component reads — so a STOMP delivery
   // regression to a single browser fails this assertion immediately
   // even if the legacy component-class selector would still match.
-  const selector = dataValues
-    .map((v) => `.game-wrap[data-phase="${v}"]`)
-    .join(', ')
+  const selector = dataValues.map((v) => `.game-wrap[data-phase="${v}"]`).join(', ')
 
   const results = await Promise.allSettled(
     Array.from(pages.entries()).map(async ([role, page]) => {

--- a/frontend/e2e/real/helpers/assertions.ts
+++ b/frontend/e2e/real/helpers/assertions.ts
@@ -125,8 +125,8 @@ export async function clickAndVerify(
  */
 async function snapshotBackendState(page: Page): Promise<Record<string, unknown> | null> {
   const gameIdMatch = page.url().match(/\/game\/(\d+)/)
-  if (!gameIdMatch) return null
-  const gameId = gameIdMatch[1]
+  const gameId = gameIdMatch?.[1]
+  if (!gameId) return null
   try {
     return await page.evaluate(async (id: string) => {
       const token = localStorage.getItem('jwt')

--- a/frontend/e2e/real/helpers/assertions.ts
+++ b/frontend/e2e/real/helpers/assertions.ts
@@ -17,6 +17,11 @@ const scale = (ms: number) => Math.round(ms * TIMEOUT_SCALE)
 
 // ── Phase selectors (derived from actual component root classes) ─────────────
 
+/**
+ * Pre-#1 selectors: inferred phase from per-component CSS classes. Kept
+ * as a documented fallback for waitForPhase (single-page helper) since
+ * some specs use it before GameView mounts (e.g. waiting-screen).
+ */
 export const PHASE_SELECTORS: Record<string, string> = {
   ROLE_REVEAL: '.reveal-wrap, .waiting-screen',
   SHERIFF_ELECTION: '.sheriff-wrap',
@@ -24,6 +29,29 @@ export const PHASE_SELECTORS: Record<string, string> = {
   DAY: '.day-wrap',
   VOTING: '.voting-wrap',
 }
+
+/**
+ * Post-#1 mapping: spec-friendly phase label → set of authoritative
+ * `data-phase` values that GameView writes onto its root element.
+ *
+ * Multiple values map to one label because the spec abstracts day/night
+ * cycle states the way humans do (DAY = "discussion-or-pending"), while
+ * the backend distinguishes DAY_PENDING / DAY_DISCUSSION precisely.
+ *
+ * Used by verifyAllBrowsersPhase below — the data-attribute selector
+ * makes phase delivery testable cross-browser without inferring from
+ * CSS classes (which would mask, e.g., a spec calling 'NIGHT' on a
+ * browser whose store is still on DAY but whose body has the night
+ * class from a stale render).
+ */
+export const PHASE_DATA_VALUES: Readonly<Record<string, readonly string[]>> = Object.freeze({
+  ROLE_REVEAL: ['ROLE_REVEAL', 'WAITING'],
+  SHERIFF_ELECTION: ['SHERIFF_ELECTION'],
+  NIGHT: ['NIGHT'],
+  DAY: ['DAY_PENDING', 'DAY_DISCUSSION'],
+  VOTING: ['DAY_VOTING'],
+  GAME_OVER: ['GAME_OVER'],
+})
 
 // ── Single-page helpers ──────────────────────────────────────────────────────
 
@@ -134,41 +162,50 @@ export async function verifyAllBrowsersPhase(
   phase: string,
   timeout = 30_000, // Increased from 15s to 30s to accommodate audio processing delays
 ): Promise<void> {
-  const selector = PHASE_SELECTORS[phase]
-  if (!selector) throw new Error(`Unknown phase: ${phase}`)
+  const dataValues = PHASE_DATA_VALUES[phase]
+  if (!dataValues) throw new Error(`Unknown phase: ${phase}`)
   const effective = scale(timeout)
+
+  // Build a CSS selector that matches the .game-wrap root only when its
+  // data-phase is one of the expected backend values. This is the
+  // authoritative phase source — backed by gameStore.state.phase, the
+  // same field every other component reads — so a STOMP delivery
+  // regression to a single browser fails this assertion immediately
+  // even if the legacy component-class selector would still match.
+  const selector = dataValues
+    .map((v) => `.game-wrap[data-phase="${v}"]`)
+    .join(', ')
 
   const results = await Promise.allSettled(
     Array.from(pages.entries()).map(async ([role, page]) => {
       try {
         await page.locator(selector).first().waitFor({ state: 'visible', timeout: effective })
       } catch {
-        // Get current page state for better error reporting
+        // Diagnostic: read the actual data-phase / data-phase-sub the
+        // browser is showing so the failure message says exactly what
+        // value was observed instead of a CSS-class inference.
         const currentPhase = await page.evaluate(() => {
-          const body = document.body
-          const hasNightWrap = !!document.querySelector('.game-wrap.night-mode')
-          const hasDayWrap = !!document.querySelector('.day-wrap')
-          const hasVotingWrap = !!document.querySelector('.voting-wrap')
-          const hasSheriffWrap = !!document.querySelector('.sheriff-wrap')
-          const hasRevealWrap = !!document.querySelector('.reveal-wrap')
-          
-          let detectedPhase = 'UNKNOWN'
-          if (hasNightWrap) detectedPhase = 'NIGHT'
-          else if (hasDayWrap) detectedPhase = 'DAY'
-          else if (hasVotingWrap) detectedPhase = 'VOTING'
-          else if (hasSheriffWrap) detectedPhase = 'SHERIFF_ELECTION'
-          else if (hasRevealWrap) detectedPhase = 'ROLE_REVEAL'
-          
+          const wrap = document.querySelector('.game-wrap') as HTMLElement | null
           return {
-            detectedPhase,
-            bodyClasses: body.className,
-            url: window.location.href
+            dataPhase: wrap?.dataset.phase ?? null,
+            dataPhaseSub: wrap?.dataset.phaseSub ?? null,
+            dataDayNumber: wrap?.dataset.dayNumber ?? null,
+            // CSS-class fallback for diagnostics only — if data-phase is
+            // empty (component hasn't mounted yet, store not populated),
+            // these still tell us how far the page got.
+            hasNightWrap: !!document.querySelector('.game-wrap.night-mode'),
+            hasDayWrap: !!document.querySelector('.day-wrap'),
+            hasVotingWrap: !!document.querySelector('.voting-wrap'),
+            hasSheriffWrap: !!document.querySelector('.sheriff-wrap'),
+            hasRevealWrap: !!document.querySelector('.reveal-wrap'),
+            url: window.location.href,
           }
         })
-        
+
         throw new Error(
-          `P0: Browser [${role}] stuck — expected phase ${phase} (selector: ${selector}) ` +
-          `but not visible after ${effective}ms. Current state: ${JSON.stringify(currentPhase)}`
+          `P0: Browser [${role}] stuck — expected phase ${phase} ` +
+            `(data-phase ∈ {${dataValues.join(',')}}) ` +
+            `but not visible after ${effective}ms. Current state: ${JSON.stringify(currentPhase)}`,
         )
       }
     }),

--- a/frontend/e2e/real/helpers/backend-log.ts
+++ b/frontend/e2e/real/helpers/backend-log.ts
@@ -1,12 +1,18 @@
 /**
- * Backend log attachment helper.
+ * Backend log attachment + ERROR-line sentinel.
  *
  * Backend stdout is captured to a file via `tee` in the webServer command in
- * playwright.real.config.ts. On test failure we attach the tail of that file
- * to the Playwright report — this is the missing link between a frontend
- * assertion ("stuck on NIGHT/WEREWOLF_PICK") and the backend reality
- * (`action.submit ... -> SUCCESS`, `PhaseChanged`, `game.state ... waitingOn=
- * [...]`, `Exception`).
+ * playwright.real.config.ts. Two consumers in this file:
+ *
+ *  1. attachBackendLogOnFailure — on failure, attaches the last 500 lines
+ *     of the log to the Playwright report. The missing link between a
+ *     frontend assertion ("stuck on NIGHT/WEREWOLF_PICK") and the backend
+ *     reality (`action.submit ... -> SUCCESS`, `PhaseChanged`, `Exception`).
+ *
+ *  2. assertNoBackendErrorsSince — fails the test in afterEach if any
+ *     ERROR / FATAL line appeared in the log during the test window, even
+ *     when the gameplay-level assertions otherwise passed. Backend bugs
+ *     that are recovered by retry/coroutine restart are still bugs.
  *
  * Default tail size is 500 lines, which on this codebase covers ~30 s of
  * backend activity — enough context for any single sub-phase stall without
@@ -44,4 +50,121 @@ export async function attachBackendLogOnFailure(
   } catch {
     // best-effort — don't crash the afterEach
   }
+}
+
+// ─── Sentinel #6 — fail on ERROR / FATAL lines during the test window ────────
+
+/**
+ * Patterns that count as "the backend logged an error event". Each pattern
+ * matches the timestamp+level prefix Spring Boot uses, not the stack-frame
+ * lines that follow — we want one match per error event, not one per frame.
+ *
+ * Examples that match:
+ *   2026-04-26 10:00:00.456 ERROR 12345 --- [    main] o.s.b.SpringApplication ...
+ *   2026-04-26 10:00:00.789 FATAL 12345 --- [scheduler] o.s.s.s.TaskScheduler ...
+ *
+ * Examples that intentionally do NOT match:
+ *   "  at com.werewolf.GameService.handleAction(GameService.kt:123)"
+ *   "Caused by: java.lang.RuntimeException"
+ *   "java.lang.RuntimeException: ..."
+ *
+ * Cause-by / stack-frame lines are useful context — they appear in the
+ * report attachment — but we don't double-count them as separate errors.
+ */
+const ERROR_LINE_PATTERNS: RegExp[] = [
+  / ERROR \d+ --- /, // Spring Boot 3 default pattern
+  / FATAL \d+ --- /,
+]
+
+/**
+ * Read the current line count of the backend log, or 0 if the file does
+ * not exist (e.g. running unit tests, or the log not yet flushed). Use
+ * this to mark the position at the start of a test.
+ */
+export function readBackendLogLineCount(logPath = DEFAULT_LOG_PATH): number {
+  if (!existsSync(logPath)) return 0
+  try {
+    return readFileSync(logPath, 'utf-8').split('\n').length
+  } catch {
+    return 0
+  }
+}
+
+/** Read the lines of the backend log written since `startLine`. */
+export function readBackendLogSince(
+  startLine: number,
+  logPath = DEFAULT_LOG_PATH,
+): string[] {
+  if (!existsSync(logPath)) return []
+  try {
+    const all = readFileSync(logPath, 'utf-8').split('\n')
+    return all.slice(Math.max(0, startLine))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Filter `lines` to those that match an ERROR_LINE_PATTERN and are not
+ * matched by any allow-list pattern. Exposed for unit testing and for
+ * specs that want to inspect the same set the assertion would fail on.
+ */
+export function findBackendErrorLines(
+  lines: string[],
+  allowPatterns: RegExp[] = [],
+): string[] {
+  return lines.filter((line) => {
+    if (!ERROR_LINE_PATTERNS.some((p) => p.test(line))) return false
+    if (allowPatterns.some((p) => p.test(line))) return false
+    return true
+  })
+}
+
+/**
+ * Fail the current test if any ERROR/FATAL line appeared in the backend
+ * log since `startLine`. Attaches a `backend-errors` report artifact
+ * with each matched line plus the immediately following stack-trace
+ * fragments (up to 8 lines) so debugging from CI doesn't require local
+ * reproduction.
+ *
+ * Pass `allowPatterns` for known intentional 5xx paths in negative-case
+ * tests; default is strict (every ERROR fails).
+ */
+export async function assertNoBackendErrorsSince(
+  startLine: number,
+  testInfo: TestInfo,
+  options?: { allowPatterns?: RegExp[]; logPath?: string },
+): Promise<void> {
+  const path = options?.logPath ?? DEFAULT_LOG_PATH
+  const allowPatterns = options?.allowPatterns ?? []
+  const lines = readBackendLogSince(startLine, path)
+  const errorLines = findBackendErrorLines(lines, allowPatterns)
+  if (errorLines.length === 0) return
+
+  // Build a richer attachment: each error line + up to 8 following lines
+  // (the cause-by / stack-frame block). Use the line index in `lines` so
+  // we don't re-grep the whole file.
+  const blocks: string[] = []
+  for (let i = 0; i < lines.length; i++) {
+    if (
+      ERROR_LINE_PATTERNS.some((p) => p.test(lines[i])) &&
+      !allowPatterns.some((p) => p.test(lines[i]))
+    ) {
+      const trace = lines.slice(i, Math.min(i + 9, lines.length)).join('\n')
+      blocks.push(trace)
+    }
+  }
+
+  await testInfo.attach('backend-errors', {
+    body:
+      `Backend log recorded ${errorLines.length} ERROR/FATAL line(s) during this test.\n` +
+      `(Stack frame and Caused-by lines that follow each error are included for context.)\n\n` +
+      blocks.map((b, i) => `── [${i + 1}] ──\n${b}`).join('\n\n'),
+    contentType: 'text/plain',
+  })
+
+  throw new Error(
+    `Backend log: ${errorLines.length} ERROR/FATAL line(s) during test — see backend-errors attachment. ` +
+      `First: ${errorLines[0].slice(0, 200)}`,
+  )
 }

--- a/frontend/e2e/real/helpers/backend-log.ts
+++ b/frontend/e2e/real/helpers/backend-log.ts
@@ -91,10 +91,7 @@ export function readBackendLogLineCount(logPath = DEFAULT_LOG_PATH): number {
 }
 
 /** Read the lines of the backend log written since `startLine`. */
-export function readBackendLogSince(
-  startLine: number,
-  logPath = DEFAULT_LOG_PATH,
-): string[] {
+export function readBackendLogSince(startLine: number, logPath = DEFAULT_LOG_PATH): string[] {
   if (!existsSync(logPath)) return []
   try {
     const all = readFileSync(logPath, 'utf-8').split('\n')
@@ -109,10 +106,7 @@ export function readBackendLogSince(
  * matched by any allow-list pattern. Exposed for unit testing and for
  * specs that want to inspect the same set the assertion would fail on.
  */
-export function findBackendErrorLines(
-  lines: string[],
-  allowPatterns: RegExp[] = [],
-): string[] {
+export function findBackendErrorLines(lines: string[], allowPatterns: RegExp[] = []): string[] {
   return lines.filter((line) => {
     if (!ERROR_LINE_PATTERNS.some((p) => p.test(line))) return false
     if (allowPatterns.some((p) => p.test(line))) return false

--- a/frontend/e2e/real/helpers/backend-log.ts
+++ b/frontend/e2e/real/helpers/backend-log.ts
@@ -140,9 +140,10 @@ export async function assertNoBackendErrorsSince(
   // we don't re-grep the whole file.
   const blocks: string[] = []
   for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
     if (
-      ERROR_LINE_PATTERNS.some((p) => p.test(lines[i])) &&
-      !allowPatterns.some((p) => p.test(lines[i]))
+      ERROR_LINE_PATTERNS.some((p) => p.test(line)) &&
+      !allowPatterns.some((p) => p.test(line))
     ) {
       const trace = lines.slice(i, Math.min(i + 9, lines.length)).join('\n')
       blocks.push(trace)
@@ -157,8 +158,9 @@ export async function assertNoBackendErrorsSince(
     contentType: 'text/plain',
   })
 
+  const firstError = errorLines[0] ?? '(no preview)'
   throw new Error(
     `Backend log: ${errorLines.length} ERROR/FATAL line(s) during test — see backend-errors attachment. ` +
-      `First: ${errorLines[0].slice(0, 200)}`,
+      `First: ${firstError.slice(0, 200)}`,
   )
 }

--- a/frontend/e2e/real/helpers/error-sentinel.ts
+++ b/frontend/e2e/real/helpers/error-sentinel.ts
@@ -1,0 +1,121 @@
+/**
+ * Per-browser console + network error sentinels.
+ *
+ * Wires `pageerror` (uncaught JS exceptions) and `response` (HTTP 5xx)
+ * listeners on every browser page in the multi-browser fixture. Errors
+ * are pushed into a shared array and `assertNoBrowserErrors()` fails the
+ * test in afterEach if anything was recorded during the test window.
+ *
+ * Why: a JS error on the seer's screen — or a 5xx from a STOMP-triggered
+ * REST call — does not by itself fail the existing assertions, because
+ * the spec only checks "did the phase advance?". This sentinel turns
+ * those silent regressions into hard test failures and attaches the
+ * error trace to the Playwright report.
+ *
+ * Usage:
+ *   const errors: BrowserError[] = []
+ *   attachErrorListeners('HOST', hostPage, errors)
+ *   // ... after each test:
+ *   assertNoBrowserErrors(errors, testInfo)
+ */
+import type { Page, TestInfo } from '@playwright/test'
+
+export interface BrowserError {
+  role: string
+  type: 'pageerror' | 'response-5xx'
+  url?: string
+  status?: number
+  message: string
+  stack?: string
+  /** ISO timestamp of capture, for ordering vs backend log */
+  capturedAt: string
+}
+
+/**
+ * Attach error listeners to a page. Listeners stay attached for the
+ * lifetime of the page; the shared `errors` array is mutated in place.
+ * Caller resets the array between tests.
+ */
+export function attachErrorListeners(
+  role: string,
+  page: Page,
+  errors: BrowserError[],
+): void {
+  page.on('pageerror', (err) => {
+    errors.push({
+      role,
+      type: 'pageerror',
+      message: err.message,
+      stack: err.stack,
+      capturedAt: new Date().toISOString(),
+    })
+  })
+  page.on('response', (resp) => {
+    const status = resp.status()
+    if (status >= 500) {
+      errors.push({
+        role,
+        type: 'response-5xx',
+        url: resp.url(),
+        status,
+        message: `${resp.request().method()} ${resp.url()} → ${status}`,
+        capturedAt: new Date().toISOString(),
+      })
+    }
+  })
+}
+
+/**
+ * Fail the current test if any browser error was recorded since the
+ * last reset. Attaches the full error list to the Playwright report
+ * before throwing so CI logs include the JS stack / 5xx URL.
+ *
+ * Call this in afterEach AFTER any failure-only attachments (composite
+ * screenshot, backend log) so they still run if the test already failed.
+ *
+ * Pass `expected` to allow specific URLs/messages — useful when a test
+ * intentionally exercises a 5xx path. Default: every recorded error
+ * fails the test.
+ */
+export async function assertNoBrowserErrors(
+  errors: BrowserError[],
+  testInfo: TestInfo,
+  expected?: { urlIncludes?: string[]; messageIncludes?: string[] },
+): Promise<void> {
+  const filtered = errors.filter((e) => {
+    if (!expected) return true
+    if (expected.urlIncludes?.some((s) => e.url?.includes(s))) return false
+    if (expected.messageIncludes?.some((s) => e.message.includes(s))) return false
+    return true
+  })
+  if (filtered.length === 0) return
+
+  const summary = filtered
+    .map(
+      (e, i) =>
+        `[${i + 1}] [${e.role}] ${e.type} @ ${e.capturedAt}\n` +
+        (e.url ? `  url: ${e.url}\n` : '') +
+        (e.status ? `  status: ${e.status}\n` : '') +
+        `  message: ${e.message}` +
+        (e.stack ? `\n  stack:\n${e.stack.split('\n').slice(0, 8).join('\n')}` : ''),
+    )
+    .join('\n\n')
+
+  await testInfo.attach('browser-errors', {
+    body: `Browser sentinel recorded ${filtered.length} error(s) during this test.\n\n${summary}`,
+    contentType: 'text/plain',
+  })
+
+  throw new Error(
+    `Browser sentinel: ${filtered.length} JS / 5xx error(s) recorded — see browser-errors attachment. ` +
+      `First: [${filtered[0].role}] ${filtered[0].message.slice(0, 200)}`,
+  )
+}
+
+/**
+ * Reset the shared errors array. Call in beforeEach so each test gets a
+ * clean window — without this, a failure in test N leaks into test N+1.
+ */
+export function resetBrowserErrors(errors: BrowserError[]): void {
+  errors.length = 0
+}

--- a/frontend/e2e/real/helpers/error-sentinel.ts
+++ b/frontend/e2e/real/helpers/error-sentinel.ts
@@ -36,11 +36,7 @@ export interface BrowserError {
  * lifetime of the page; the shared `errors` array is mutated in place.
  * Caller resets the array between tests.
  */
-export function attachErrorListeners(
-  role: string,
-  page: Page,
-  errors: BrowserError[],
-): void {
+export function attachErrorListeners(role: string, page: Page, errors: BrowserError[]): void {
   page.on('pageerror', (err) => {
     errors.push({
       role,

--- a/frontend/e2e/real/helpers/error-sentinel.ts
+++ b/frontend/e2e/real/helpers/error-sentinel.ts
@@ -102,9 +102,14 @@ export async function assertNoBrowserErrors(
     contentType: 'text/plain',
   })
 
+  // filtered.length > 0 has been checked above, so [0] is defined; use a
+  // local to keep TS strict-null-check happy without `!`.
+  const first = filtered[0]
   throw new Error(
     `Browser sentinel: ${filtered.length} JS / 5xx error(s) recorded — see browser-errors attachment. ` +
-      `First: [${filtered[0].role}] ${filtered[0].message.slice(0, 200)}`,
+      (first
+        ? `First: [${first.role}] ${first.message.slice(0, 200)}`
+        : ''),
   )
 }
 

--- a/frontend/e2e/real/helpers/invariants.ts
+++ b/frontend/e2e/real/helpers/invariants.ts
@@ -39,7 +39,7 @@ import type { Page } from '@playwright/test'
  * strictly greater than day-1-DAY_VOTING (1000+60=1060). GAME_OVER is
  * a terminal marker; rank is meaningless once reached.
  */
-export const PHASE_RANK: Readonly<Record<string, number>> = Object.freeze({
+export const PHASE_RANK: Record<string, number> = Object.freeze({
   ROLE_REVEAL: 0,
   WAITING: 10,
   SHERIFF_ELECTION: 20,
@@ -49,6 +49,9 @@ export const PHASE_RANK: Readonly<Record<string, number>> = Object.freeze({
   DAY_VOTING: 60,
   GAME_OVER: 9999,
 })
+
+/** Standalone constant so direct access avoids noUncheckedIndexedAccess. */
+const GAME_OVER_RANK = 9999
 
 const NIGHT_SUBS = new Set([
   'WAITING',
@@ -103,7 +106,7 @@ export function computePhaseRank(phase: string, dayNumber: number): number {
   if (base === undefined) {
     throw new Error(`computePhaseRank: unknown phase "${phase}"`)
   }
-  if (phase === 'GAME_OVER') return PHASE_RANK.GAME_OVER
+  if (phase === 'GAME_OVER') return GAME_OVER_RANK
   return base + dayNumber * 1000
 }
 

--- a/frontend/e2e/real/helpers/invariants.ts
+++ b/frontend/e2e/real/helpers/invariants.ts
@@ -1,0 +1,246 @@
+/**
+ * Game-state invariants asserted between every test step.
+ *
+ * The principle: there are properties of a running werewolf game that
+ * MUST always hold, and a single cheap state read after each step
+ * surfaces violations the per-step assertions would never catch on
+ * their own.
+ *
+ * Invariants enforced:
+ *
+ *   1. (dayNumber, phase) rank is monotonic — the game never goes
+ *      backwards in time. Phase aliases (DAY_PENDING / DAY_DISCUSSION)
+ *      are ranked in their natural order; round number multiplies
+ *      so day-2-NIGHT is strictly after day-1-DAY_VOTING.
+ *   2. Alive count is monotonic decreasing — players never resurrect.
+ *   3. Sub-phase belongs to the parent phase — NightSubPhase only
+ *      makes sense in NIGHT, VotingSubPhase in DAY_VOTING, etc.
+ *   4. Sheriff (if elected) is alive while the game is running.
+ *      Exceptions: the GAME_OVER terminal state and the BADGE_HANDOVER
+ *      sub-phase, where the dying sheriff transfers the badge.
+ *
+ * Use:
+ *
+ *   let invariants = newInvariantState()
+ *   test('1. step', async () => {
+ *     // ... gameplay
+ *     invariants = await assertGameInvariants(hostPage, gameId, invariants, 'step-1')
+ *   })
+ *
+ * Each call returns the new state; pass it back in for the next step.
+ */
+import type { Page } from '@playwright/test'
+
+// ── Phase ranking ────────────────────────────────────────────────────────────
+
+/**
+ * Per-round phase position. Higher = later within the round.
+ * dayNumber multiplies by 1000, so day-2-NIGHT (2000+30=2030) is
+ * strictly greater than day-1-DAY_VOTING (1000+60=1060). GAME_OVER is
+ * a terminal marker; rank is meaningless once reached.
+ */
+export const PHASE_RANK: Readonly<Record<string, number>> = Object.freeze({
+  ROLE_REVEAL: 0,
+  WAITING: 10,
+  SHERIFF_ELECTION: 20,
+  NIGHT: 30,
+  DAY_PENDING: 40,
+  DAY_DISCUSSION: 50,
+  DAY_VOTING: 60,
+  GAME_OVER: 9999,
+})
+
+const NIGHT_SUBS = new Set([
+  'WAITING',
+  'WEREWOLF_PICK',
+  'SEER_PICK',
+  'SEER_RESULT',
+  'WITCH_ACT',
+  'GUARD_PICK',
+  'COMPLETE',
+])
+
+const DAY_SUBS = new Set(['RESULT_HIDDEN', 'RESULT_REVEALED'])
+
+const VOTING_SUBS = new Set([
+  'VOTING',
+  'RE_VOTING',
+  'VOTE_RESULT',
+  'HUNTER_SHOOT',
+  'BADGE_HANDOVER',
+])
+
+const SHERIFF_SUBS = new Set(['SIGNUP', 'SPEECH', 'VOTING', 'RESULT', 'TIED'])
+
+// ── State carried across test steps ──────────────────────────────────────────
+
+export interface GameInvariantState {
+  /** Last observed top-level phase, or null before the first call. */
+  lastPhase: string | null
+  /** Last observed day number (defaults to 1 before the first NIGHT). */
+  lastDayNumber: number
+  /** Last observed alive-player count, or null before the first call. */
+  lastAliveCount: number | null
+  /**
+   * Composite rank (PHASE_RANK[phase] + dayNumber * 1000); used for the
+   * monotonic time-direction check. Initialized at -1 so the very first
+   * observation always passes.
+   */
+  lastPhaseRank: number
+}
+
+export const newInvariantState = (): GameInvariantState => ({
+  lastPhase: null,
+  lastDayNumber: 1,
+  lastAliveCount: null,
+  lastPhaseRank: -1,
+})
+
+// ── Pure rank computation (exported for unit tests) ──────────────────────────
+
+export function computePhaseRank(phase: string, dayNumber: number): number {
+  const base = PHASE_RANK[phase]
+  if (base === undefined) {
+    throw new Error(`computePhaseRank: unknown phase "${phase}"`)
+  }
+  if (phase === 'GAME_OVER') return PHASE_RANK.GAME_OVER
+  return base + dayNumber * 1000
+}
+
+// ── Pure invariant check (exported so tests can drive it without a page) ─────
+
+export interface MinimalGameState {
+  phase: string
+  nightPhase?: { subPhase?: string; dayNumber?: number } | null
+  votingPhase?: { subPhase?: string } | null
+  dayPhase?: { subPhase?: string; dayNumber?: number } | null
+  sheriffElection?: { subPhase?: string } | null
+  players?: Array<{
+    userId: string
+    isAlive: boolean
+    isSheriff?: boolean
+    nickname?: string
+    seatIndex?: number
+  }>
+  dayNumber?: number
+}
+
+/**
+ * Throws if any invariant is violated. Returns the new state for the
+ * caller to thread into the next call. The `contextLabel` appears in
+ * every thrown error so the failing test step is identifiable.
+ */
+export function assertGameInvariantsOnState(
+  state: MinimalGameState,
+  prev: GameInvariantState,
+  contextLabel: string,
+): GameInvariantState {
+  const phase = state.phase
+  if (PHASE_RANK[phase] === undefined) {
+    throw new Error(`[invariants/${contextLabel}] unknown phase "${phase}"`)
+  }
+  const dayNumber =
+    state.nightPhase?.dayNumber ??
+    state.dayPhase?.dayNumber ??
+    state.dayNumber ??
+    prev.lastDayNumber
+  const aliveCount = (state.players ?? []).filter((p) => p.isAlive).length
+  const rank = computePhaseRank(phase, dayNumber)
+
+  // 1. Monotonic time direction (skip when entering GAME_OVER, which
+  //    overrides ranking).
+  if (phase !== 'GAME_OVER' && rank < prev.lastPhaseRank) {
+    throw new Error(
+      `[invariants/${contextLabel}] phase regressed: ` +
+        `${prev.lastPhase}/day${prev.lastDayNumber} (rank ${prev.lastPhaseRank}) → ` +
+        `${phase}/day${dayNumber} (rank ${rank})`,
+    )
+  }
+
+  // 2. Alive count is monotonic decreasing.
+  if (prev.lastAliveCount !== null && aliveCount > prev.lastAliveCount) {
+    throw new Error(
+      `[invariants/${contextLabel}] alive count grew: ` +
+        `${prev.lastAliveCount} → ${aliveCount} (resurrection?)`,
+    )
+  }
+
+  // 3. Sub-phase belongs to its parent phase (when set).
+  const nSub = state.nightPhase?.subPhase
+  if (phase === 'NIGHT' && nSub && !NIGHT_SUBS.has(nSub)) {
+    throw new Error(
+      `[invariants/${contextLabel}] phase=NIGHT but unrecognized nightSubPhase="${nSub}"`,
+    )
+  }
+  const dSub = state.dayPhase?.subPhase
+  if ((phase === 'DAY_PENDING' || phase === 'DAY_DISCUSSION') && dSub && !DAY_SUBS.has(dSub)) {
+    throw new Error(
+      `[invariants/${contextLabel}] phase=${phase} but unrecognized daySubPhase="${dSub}"`,
+    )
+  }
+  const vSub = state.votingPhase?.subPhase
+  if (phase === 'DAY_VOTING' && vSub && !VOTING_SUBS.has(vSub)) {
+    throw new Error(
+      `[invariants/${contextLabel}] phase=DAY_VOTING but unrecognized votingSubPhase="${vSub}"`,
+    )
+  }
+  const sSub = state.sheriffElection?.subPhase
+  if (phase === 'SHERIFF_ELECTION' && sSub && !SHERIFF_SUBS.has(sSub)) {
+    throw new Error(
+      `[invariants/${contextLabel}] phase=SHERIFF_ELECTION but unrecognized electionSubPhase="${sSub}"`,
+    )
+  }
+
+  // 4. Sheriff (if any) is alive while the game is running. The badge can
+  //    persist for a moment during BADGE_HANDOVER while it transfers; the
+  //    GAME_OVER terminal state is exempt.
+  const sheriff = (state.players ?? []).find((p) => p.isSheriff)
+  if (sheriff && !sheriff.isAlive) {
+    const inHandover = phase === 'DAY_VOTING' && vSub === 'BADGE_HANDOVER'
+    if (phase !== 'GAME_OVER' && !inHandover) {
+      throw new Error(
+        `[invariants/${contextLabel}] sheriff (seat ${sheriff.seatIndex} ${sheriff.nickname}) ` +
+          `is dead while phase=${phase}/sub=${vSub ?? '-'} — badge should have transferred`,
+      )
+    }
+  }
+
+  return {
+    lastPhase: phase,
+    lastDayNumber: dayNumber,
+    lastAliveCount: aliveCount,
+    lastPhaseRank: rank,
+  }
+}
+
+// ── Live-page wrapper ────────────────────────────────────────────────────────
+
+/**
+ * Fetch /api/game/{id}/state via the host page's JWT and run the pure
+ * invariant check on the result. Returns the new state; throws on
+ * violation or on /state read failure.
+ */
+export async function assertGameInvariants(
+  hostPage: Page,
+  gameId: string,
+  prev: GameInvariantState,
+  contextLabel: string,
+): Promise<GameInvariantState> {
+  const state = await hostPage.evaluate(async (id: string) => {
+    const token = localStorage.getItem('jwt')
+    if (!token) return null
+    const res = await fetch(`/api/game/${id}/state`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!res.ok) return null
+    return res.json()
+  }, gameId)
+
+  if (!state || typeof state.phase !== 'string') {
+    throw new Error(
+      `[invariants/${contextLabel}] failed to read /api/game/${gameId}/state — backend down or auth lost`,
+    )
+  }
+
+  return assertGameInvariantsOnState(state as MinimalGameState, prev, contextLabel)
+}

--- a/frontend/e2e/real/helpers/multi-browser.ts
+++ b/frontend/e2e/real/helpers/multi-browser.ts
@@ -12,7 +12,7 @@
  */
 import {readFileSync, writeFileSync} from 'fs'
 import path from 'path'
-import {type Browser, type BrowserContext, expect, type Page} from '@playwright/test'
+import {type Browser, type BrowserContext, expect, type Page, type TestInfo} from '@playwright/test'
 import {
     act,
     type BotInfo,
@@ -24,6 +24,7 @@ import {
     type RoleName,
 } from './shell-runner'
 import {attachErrorListeners, type BrowserError, resetBrowserErrors} from './error-sentinel'
+import {assertNoBackendErrorsSince, readBackendLogLineCount} from './backend-log'
 
 const BASE_URL = 'http://localhost:5174'
 
@@ -54,6 +55,18 @@ export interface GameContext {
   errors: BrowserError[]
   /** Clear the errors buffer; call in beforeEach for a clean test window. */
   resetErrors: () => void
+  /**
+   * Snapshot the current backend-log line count so the next
+   * `assertNoBackendErrors` call only inspects lines added during the
+   * test. Call in beforeEach.
+   */
+  markBackendLogPosition: () => void
+  /**
+   * Fail the test if any ERROR/FATAL line appeared in the backend log
+   * since the most recent `markBackendLogPosition`. Call in afterEach
+   * after any failure-only attachments.
+   */
+  assertNoBackendErrors: (testInfo: TestInfo) => Promise<void>
   /** Clean up all browser contexts */
   cleanup: () => Promise<void>
 }
@@ -366,6 +379,8 @@ export async function setupGame(
 
   const isHostRole = (role: RoleName) => hostRole === role
 
+  let backendLogStartLine = readBackendLogLineCount()
+
   return {
     roomCode,
     gameId,
@@ -379,6 +394,11 @@ export async function setupGame(
     isHostRole,
     errors,
     resetErrors: () => resetBrowserErrors(errors),
+    markBackendLogPosition: () => {
+      backendLogStartLine = readBackendLogLineCount()
+    },
+    assertNoBackendErrors: (testInfo) =>
+      assertNoBackendErrorsSince(backendLogStartLine, testInfo),
     cleanup: async () => {
       for (const ctx of contexts) {
         try {

--- a/frontend/e2e/real/helpers/multi-browser.ts
+++ b/frontend/e2e/real/helpers/multi-browser.ts
@@ -23,6 +23,7 @@ import {
     type RoleMap,
     type RoleName,
 } from './shell-runner'
+import {attachErrorListeners, type BrowserError, resetBrowserErrors} from './error-sentinel'
 
 const BASE_URL = 'http://localhost:5174'
 
@@ -45,6 +46,14 @@ export interface GameContext {
   hostRole: RoleName | null
   /** Roles where the host IS the player (use browser, not scripts) */
   isHostRole: (role: RoleName) => boolean
+  /**
+   * Per-test browser-error buffer. Populated by the page sentinels on
+   * `pageerror` and `response` (5xx). Reset between tests via `resetErrors()`;
+   * asserted in afterEach via `assertNoBrowserErrors()`.
+   */
+  errors: BrowserError[]
+  /** Clear the errors buffer; call in beforeEach for a clean test window. */
+  resetErrors: () => void
   /** Clean up all browser contexts */
   cleanup: () => Promise<void>
 }
@@ -81,9 +90,12 @@ export async function setupGame(
 
   // ── Step 1: Host logs in and creates room ──────────────────────────────
 
+  const errors: BrowserError[] = []
+
   const hostContext = await browser.newContext()
   contexts.push(hostContext)
   const hostPage = await hostContext.newPage()
+  attachErrorListeners('HOST', hostPage, errors)
 
   await hostPage.goto(`${BASE_URL}/`)
   await hostPage.evaluate(() => localStorage.clear())
@@ -329,6 +341,7 @@ export async function setupGame(
     const ctx = await browser.newContext()
     contexts.push(ctx)
     const page = await ctx.newPage()
+    attachErrorListeners(role, page, errors)
 
     // Login by setting localStorage directly
     await page.goto(`${BASE_URL}/`)
@@ -364,6 +377,8 @@ export async function setupGame(
     roleMap,
     hostRole,
     isHostRole,
+    errors,
+    resetErrors: () => resetBrowserErrors(errors),
     cleanup: async () => {
       for (const ctx of contexts) {
         try {

--- a/frontend/e2e/real/helpers/multi-browser.ts
+++ b/frontend/e2e/real/helpers/multi-browser.ts
@@ -10,21 +10,27 @@
  *   // ctx.pages.get('SEER')     — seer's browser page
  *   // ctx.hostPage              — host's browser page
  */
-import {readFileSync, writeFileSync} from 'fs'
+import { readFileSync, writeFileSync } from 'fs'
 import path from 'path'
-import {type Browser, type BrowserContext, expect, type Page, type TestInfo} from '@playwright/test'
 import {
-    act,
-    type BotInfo,
-    getConsoleLogin,
-    getRoles,
-    joinBots,
-    readStateFile,
-    type RoleMap,
-    type RoleName,
+  type Browser,
+  type BrowserContext,
+  expect,
+  type Page,
+  type TestInfo,
+} from '@playwright/test'
+import {
+  act,
+  type BotInfo,
+  getConsoleLogin,
+  getRoles,
+  joinBots,
+  readStateFile,
+  type RoleMap,
+  type RoleName,
 } from './shell-runner'
-import {attachErrorListeners, type BrowserError, resetBrowserErrors} from './error-sentinel'
-import {assertNoBackendErrorsSince, readBackendLogLineCount} from './backend-log'
+import { attachErrorListeners, type BrowserError, resetBrowserErrors } from './error-sentinel'
+import { assertNoBackendErrorsSince, readBackendLogLineCount } from './backend-log'
 
 const BASE_URL = 'http://localhost:5174'
 
@@ -116,7 +122,10 @@ export async function setupGame(
 
   // Login
   await hostPage.getByPlaceholder('Enter your nickname').fill('Host')
-  await hostPage.getByRole('button', { name: /Create Room/i }).first().click()
+  await hostPage
+    .getByRole('button', { name: /Create Room/i })
+    .first()
+    .click()
   // Bump from 10s → 30s: CI-3 flaked repeatedly here on 2026-04-24 /
   // 2026-04-25 because the initial '/' → '/create-room' navigation after a
   // cold Vite start plus Spring Tomcat warmup sometimes exceeds 10 s. The
@@ -145,7 +154,7 @@ export async function setupGame(
     const defaultOptional = ['SEER', 'WITCH', 'HUNTER']
     const requiredRoles = ['WEREWOLF', 'VILLAGER']
     const allOptionalRoles = ['SEER', 'WITCH', 'HUNTER', 'GUARD', 'IDIOT']
-    
+
     // For each optional role, toggle to match desired state. Retry up to
     // 3 times if the click didn't register — on slow CI the first click
     // is occasionally swallowed and the role ends up in the wrong state,
@@ -153,7 +162,9 @@ export async function setupGame(
     // assignment (observed failure: "IDIOT bots not found" across all
     // idiot-flow tests when the IDIOT toggle stayed off).
     for (const role of allOptionalRoles) {
-      const shouldBeEnabled = opts.roles.includes(<"WEREWOLF" | "SEER" | "WITCH" | "GUARD" | "HUNTER" | "IDIOT" | "VILLAGER">role)
+      const shouldBeEnabled = opts.roles.includes(
+        <'WEREWOLF' | 'SEER' | 'WITCH' | 'GUARD' | 'HUNTER' | 'IDIOT' | 'VILLAGER'>role,
+      )
 
       const roleRow = hostPage.locator('.role-row').filter({ hasText: new RegExp(role, 'i') })
 
@@ -161,9 +172,7 @@ export async function setupGame(
         const isEnabled = (await roleRow.locator('.toggle-on').count()) > 0
         if (isEnabled === shouldBeEnabled) break
 
-        const toggle = isEnabled
-          ? roleRow.locator('.toggle-on')
-          : roleRow.locator('.toggle-off')
+        const toggle = isEnabled ? roleRow.locator('.toggle-on') : roleRow.locator('.toggle-off')
         if ((await toggle.count()) === 0) break
 
         await toggle.click()
@@ -262,20 +271,20 @@ export async function setupGame(
   // Check if we're still on the role reveal screen
   const revealWrap = hostPage.locator('.reveal-wrap')
   const revealVisible = await revealWrap.isVisible().catch(() => false)
-  
+
   if (revealVisible) {
     // Still on role reveal screen - need to complete the browser confirm flow
     const revealBtn = hostPage.getByTestId('reveal-role-btn')
     const revealBtnCount = await revealBtn.count()
-    
+
     if (revealBtnCount > 0) {
       const revealBtnVisible = await revealBtn.isVisible().catch(() => false)
-      
+
       if (revealBtnVisible) {
         // Click reveal button
         await revealBtn.click()
         await hostPage.waitForTimeout(300)
-        
+
         // Click confirm button
         const confirmBtn = hostPage.getByTestId('confirm-role-btn')
         try {
@@ -288,7 +297,7 @@ export async function setupGame(
       }
     }
   }
-  
+
   // Additional wait to ensure all STMP events are processed
   await hostPage.waitForTimeout(2_000)
 
@@ -302,8 +311,8 @@ export async function setupGame(
   let roleMap = getRoles(roomCode)
   const expectedRoles = (opts.roles ?? []) as RoleName[]
   for (let attempt = 0; attempt < 8; attempt++) {
-    const haveAllRequested = expectedRoles.length === 0
-      || expectedRoles.every((r) => (roleMap[r]?.length ?? 0) > 0)
+    const haveAllRequested =
+      expectedRoles.length === 0 || expectedRoles.every((r) => (roleMap[r]?.length ?? 0) > 0)
     if (Object.keys(roleMap).length > 0 && haveAllRequested) break
     await hostPage.waitForTimeout(1_000)
     roleMap = getRoles(roomCode)
@@ -324,8 +333,7 @@ export async function setupGame(
 
   // Determine which roles to open browsers for
   const desiredRoles =
-    opts.browserRoles ??
-    (['WEREWOLF', 'SEER', 'WITCH', 'GUARD', 'VILLAGER'] as RoleName[])
+    opts.browserRoles ?? (['WEREWOLF', 'SEER', 'WITCH', 'GUARD', 'VILLAGER'] as RoleName[])
 
   const pages = new Map<string, Page>()
   const botsByRole = new Map<string, BotInfo>()
@@ -397,8 +405,7 @@ export async function setupGame(
     markBackendLogPosition: () => {
       backendLogStartLine = readBackendLogLineCount()
     },
-    assertNoBackendErrors: (testInfo) =>
-      assertNoBackendErrorsSince(backendLogStartLine, testInfo),
+    assertNoBackendErrors: (testInfo) => assertNoBackendErrorsSince(backendLogStartLine, testInfo),
     cleanup: async () => {
       for (const ctx of contexts) {
         try {

--- a/frontend/e2e/real/helpers/state-polling.ts
+++ b/frontend/e2e/real/helpers/state-polling.ts
@@ -114,10 +114,7 @@ export async function waitForVotingSubPhase(
  * when players die, so without this filter every night re-tries the full
  * original role-bot list.
  */
-export async function readAlivePlayerIds(
-  hostPage: Page,
-  gameId: string,
-): Promise<Set<string>> {
+export async function readAlivePlayerIds(hostPage: Page, gameId: string): Promise<Set<string>> {
   const ids = await hostPage.evaluate(async (id: string) => {
     const token = localStorage.getItem('jwt')
     if (!token) return [] as string[]

--- a/frontend/e2e/real/helpers/state-polling.ts
+++ b/frontend/e2e/real/helpers/state-polling.ts
@@ -185,3 +185,116 @@ export async function readUnvotedAlivePlayerIds(
 export async function readHostUserId(hostPage: Page): Promise<string | null> {
   return hostPage.evaluate(() => localStorage.getItem('userId'))
 }
+
+/**
+ * Generic effect-poll helper. Calls `predicate()` every `pollMs` until it
+ * resolves true OR the deadline expires. Throws on timeout with the
+ * supplied `description` so the failure log says what we were waiting on.
+ *
+ * Use this in place of `page.waitForTimeout(N)` whenever the wait is for
+ * a backend-state effect that has no DOM-locator equivalent — e.g.
+ * "until userId X is in votedPlayerIds", "until the action_log row for
+ * SEER_CHECK has been written".
+ *
+ * `timeoutMs` is scaled 2× automatically on CI.
+ */
+export async function waitForCondition(
+  predicate: () => Promise<boolean>,
+  description: string,
+  timeoutMs = 10_000,
+  pollMs = 200,
+): Promise<void> {
+  const deadline = Date.now() + scale(timeoutMs)
+  let lastErr: unknown = undefined
+  while (Date.now() < deadline) {
+    try {
+      if (await predicate()) return
+    } catch (e) {
+      lastErr = e
+    }
+    await new Promise((r) => setTimeout(r, pollMs))
+  }
+  const tail = lastErr ? ` (last predicate error: ${(lastErr as Error).message})` : ''
+  throw new Error(`waitForCondition timed out after ${scale(timeoutMs)}ms: ${description}${tail}`)
+}
+
+/**
+ * Block until userId `userId` has registered a vote in the current voting
+ * round. Used after a single-player vote click to confirm the backend
+ * received it before the next action fires. Fails after `timeoutMs`.
+ */
+export async function waitForVoteRegistered(
+  hostPage: Page,
+  gameId: string,
+  userId: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  await waitForCondition(
+    async () => {
+      const unvoted = await readUnvotedAlivePlayerIds(hostPage, gameId)
+      // userId not in `unvoted` ⇒ they have voted (or are not eligible)
+      return !unvoted.has(userId)
+    },
+    `vote registered for userId=${userId}`,
+    timeoutMs,
+  )
+}
+
+/**
+ * Block until every userId in `expectedVoters` has registered a vote.
+ * Used after a SUBMIT_VOTE fan-out so the test does not race the
+ * voting-reveal step.
+ */
+export async function waitForAllVotesRegistered(
+  hostPage: Page,
+  gameId: string,
+  expectedVoters: string[],
+  timeoutMs = 10_000,
+): Promise<void> {
+  const expected = new Set(expectedVoters)
+  await waitForCondition(
+    async () => {
+      const unvoted = await readUnvotedAlivePlayerIds(hostPage, gameId)
+      for (const id of expected) {
+        if (unvoted.has(id)) return false
+      }
+      return true
+    },
+    `all ${expectedVoters.length} expected voters have voted`,
+    timeoutMs,
+  )
+}
+
+/**
+ * Block until the night sub-phase is anything OTHER than `fromSubPhase`
+ * (or the game has left NIGHT entirely). Use after firing a role-action
+ * to confirm the role-loop coroutine advanced. Returns the new sub-phase
+ * (or `null` if the phase changed).
+ */
+export async function waitForNightSubPhaseChange(
+  hostPage: Page,
+  gameId: string,
+  fromSubPhase: string,
+  timeoutMs = 8_000,
+): Promise<string | null> {
+  let result: string | null = null
+  await waitForCondition(
+    async () => {
+      const state = await fetchGameState(hostPage, gameId)
+      if (!state) return false
+      if (state.phase !== 'NIGHT') {
+        result = null
+        return true
+      }
+      const sp = state.nightPhase?.subPhase ?? ''
+      if (sp && sp !== fromSubPhase) {
+        result = sp
+        return true
+      }
+      return false
+    },
+    `night sub-phase to advance past ${fromSubPhase}`,
+    timeoutMs,
+  )
+  return result
+}

--- a/frontend/playwright.real.config.ts
+++ b/frontend/playwright.real.config.ts
@@ -9,6 +9,20 @@ import {defineConfig} from '@playwright/test'
 export default defineConfig({
   testDir: './e2e/real',
   fullyParallel: false, // tests share one backend instance; avoid parallel state collisions
+  // workers: 1 is REQUIRED — fullyParallel:false alone only serializes
+  // tests WITHIN a spec file. Without workers:1, multiple spec files run
+  // concurrently within a shard. Each spec's setupGame POSTs
+  // /api/user/login {nickname:"Host"} → userId="guest:host". Two
+  // simultaneous requests both pass findById (race window before either
+  // commits), both INSERT, second one fails with H2 unique-constraint
+  // violation → 500. The frontend's handleCreateRoom catches the error,
+  // sets `error.value` ("Request failed with status code 500"), and
+  // does NOT call router.push('/create-room'). The test's
+  // `await waitForURL(/\/create-room/, { timeout: 30_000 })` then sits
+  // for 30 s and times out. Verified by adding INFO logging to
+  // AuthService.loginOrRegister and observing two concurrent calls in
+  // the same millisecond on different exec threads.
+  workers: 1,
   // CI: retry once to absorb timing-sensitive NIGHT→DAY phase-transition flakes
   // that pass locally on fast hardware but occasionally stall on slower GH
   // runners. Local runs keep retries: 0 so flakes aren't hidden.

--- a/frontend/src/__tests__/backendLogSentinel.test.ts
+++ b/frontend/src/__tests__/backendLogSentinel.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the backend-log ERROR-line sentinel.
+ *
+ * Verifies the pure-logic parts: `findBackendErrorLines` (which lines
+ * count as errors, what the allow-list does) and `assertNoBackendErrorsSince`
+ * (the throwing/attachment behavior). Real-backend integration is left to
+ * the Playwright run.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  assertNoBackendErrorsSince,
+  findBackendErrorLines,
+  readBackendLogLineCount,
+  readBackendLogSince,
+} from '../../e2e/real/helpers/backend-log'
+
+const SAMPLE_OK_LINES = [
+  '2026-04-26 10:00:00.001  INFO 12345 --- [    main] o.s.boot.SpringApplication: Started',
+  '2026-04-26 10:00:00.123  INFO 12345 --- [scheduler] c.w.GameService: NIGHT/WEREWOLF_PICK ready',
+  '2026-04-26 10:00:00.456  WARN 12345 --- [   ws-1] c.w.WsHandler: heartbeat slow (200ms)',
+]
+
+const SAMPLE_ERROR = '2026-04-26 10:00:00.789 ERROR 12345 --- [scheduler] c.w.GameService: nightmare'
+const SAMPLE_FATAL = '2026-04-26 10:00:00.999 FATAL 12345 --- [    main] c.w.Boot: kernel panic'
+const SAMPLE_STACK_FRAME = '\tat com.werewolf.GameService.handleAction(GameService.kt:123)'
+const SAMPLE_CAUSED_BY = 'Caused by: java.lang.RuntimeException: nightmare'
+
+type TestInfoMock = { attach: ReturnType<typeof vi.fn> }
+const mkTestInfo = (): TestInfoMock => ({ attach: vi.fn().mockResolvedValue(undefined) })
+
+let tmpDir: string
+let logPath: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'backend-log-test-'))
+  logPath = join(tmpDir, 'werewolf-e2e-backend.log')
+})
+
+afterEach(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true })
+  } catch {
+    /* ignore */
+  }
+})
+
+describe('findBackendErrorLines', () => {
+  it('returns no matches for a clean info/warn-only log', () => {
+    const matches = findBackendErrorLines(SAMPLE_OK_LINES)
+    expect(matches).toEqual([])
+  })
+
+  it('matches an ERROR-level line with the Spring prefix', () => {
+    const lines = [...SAMPLE_OK_LINES, SAMPLE_ERROR]
+    const matches = findBackendErrorLines(lines)
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toBe(SAMPLE_ERROR)
+  })
+
+  it('matches a FATAL-level line', () => {
+    const lines = [...SAMPLE_OK_LINES, SAMPLE_FATAL]
+    expect(findBackendErrorLines(lines)).toHaveLength(1)
+  })
+
+  it('does NOT match stack-frame lines (would inflate the count)', () => {
+    const lines = [SAMPLE_ERROR, SAMPLE_STACK_FRAME, SAMPLE_STACK_FRAME, SAMPLE_CAUSED_BY]
+    const matches = findBackendErrorLines(lines)
+    // Only the level-prefixed line counts as an event.
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toBe(SAMPLE_ERROR)
+  })
+
+  it('respects the allowPatterns filter', () => {
+    const allowed =
+      '2026-04-26 10:00:01.000 ERROR 12345 --- [scheduler] c.w.NoiseSource: known-flake xyz'
+    const real =
+      '2026-04-26 10:00:02.000 ERROR 12345 --- [scheduler] c.w.GameService: real bug'
+    const matches = findBackendErrorLines([allowed, real], [/known-flake/])
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toBe(real)
+  })
+})
+
+describe('readBackendLogLineCount + readBackendLogSince', () => {
+  it('returns 0 when the file does not exist', () => {
+    expect(readBackendLogLineCount(logPath)).toBe(0)
+    expect(readBackendLogSince(0, logPath)).toEqual([])
+  })
+
+  it('reads the line count of an existing log', () => {
+    writeFileSync(logPath, [...SAMPLE_OK_LINES, ''].join('\n'))
+    // Note: trailing newline → split('\n') yields an extra empty string.
+    expect(readBackendLogLineCount(logPath)).toBe(SAMPLE_OK_LINES.length + 1)
+  })
+
+  it('returns only lines added since startLine', () => {
+    writeFileSync(logPath, SAMPLE_OK_LINES.join('\n'))
+    const before = readBackendLogLineCount(logPath)
+    writeFileSync(
+      logPath,
+      [...SAMPLE_OK_LINES, SAMPLE_ERROR, SAMPLE_STACK_FRAME].join('\n'),
+    )
+    const tail = readBackendLogSince(before, logPath)
+    expect(tail).toContain(SAMPLE_ERROR)
+    // SAMPLE_OK_LINES already existed before, so they should NOT appear
+    expect(tail).not.toContain(SAMPLE_OK_LINES[0])
+  })
+})
+
+describe('assertNoBackendErrorsSince', () => {
+  it('passes silently on a clean window', async () => {
+    writeFileSync(logPath, SAMPLE_OK_LINES.join('\n'))
+    const info = mkTestInfo()
+    await expect(
+      assertNoBackendErrorsSince(0, info as never, { logPath }),
+    ).resolves.toBeUndefined()
+    expect(info.attach).not.toHaveBeenCalled()
+  })
+
+  it('throws and attaches when an ERROR appears in the window', async () => {
+    writeFileSync(
+      logPath,
+      [...SAMPLE_OK_LINES, SAMPLE_ERROR, SAMPLE_STACK_FRAME].join('\n'),
+    )
+    const info = mkTestInfo()
+    await expect(
+      assertNoBackendErrorsSince(0, info as never, { logPath }),
+    ).rejects.toThrow(/ERROR\/FATAL/)
+    expect(info.attach).toHaveBeenCalledTimes(1)
+    const body = String(info.attach.mock.calls[0][1].body)
+    expect(body).toContain('nightmare')
+    // Stack frame block is included as context
+    expect(body).toContain('GameService.kt:123')
+  })
+
+  it('starts from the snapshot point — pre-existing errors do not fail the test', async () => {
+    // First, the log already has an old error from a previous test.
+    writeFileSync(logPath, [SAMPLE_ERROR, SAMPLE_STACK_FRAME].join('\n'))
+    const startLine = readBackendLogLineCount(logPath)
+    // Then the current test logs only OK lines.
+    writeFileSync(
+      logPath,
+      [SAMPLE_ERROR, SAMPLE_STACK_FRAME, ...SAMPLE_OK_LINES].join('\n'),
+    )
+    const info = mkTestInfo()
+    await expect(
+      assertNoBackendErrorsSince(startLine, info as never, { logPath }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('detects a NEW error after the snapshot even if older errors exist', async () => {
+    writeFileSync(logPath, [SAMPLE_ERROR].join('\n'))
+    const startLine = readBackendLogLineCount(logPath)
+    writeFileSync(
+      logPath,
+      [SAMPLE_ERROR, SAMPLE_FATAL, SAMPLE_STACK_FRAME].join('\n'),
+    )
+    const info = mkTestInfo()
+    await expect(
+      assertNoBackendErrorsSince(startLine, info as never, { logPath }),
+    ).rejects.toThrow()
+  })
+})

--- a/frontend/src/__tests__/backendLogSentinel.test.ts
+++ b/frontend/src/__tests__/backendLogSentinel.test.ts
@@ -122,7 +122,7 @@ describe('assertNoBackendErrorsSince', () => {
       /ERROR\/FATAL/,
     )
     expect(info.attach).toHaveBeenCalledTimes(1)
-    const body = String(info.attach.mock.calls[0][1].body)
+    const body = String(info.attach.mock.calls[0]?.[1]?.body)
     expect(body).toContain('nightmare')
     // Stack frame block is included as context
     expect(body).toContain('GameService.kt:123')

--- a/frontend/src/__tests__/backendLogSentinel.test.ts
+++ b/frontend/src/__tests__/backendLogSentinel.test.ts
@@ -23,7 +23,8 @@ const SAMPLE_OK_LINES = [
   '2026-04-26 10:00:00.456  WARN 12345 --- [   ws-1] c.w.WsHandler: heartbeat slow (200ms)',
 ]
 
-const SAMPLE_ERROR = '2026-04-26 10:00:00.789 ERROR 12345 --- [scheduler] c.w.GameService: nightmare'
+const SAMPLE_ERROR =
+  '2026-04-26 10:00:00.789 ERROR 12345 --- [scheduler] c.w.GameService: nightmare'
 const SAMPLE_FATAL = '2026-04-26 10:00:00.999 FATAL 12345 --- [    main] c.w.Boot: kernel panic'
 const SAMPLE_STACK_FRAME = '\tat com.werewolf.GameService.handleAction(GameService.kt:123)'
 const SAMPLE_CAUSED_BY = 'Caused by: java.lang.RuntimeException: nightmare'
@@ -76,8 +77,7 @@ describe('findBackendErrorLines', () => {
   it('respects the allowPatterns filter', () => {
     const allowed =
       '2026-04-26 10:00:01.000 ERROR 12345 --- [scheduler] c.w.NoiseSource: known-flake xyz'
-    const real =
-      '2026-04-26 10:00:02.000 ERROR 12345 --- [scheduler] c.w.GameService: real bug'
+    const real = '2026-04-26 10:00:02.000 ERROR 12345 --- [scheduler] c.w.GameService: real bug'
     const matches = findBackendErrorLines([allowed, real], [/known-flake/])
     expect(matches).toHaveLength(1)
     expect(matches[0]).toBe(real)
@@ -99,10 +99,7 @@ describe('readBackendLogLineCount + readBackendLogSince', () => {
   it('returns only lines added since startLine', () => {
     writeFileSync(logPath, SAMPLE_OK_LINES.join('\n'))
     const before = readBackendLogLineCount(logPath)
-    writeFileSync(
-      logPath,
-      [...SAMPLE_OK_LINES, SAMPLE_ERROR, SAMPLE_STACK_FRAME].join('\n'),
-    )
+    writeFileSync(logPath, [...SAMPLE_OK_LINES, SAMPLE_ERROR, SAMPLE_STACK_FRAME].join('\n'))
     const tail = readBackendLogSince(before, logPath)
     expect(tail).toContain(SAMPLE_ERROR)
     // SAMPLE_OK_LINES already existed before, so they should NOT appear
@@ -114,21 +111,16 @@ describe('assertNoBackendErrorsSince', () => {
   it('passes silently on a clean window', async () => {
     writeFileSync(logPath, SAMPLE_OK_LINES.join('\n'))
     const info = mkTestInfo()
-    await expect(
-      assertNoBackendErrorsSince(0, info as never, { logPath }),
-    ).resolves.toBeUndefined()
+    await expect(assertNoBackendErrorsSince(0, info as never, { logPath })).resolves.toBeUndefined()
     expect(info.attach).not.toHaveBeenCalled()
   })
 
   it('throws and attaches when an ERROR appears in the window', async () => {
-    writeFileSync(
-      logPath,
-      [...SAMPLE_OK_LINES, SAMPLE_ERROR, SAMPLE_STACK_FRAME].join('\n'),
-    )
+    writeFileSync(logPath, [...SAMPLE_OK_LINES, SAMPLE_ERROR, SAMPLE_STACK_FRAME].join('\n'))
     const info = mkTestInfo()
-    await expect(
-      assertNoBackendErrorsSince(0, info as never, { logPath }),
-    ).rejects.toThrow(/ERROR\/FATAL/)
+    await expect(assertNoBackendErrorsSince(0, info as never, { logPath })).rejects.toThrow(
+      /ERROR\/FATAL/,
+    )
     expect(info.attach).toHaveBeenCalledTimes(1)
     const body = String(info.attach.mock.calls[0][1].body)
     expect(body).toContain('nightmare')
@@ -141,10 +133,7 @@ describe('assertNoBackendErrorsSince', () => {
     writeFileSync(logPath, [SAMPLE_ERROR, SAMPLE_STACK_FRAME].join('\n'))
     const startLine = readBackendLogLineCount(logPath)
     // Then the current test logs only OK lines.
-    writeFileSync(
-      logPath,
-      [SAMPLE_ERROR, SAMPLE_STACK_FRAME, ...SAMPLE_OK_LINES].join('\n'),
-    )
+    writeFileSync(logPath, [SAMPLE_ERROR, SAMPLE_STACK_FRAME, ...SAMPLE_OK_LINES].join('\n'))
     const info = mkTestInfo()
     await expect(
       assertNoBackendErrorsSince(startLine, info as never, { logPath }),
@@ -154,10 +143,7 @@ describe('assertNoBackendErrorsSince', () => {
   it('detects a NEW error after the snapshot even if older errors exist', async () => {
     writeFileSync(logPath, [SAMPLE_ERROR].join('\n'))
     const startLine = readBackendLogLineCount(logPath)
-    writeFileSync(
-      logPath,
-      [SAMPLE_ERROR, SAMPLE_FATAL, SAMPLE_STACK_FRAME].join('\n'),
-    )
+    writeFileSync(logPath, [SAMPLE_ERROR, SAMPLE_FATAL, SAMPLE_STACK_FRAME].join('\n'))
     const info = mkTestInfo()
     await expect(
       assertNoBackendErrorsSince(startLine, info as never, { logPath }),

--- a/frontend/src/__tests__/dayPhase.test.ts
+++ b/frontend/src/__tests__/dayPhase.test.ts
@@ -53,3 +53,68 @@ describe('DayPhase — game log button visibility', () => {
     expect(wrapper.find('.log-fab').exists()).toBe(true)
   })
 })
+
+describe('DayPhase — observability testids (action-observability sentinel)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  const peacefulDay: DayPhaseState = {
+    subPhase: 'RESULT_REVEALED',
+    dayNumber: 2,
+    phaseDeadline: Date.now() + 60000,
+    phaseStarted: Date.now() - 5000,
+    canVote: true,
+    nightResult: { killedPlayers: [] },
+  }
+
+  it('peaceful night surfaces day-banner-peaceful testid', () => {
+    const wrapper = mount(DayPhase, {
+      props: { ...BASE_PROPS, dayPhase: peacefulDay },
+    })
+    expect(wrapper.find('[data-testid="day-banner-peaceful"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="day-banner-kill"]').exists()).toBe(false)
+  })
+
+  it('kill night surfaces day-banner-kill testid + per-seat testids', () => {
+    const dayWithKill: DayPhaseState = {
+      ...peacefulDay,
+      nightResult: {
+        killedPlayers: [
+          { killedPlayerId: 'u-killed', killedSeatIndex: 5, killedNickname: 'Eve' },
+        ],
+      },
+    }
+    const wrapper = mount(DayPhase, {
+      props: { ...BASE_PROPS, dayPhase: dayWithKill },
+    })
+    expect(wrapper.find('[data-testid="day-banner-kill"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="day-banner-peaceful"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="day-killed-seat-5"]').exists()).toBe(true)
+  })
+
+  it('multiple kills each get their own per-seat testid', () => {
+    const dayWithKills: DayPhaseState = {
+      ...peacefulDay,
+      nightResult: {
+        killedPlayers: [
+          { killedPlayerId: 'a', killedSeatIndex: 3, killedNickname: 'Ann' },
+          { killedPlayerId: 'b', killedSeatIndex: 7, killedNickname: 'Bea' },
+        ],
+      },
+    }
+    const wrapper = mount(DayPhase, {
+      props: { ...BASE_PROPS, dayPhase: dayWithKills },
+    })
+    expect(wrapper.find('[data-testid="day-killed-seat-3"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="day-killed-seat-7"]').exists()).toBe(true)
+  })
+
+  it('RESULT_HIDDEN renders neither banner (so result is not leaked)', () => {
+    const wrapper = mount(DayPhase, {
+      props: { ...BASE_PROPS, dayPhase: makeDay('RESULT_HIDDEN') },
+    })
+    expect(wrapper.find('[data-testid="day-banner-peaceful"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="day-banner-kill"]').exists()).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/dayPhase.test.ts
+++ b/frontend/src/__tests__/dayPhase.test.ts
@@ -80,9 +80,7 @@ describe('DayPhase — observability testids (action-observability sentinel)', (
     const dayWithKill: DayPhaseState = {
       ...peacefulDay,
       nightResult: {
-        killedPlayers: [
-          { killedPlayerId: 'u-killed', killedSeatIndex: 5, killedNickname: 'Eve' },
-        ],
+        killedPlayers: [{ killedPlayerId: 'u-killed', killedSeatIndex: 5, killedNickname: 'Eve' }],
       },
     }
     const wrapper = mount(DayPhase, {

--- a/frontend/src/__tests__/errorSentinel.test.ts
+++ b/frontend/src/__tests__/errorSentinel.test.ts
@@ -31,18 +31,16 @@ describe('error-sentinel', () => {
   it('passes silently when the buffer is empty', async () => {
     const errors: BrowserError[] = []
     const info = mkTestInfo()
-    await expect(
-      assertNoBrowserErrors(errors, info as never),
-    ).resolves.toBeUndefined()
+    await expect(assertNoBrowserErrors(errors, info as never)).resolves.toBeUndefined()
     expect(info.attach).not.toHaveBeenCalled()
   })
 
   it('throws and attaches when any pageerror is recorded', async () => {
     const errors: BrowserError[] = [mkErr({ message: 'TypeError: x is undefined' })]
     const info = mkTestInfo()
-    await expect(
-      assertNoBrowserErrors(errors, info as never),
-    ).rejects.toThrow(/TypeError: x is undefined/)
+    await expect(assertNoBrowserErrors(errors, info as never)).rejects.toThrow(
+      /TypeError: x is undefined/,
+    )
     expect(info.attach).toHaveBeenCalledTimes(1)
     const attachArg = info.attach.mock.calls[0][1]
     expect(String(attachArg.body)).toContain('pageerror')
@@ -59,9 +57,7 @@ describe('error-sentinel', () => {
       }),
     ]
     const info = mkTestInfo()
-    await expect(
-      assertNoBrowserErrors(errors, info as never),
-    ).rejects.toThrow(/503/)
+    await expect(assertNoBrowserErrors(errors, info as never)).rejects.toThrow(/503/)
     expect(info.attach).toHaveBeenCalledTimes(1)
   })
 
@@ -110,9 +106,7 @@ describe('error-sentinel', () => {
       mkErr({ role: 'SEER', message: 'second' }),
     ]
     const info = mkTestInfo()
-    await expect(
-      assertNoBrowserErrors(errors, info as never),
-    ).rejects.toThrow()
+    await expect(assertNoBrowserErrors(errors, info as never)).rejects.toThrow()
     const body = String(info.attach.mock.calls[0][1].body)
     expect(body).toContain('[WEREWOLF]')
     expect(body).toContain('first')

--- a/frontend/src/__tests__/errorSentinel.test.ts
+++ b/frontend/src/__tests__/errorSentinel.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the E2E browser-error sentinel.
+ *
+ * The sentinel is exercised by real-backend Playwright runs at integration
+ * time, but its logic (filtering, formatting, the assertNoBrowserErrors
+ * decision) is pure and easy to verify here so we can iterate on it
+ * without spinning up the backend.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import {
+  assertNoBrowserErrors,
+  resetBrowserErrors,
+  type BrowserError,
+} from '../../e2e/real/helpers/error-sentinel'
+
+type TestInfoMock = {
+  attach: ReturnType<typeof vi.fn>
+}
+
+const mkErr = (over: Partial<BrowserError> = {}): BrowserError => ({
+  role: 'HOST',
+  type: 'pageerror',
+  message: 'boom',
+  capturedAt: '2026-04-26T00:00:00Z',
+  ...over,
+})
+
+const mkTestInfo = (): TestInfoMock => ({ attach: vi.fn().mockResolvedValue(undefined) })
+
+describe('error-sentinel', () => {
+  it('passes silently when the buffer is empty', async () => {
+    const errors: BrowserError[] = []
+    const info = mkTestInfo()
+    await expect(
+      assertNoBrowserErrors(errors, info as never),
+    ).resolves.toBeUndefined()
+    expect(info.attach).not.toHaveBeenCalled()
+  })
+
+  it('throws and attaches when any pageerror is recorded', async () => {
+    const errors: BrowserError[] = [mkErr({ message: 'TypeError: x is undefined' })]
+    const info = mkTestInfo()
+    await expect(
+      assertNoBrowserErrors(errors, info as never),
+    ).rejects.toThrow(/TypeError: x is undefined/)
+    expect(info.attach).toHaveBeenCalledTimes(1)
+    const attachArg = info.attach.mock.calls[0][1]
+    expect(String(attachArg.body)).toContain('pageerror')
+    expect(String(attachArg.body)).toContain('TypeError: x is undefined')
+  })
+
+  it('throws on a 5xx response', async () => {
+    const errors: BrowserError[] = [
+      mkErr({
+        type: 'response-5xx',
+        url: 'http://localhost:5174/api/game/123/state',
+        status: 503,
+        message: 'GET http://localhost:5174/api/game/123/state → 503',
+      }),
+    ]
+    const info = mkTestInfo()
+    await expect(
+      assertNoBrowserErrors(errors, info as never),
+    ).rejects.toThrow(/503/)
+    expect(info.attach).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects the urlIncludes allow-list', async () => {
+    const errors: BrowserError[] = [
+      mkErr({
+        type: 'response-5xx',
+        url: 'http://localhost:5174/api/admin/test-only',
+        status: 500,
+        message: 'allowed',
+      }),
+    ]
+    const info = mkTestInfo()
+    await expect(
+      assertNoBrowserErrors(errors, info as never, { urlIncludes: ['/api/admin/'] }),
+    ).resolves.toBeUndefined()
+    expect(info.attach).not.toHaveBeenCalled()
+  })
+
+  it('respects the messageIncludes allow-list', async () => {
+    const errors: BrowserError[] = [mkErr({ message: 'expected: known-flake' })]
+    const info = mkTestInfo()
+    await expect(
+      assertNoBrowserErrors(errors, info as never, {
+        messageIncludes: ['known-flake'],
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('only filters specifically-allowed errors and still throws on others', async () => {
+    const errors: BrowserError[] = [
+      mkErr({ message: 'expected: known-flake' }),
+      mkErr({ message: 'real bug' }),
+    ]
+    const info = mkTestInfo()
+    await expect(
+      assertNoBrowserErrors(errors, info as never, {
+        messageIncludes: ['known-flake'],
+      }),
+    ).rejects.toThrow(/real bug/)
+  })
+
+  it('summary lists every error not just the first', async () => {
+    const errors: BrowserError[] = [
+      mkErr({ role: 'WEREWOLF', message: 'first' }),
+      mkErr({ role: 'SEER', message: 'second' }),
+    ]
+    const info = mkTestInfo()
+    await expect(
+      assertNoBrowserErrors(errors, info as never),
+    ).rejects.toThrow()
+    const body = String(info.attach.mock.calls[0][1].body)
+    expect(body).toContain('[WEREWOLF]')
+    expect(body).toContain('first')
+    expect(body).toContain('[SEER]')
+    expect(body).toContain('second')
+  })
+
+  it('resetBrowserErrors clears the buffer in place', () => {
+    const errors: BrowserError[] = [mkErr(), mkErr()]
+    const same = errors
+    resetBrowserErrors(errors)
+    expect(errors.length).toBe(0)
+    expect(same).toBe(errors) // mutated in place, not replaced
+  })
+})

--- a/frontend/src/__tests__/errorSentinel.test.ts
+++ b/frontend/src/__tests__/errorSentinel.test.ts
@@ -42,9 +42,9 @@ describe('error-sentinel', () => {
       /TypeError: x is undefined/,
     )
     expect(info.attach).toHaveBeenCalledTimes(1)
-    const attachArg = info.attach.mock.calls[0][1]
-    expect(String(attachArg.body)).toContain('pageerror')
-    expect(String(attachArg.body)).toContain('TypeError: x is undefined')
+    const attachArg = info.attach.mock.calls[0]?.[1]
+    expect(String(attachArg?.body)).toContain('pageerror')
+    expect(String(attachArg?.body)).toContain('TypeError: x is undefined')
   })
 
   it('throws on a 5xx response', async () => {
@@ -107,7 +107,7 @@ describe('error-sentinel', () => {
     ]
     const info = mkTestInfo()
     await expect(assertNoBrowserErrors(errors, info as never)).rejects.toThrow()
-    const body = String(info.attach.mock.calls[0][1].body)
+    const body = String(info.attach.mock.calls[0]?.[1]?.body)
     expect(body).toContain('[WEREWOLF]')
     expect(body).toContain('first')
     expect(body).toContain('[SEER]')

--- a/frontend/src/__tests__/invariants.test.ts
+++ b/frontend/src/__tests__/invariants.test.ts
@@ -27,12 +27,8 @@ describe('computePhaseRank', () => {
   it('orders within a single round', () => {
     expect(computePhaseRank('ROLE_REVEAL', 1)).toBeLessThan(computePhaseRank('NIGHT', 1))
     expect(computePhaseRank('NIGHT', 1)).toBeLessThan(computePhaseRank('DAY_PENDING', 1))
-    expect(computePhaseRank('DAY_PENDING', 1)).toBeLessThan(
-      computePhaseRank('DAY_DISCUSSION', 1),
-    )
-    expect(computePhaseRank('DAY_DISCUSSION', 1)).toBeLessThan(
-      computePhaseRank('DAY_VOTING', 1),
-    )
+    expect(computePhaseRank('DAY_PENDING', 1)).toBeLessThan(computePhaseRank('DAY_DISCUSSION', 1))
+    expect(computePhaseRank('DAY_DISCUSSION', 1)).toBeLessThan(computePhaseRank('DAY_VOTING', 1))
   })
 
   it('day 2 NIGHT > day 1 DAY_VOTING', () => {
@@ -60,7 +56,11 @@ describe('assertGameInvariantsOnState — happy path', () => {
     let s = newInvariantState()
     s = assertGameInvariantsOnState(baseState(), s, 'night')
     s = assertGameInvariantsOnState(
-      baseState({ phase: 'DAY_PENDING', nightPhase: null, dayPhase: { subPhase: 'RESULT_HIDDEN', dayNumber: 1 } }),
+      baseState({
+        phase: 'DAY_PENDING',
+        nightPhase: null,
+        dayPhase: { subPhase: 'RESULT_HIDDEN', dayNumber: 1 },
+      }),
       s,
       'pending',
     )

--- a/frontend/src/__tests__/invariants.test.ts
+++ b/frontend/src/__tests__/invariants.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for the pure invariant logic. Drives
+ * assertGameInvariantsOnState with hand-rolled MinimalGameState objects
+ * and confirms each rule fires (or holds silent) as designed.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  assertGameInvariantsOnState,
+  computePhaseRank,
+  newInvariantState,
+  type GameInvariantState,
+  type MinimalGameState,
+} from '../../e2e/real/helpers/invariants'
+
+const baseState = (over: Partial<MinimalGameState> = {}): MinimalGameState => ({
+  phase: 'NIGHT',
+  nightPhase: { subPhase: 'WEREWOLF_PICK', dayNumber: 1 },
+  players: [
+    { userId: 'u1', isAlive: true, seatIndex: 1, nickname: 'Alice' },
+    { userId: 'u2', isAlive: true, seatIndex: 2, nickname: 'Bob' },
+    { userId: 'u3', isAlive: true, seatIndex: 3, nickname: 'Cara' },
+  ],
+  ...over,
+})
+
+describe('computePhaseRank', () => {
+  it('orders within a single round', () => {
+    expect(computePhaseRank('ROLE_REVEAL', 1)).toBeLessThan(computePhaseRank('NIGHT', 1))
+    expect(computePhaseRank('NIGHT', 1)).toBeLessThan(computePhaseRank('DAY_PENDING', 1))
+    expect(computePhaseRank('DAY_PENDING', 1)).toBeLessThan(
+      computePhaseRank('DAY_DISCUSSION', 1),
+    )
+    expect(computePhaseRank('DAY_DISCUSSION', 1)).toBeLessThan(
+      computePhaseRank('DAY_VOTING', 1),
+    )
+  })
+
+  it('day 2 NIGHT > day 1 DAY_VOTING', () => {
+    expect(computePhaseRank('NIGHT', 2)).toBeGreaterThan(computePhaseRank('DAY_VOTING', 1))
+  })
+
+  it('throws on unknown phase', () => {
+    expect(() => computePhaseRank('FOO_BAR', 1)).toThrow(/unknown phase/)
+  })
+
+  it('GAME_OVER is terminal regardless of dayNumber', () => {
+    expect(computePhaseRank('GAME_OVER', 1)).toBe(computePhaseRank('GAME_OVER', 99))
+  })
+})
+
+describe('assertGameInvariantsOnState — happy path', () => {
+  it('first call accepts any reasonable state', () => {
+    const next = assertGameInvariantsOnState(baseState(), newInvariantState(), 'first')
+    expect(next.lastPhase).toBe('NIGHT')
+    expect(next.lastDayNumber).toBe(1)
+    expect(next.lastAliveCount).toBe(3)
+  })
+
+  it('forward NIGHT → DAY_PENDING is allowed', () => {
+    let s = newInvariantState()
+    s = assertGameInvariantsOnState(baseState(), s, 'night')
+    s = assertGameInvariantsOnState(
+      baseState({ phase: 'DAY_PENDING', nightPhase: null, dayPhase: { subPhase: 'RESULT_HIDDEN', dayNumber: 1 } }),
+      s,
+      'pending',
+    )
+    expect(s.lastPhase).toBe('DAY_PENDING')
+  })
+
+  it('cross-day forward is allowed (day 1 DAY_VOTING → day 2 NIGHT)', () => {
+    let s = newInvariantState()
+    s = assertGameInvariantsOnState(
+      baseState({
+        phase: 'DAY_VOTING',
+        nightPhase: null,
+        votingPhase: { subPhase: 'VOTING' },
+        dayPhase: { dayNumber: 1 },
+      }),
+      s,
+      'day1-vote',
+    )
+    s = assertGameInvariantsOnState(
+      baseState({
+        phase: 'NIGHT',
+        nightPhase: { subPhase: 'WEREWOLF_PICK', dayNumber: 2 },
+      }),
+      s,
+      'day2-night',
+    )
+    expect(s.lastDayNumber).toBe(2)
+  })
+
+  it('alive count decreasing from 3 to 2 is allowed', () => {
+    let s = newInvariantState()
+    s = assertGameInvariantsOnState(baseState(), s, 'before')
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({
+          players: [
+            { userId: 'u1', isAlive: true, seatIndex: 1 },
+            { userId: 'u2', isAlive: false, seatIndex: 2 },
+            { userId: 'u3', isAlive: true, seatIndex: 3 },
+          ],
+        }),
+        s,
+        'after-night',
+      ),
+    ).not.toThrow()
+  })
+})
+
+describe('assertGameInvariantsOnState — violations', () => {
+  it('phase regression throws (DAY_VOTING day1 → NIGHT day1)', () => {
+    let s = newInvariantState()
+    s = assertGameInvariantsOnState(
+      baseState({ phase: 'DAY_VOTING', nightPhase: null, dayPhase: { dayNumber: 1 } }),
+      s,
+      'voted',
+    )
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({ phase: 'NIGHT', nightPhase: { subPhase: 'WEREWOLF_PICK', dayNumber: 1 } }),
+        s,
+        'regress',
+      ),
+    ).toThrow(/regressed/)
+  })
+
+  it('alive count growing throws', () => {
+    let s = newInvariantState()
+    s = assertGameInvariantsOnState(
+      baseState({
+        players: [
+          { userId: 'u1', isAlive: true, seatIndex: 1 },
+          { userId: 'u2', isAlive: false, seatIndex: 2 },
+        ],
+      }),
+      s,
+      'two-alive',
+    )
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({
+          players: [
+            { userId: 'u1', isAlive: true, seatIndex: 1 },
+            { userId: 'u2', isAlive: true, seatIndex: 2 },
+          ],
+        }),
+        s,
+        'resurrected',
+      ),
+    ).toThrow(/grew/)
+  })
+
+  it('unknown nightSubPhase throws', () => {
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({ nightPhase: { subPhase: 'NONSENSE_PICK', dayNumber: 1 } }),
+        newInvariantState(),
+        'bad-sub',
+      ),
+    ).toThrow(/unrecognized nightSubPhase/)
+  })
+
+  it('unknown votingSubPhase throws when phase=DAY_VOTING', () => {
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({
+          phase: 'DAY_VOTING',
+          nightPhase: null,
+          votingPhase: { subPhase: 'NOT_A_REAL_SUB' },
+        }),
+        newInvariantState(),
+        'bad-voting-sub',
+      ),
+    ).toThrow(/unrecognized votingSubPhase/)
+  })
+
+  it('dead sheriff during DAY_DISCUSSION throws', () => {
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({
+          phase: 'DAY_DISCUSSION',
+          nightPhase: null,
+          dayPhase: { dayNumber: 1 },
+          players: [
+            { userId: 'u1', isAlive: false, isSheriff: true, seatIndex: 1, nickname: 'Sheriff' },
+            { userId: 'u2', isAlive: true, seatIndex: 2 },
+          ],
+        }),
+        newInvariantState(),
+        'dead-sheriff',
+      ),
+    ).toThrow(/sheriff.*is dead/)
+  })
+
+  it('dead sheriff during BADGE_HANDOVER does NOT throw (badge transferring)', () => {
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({
+          phase: 'DAY_VOTING',
+          nightPhase: null,
+          votingPhase: { subPhase: 'BADGE_HANDOVER' },
+          dayPhase: { dayNumber: 2 },
+          players: [
+            { userId: 'u1', isAlive: false, isSheriff: true, seatIndex: 1, nickname: 'Sheriff' },
+            { userId: 'u2', isAlive: true, seatIndex: 2 },
+          ],
+        }),
+        newInvariantState(),
+        'badge-handover',
+      ),
+    ).not.toThrow()
+  })
+
+  it('dead sheriff during GAME_OVER does NOT throw', () => {
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({
+          phase: 'GAME_OVER',
+          nightPhase: null,
+          players: [
+            { userId: 'u1', isAlive: false, isSheriff: true, seatIndex: 1 },
+            { userId: 'u2', isAlive: true, seatIndex: 2 },
+          ],
+        }),
+        newInvariantState(),
+        'game-over',
+      ),
+    ).not.toThrow()
+  })
+
+  it('unknown top-level phase throws', () => {
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({ phase: 'WEIRD_PHASE' }),
+        newInvariantState(),
+        'unknown',
+      ),
+    ).toThrow(/unknown phase/)
+  })
+})
+
+describe('assertGameInvariantsOnState — context label appears in errors', () => {
+  it('error message includes the label so failing step is identifiable', () => {
+    expect(() =>
+      assertGameInvariantsOnState(
+        baseState({ phase: 'WEIRD' }),
+        newInvariantState(),
+        'step-3-vote',
+      ),
+    ).toThrow(/step-3-vote/)
+  })
+})

--- a/frontend/src/__tests__/invariants.test.ts
+++ b/frontend/src/__tests__/invariants.test.ts
@@ -8,7 +8,6 @@ import {
   assertGameInvariantsOnState,
   computePhaseRank,
   newInvariantState,
-  type GameInvariantState,
   type MinimalGameState,
 } from '../../e2e/real/helpers/invariants'
 

--- a/frontend/src/__tests__/phaseDataAttributes.test.ts
+++ b/frontend/src/__tests__/phaseDataAttributes.test.ts
@@ -83,10 +83,7 @@ describe('GameView template binds data-phase / data-phase-sub / data-day-number'
   // assert the static template includes the bindings — a regex over the
   // file content is enough to catch "binding was renamed/removed and
   // verifyAllBrowsersPhase silently switched to its CSS-class fallback".
-  const template = readFileSync(
-    join(__dirname, '..', 'views', 'GameView.vue'),
-    'utf-8',
-  )
+  const template = readFileSync(join(__dirname, '..', 'views', 'GameView.vue'), 'utf-8')
 
   it('binds :data-phase from gameStore.state?.phase', () => {
     expect(template).toMatch(/:data-phase="\s*gameStore\.state\?\.phase\s*\?\?/)

--- a/frontend/src/__tests__/phaseDataAttributes.test.ts
+++ b/frontend/src/__tests__/phaseDataAttributes.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Verifies the GameView data-phase / data-phase-sub / data-day-number
+ * binding wired in for sentinel #1 (cross-browser DOM phase attributes).
+ *
+ * Two slices are tested:
+ *
+ *   1. The PHASE_DATA_VALUES mapping in assertions.ts — every spec label
+ *      ('NIGHT', 'DAY', 'VOTING', etc.) maps to a non-empty list of
+ *      authoritative `data-phase` values, and the lists do not silently
+ *      overlap (which would make verifyAllBrowsersPhase ambiguous).
+ *
+ *   2. The Kotlin GamePhase enum is fully covered. Without this check, a
+ *      backend phase added later (e.g. a new transition) would silently
+ *      break the spec — the test fails the moment the enum drifts so we
+ *      remember to update PHASE_DATA_VALUES at the same time.
+ *
+ * The component-level wiring (GameView.vue's :data-phase binding) is
+ * exercised by the real-backend Playwright run, where assertNoBrowserErrors
+ * + verifyAllBrowsersPhase together fail loudly on missing attributes.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PHASE_DATA_VALUES } from '../../e2e/real/helpers/assertions'
+
+// Scraped from backend/src/main/kotlin/com/werewolf/model/Enums.kt at the
+// time of writing this test. If the enum changes, this list must change
+// or the "every backend phase is covered" test will fail — which is the
+// point.
+const BACKEND_GAME_PHASES = [
+  'ROLE_REVEAL',
+  'SHERIFF_ELECTION',
+  'WAITING',
+  'NIGHT',
+  'DAY_PENDING',
+  'DAY_DISCUSSION',
+  'DAY_VOTING',
+  'GAME_OVER',
+] as const
+
+describe('PHASE_DATA_VALUES contract', () => {
+  it('every label maps to at least one backend phase', () => {
+    for (const [label, values] of Object.entries(PHASE_DATA_VALUES)) {
+      expect(values.length, `label ${label} has empty mapping`).toBeGreaterThan(0)
+    }
+  })
+
+  it('every mapped value is a real backend phase', () => {
+    const known = new Set<string>(BACKEND_GAME_PHASES)
+    for (const [label, values] of Object.entries(PHASE_DATA_VALUES)) {
+      for (const v of values) {
+        expect(known.has(v), `label=${label} value=${v} not in BACKEND_GAME_PHASES`).toBe(true)
+      }
+    }
+  })
+
+  it('every backend phase has at least one label that maps to it', () => {
+    const covered = new Set<string>()
+    for (const values of Object.values(PHASE_DATA_VALUES)) {
+      for (const v of values) covered.add(v)
+    }
+    for (const phase of BACKEND_GAME_PHASES) {
+      expect(covered.has(phase), `backend phase ${phase} has no label`).toBe(true)
+    }
+  })
+
+  it('label-to-value mapping is unambiguous (no value belongs to two labels)', () => {
+    const valueToLabel = new Map<string, string>()
+    for (const [label, values] of Object.entries(PHASE_DATA_VALUES)) {
+      for (const v of values) {
+        const prior = valueToLabel.get(v)
+        if (prior) {
+          throw new Error(`backend phase ${v} mapped by both '${prior}' and '${label}'`)
+        }
+        valueToLabel.set(v, label)
+      }
+    }
+  })
+})
+
+describe('GameView template binds data-phase / data-phase-sub / data-day-number', () => {
+  // We do not mount GameView here (heavy dependency tree). Instead we
+  // assert the static template includes the bindings — a regex over the
+  // file content is enough to catch "binding was renamed/removed and
+  // verifyAllBrowsersPhase silently switched to its CSS-class fallback".
+  const template = readFileSync(
+    join(__dirname, '..', 'views', 'GameView.vue'),
+    'utf-8',
+  )
+
+  it('binds :data-phase from gameStore.state?.phase', () => {
+    expect(template).toMatch(/:data-phase="\s*gameStore\.state\?\.phase\s*\?\?/)
+  })
+
+  it('binds :data-phase-sub from at least one of nightPhase/votingPhase/dayPhase/sheriffElection', () => {
+    expect(template).toMatch(/:data-phase-sub=/)
+    expect(template).toMatch(/nightPhase\?\.subPhase/)
+    expect(template).toMatch(/votingPhase\?\.subPhase/)
+    expect(template).toMatch(/dayPhase\?\.subPhase/)
+    expect(template).toMatch(/sheriffElection\?\.subPhase/)
+  })
+
+  it('binds :data-day-number from the right state path', () => {
+    expect(template).toMatch(/:data-day-number=/)
+    expect(template).toMatch(/nightPhase\?\.dayNumber/)
+  })
+})

--- a/frontend/src/__tests__/waitForCondition.test.ts
+++ b/frontend/src/__tests__/waitForCondition.test.ts
@@ -13,9 +13,7 @@ import { waitForCondition } from '../../e2e/real/helpers/state-polling'
 describe('waitForCondition', () => {
   it('resolves immediately when the predicate returns true on first call', async () => {
     const predicate = vi.fn().mockResolvedValue(true)
-    await expect(
-      waitForCondition(predicate, 'first-call true', 1_000, 50),
-    ).resolves.toBeUndefined()
+    await expect(waitForCondition(predicate, 'first-call true', 1_000, 50)).resolves.toBeUndefined()
     expect(predicate).toHaveBeenCalledTimes(1)
   })
 
@@ -33,18 +31,18 @@ describe('waitForCondition', () => {
 
   it('throws with the description when the predicate stays false past the deadline', async () => {
     const predicate = vi.fn().mockResolvedValue(false)
-    await expect(
-      waitForCondition(predicate, 'never-true predicate', 200, 50),
-    ).rejects.toThrow(/never-true predicate/)
+    await expect(waitForCondition(predicate, 'never-true predicate', 200, 50)).rejects.toThrow(
+      /never-true predicate/,
+    )
     // We polled at least once
     expect(predicate.mock.calls.length).toBeGreaterThanOrEqual(1)
   })
 
   it('includes the last predicate error in the timeout message', async () => {
     const predicate = vi.fn().mockRejectedValue(new Error('backend offline'))
-    await expect(
-      waitForCondition(predicate, 'predicate keeps throwing', 200, 50),
-    ).rejects.toThrow(/backend offline/)
+    await expect(waitForCondition(predicate, 'predicate keeps throwing', 200, 50)).rejects.toThrow(
+      /backend offline/,
+    )
   })
 
   it('does not abort the poll when the predicate occasionally throws', async () => {

--- a/frontend/src/__tests__/waitForCondition.test.ts
+++ b/frontend/src/__tests__/waitForCondition.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the generic effect-poll helper.
+ *
+ * `waitForCondition` is the foundation for the role-action and vote
+ * waits in game-flow.spec.ts. The contract: poll a predicate at fixed
+ * intervals up to a deadline; resolve when the predicate returns true;
+ * throw a descriptive error on timeout (including the latest predicate
+ * error if the predicate itself was throwing).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { waitForCondition } from '../../e2e/real/helpers/state-polling'
+
+describe('waitForCondition', () => {
+  it('resolves immediately when the predicate returns true on first call', async () => {
+    const predicate = vi.fn().mockResolvedValue(true)
+    await expect(
+      waitForCondition(predicate, 'first-call true', 1_000, 50),
+    ).resolves.toBeUndefined()
+    expect(predicate).toHaveBeenCalledTimes(1)
+  })
+
+  it('polls until the predicate flips to true', async () => {
+    let calls = 0
+    const predicate = vi.fn().mockImplementation(async () => {
+      calls += 1
+      return calls >= 3
+    })
+    await expect(
+      waitForCondition(predicate, 'flip after 3 calls', 1_000, 20),
+    ).resolves.toBeUndefined()
+    expect(calls).toBeGreaterThanOrEqual(3)
+  })
+
+  it('throws with the description when the predicate stays false past the deadline', async () => {
+    const predicate = vi.fn().mockResolvedValue(false)
+    await expect(
+      waitForCondition(predicate, 'never-true predicate', 200, 50),
+    ).rejects.toThrow(/never-true predicate/)
+    // We polled at least once
+    expect(predicate.mock.calls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('includes the last predicate error in the timeout message', async () => {
+    const predicate = vi.fn().mockRejectedValue(new Error('backend offline'))
+    await expect(
+      waitForCondition(predicate, 'predicate keeps throwing', 200, 50),
+    ).rejects.toThrow(/backend offline/)
+  })
+
+  it('does not abort the poll when the predicate occasionally throws', async () => {
+    let calls = 0
+    const predicate = vi.fn().mockImplementation(async () => {
+      calls += 1
+      if (calls === 1) throw new Error('transient')
+      if (calls === 2) return false
+      return true
+    })
+    await expect(
+      waitForCondition(predicate, 'recovers after a throw', 1_000, 20),
+    ).resolves.toBeUndefined()
+    expect(calls).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/frontend/src/__tests__/witchSingleAction.test.ts
+++ b/frontend/src/__tests__/witchSingleAction.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Witch single-action contract.
+ *
+ * Each witch button click submits a complete `WITCH_ACT` to the backend
+ * (useAntidote + poisonTargetUserId in one payload). The frontend must
+ * reflect this by hiding the witch UI on the FIRST click — otherwise a
+ * second click sends a stale WITCH_ACT during the night-loop's
+ * inter-role-gap, racing `queuedActionSignals` and auto-completing the
+ * next role's sub-phase before its UI can render.
+ *
+ * This test mounts NightPhase as the witch and verifies that one click
+ * on any of the four turn-ending buttons hides the witch panel
+ * (sleep-screen takes over) and emits exactly one event.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import NightPhase from '@/components/NightPhase.vue'
+import type { GamePlayer, NightPhaseState } from '@/types'
+
+const ME = 'u-witch'
+
+const PLAYERS: GamePlayer[] = [
+  { userId: ME, nickname: 'Witch', seatIndex: 1, isAlive: true, isSheriff: false },
+  { userId: 'u2', nickname: 'Bot2', seatIndex: 2, isAlive: true, isSheriff: false },
+  { userId: 'u3', nickname: 'Bot3', seatIndex: 3, isAlive: true, isSheriff: false },
+]
+
+function makeNight(over: Partial<NightPhaseState> = {}): NightPhaseState {
+  return {
+    subPhase: 'WITCH_ACT',
+    dayNumber: 1,
+    hasAntidote: true,
+    hasPoison: true,
+    antidoteDecided: false,
+    poisonDecided: false,
+    attackedSeatIndex: 2,
+    attackedNickname: 'Bot2',
+    ...over,
+  }
+}
+
+const BASE_PROPS = {
+  players: PLAYERS,
+  myUserId: ME,
+  myRole: 'WITCH' as const,
+  actionPending: false,
+}
+
+describe('Witch — single-click ends the turn', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('clicking witch-antidote hides BOTH antidote and poison panels and emits exactly one witchAntidote event', async () => {
+    const wrapper = mount(NightPhase, {
+      props: { ...BASE_PROPS, nightPhase: makeNight() },
+    })
+    expect(wrapper.find('[data-testid="witch-antidote"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="switch-pass-poison"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="witch-antidote"]').trigger('click')
+
+    // Both panels must be gone — sleep-screen takes over via NightPhase's
+    // hasActed flag. A second click on the still-visible poison panel
+    // would race the role-loop with a stale WITCH_ACT during the
+    // inter-role-gap (the bug this regression-tests).
+    expect(wrapper.find('[data-testid="witch-antidote"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="switch-pass-poison"]').exists()).toBe(false)
+
+    expect(wrapper.emitted('witchAntidote')).toHaveLength(1)
+  })
+
+  it('clicking switch-pass-antidote hides everything and emits exactly one witchPassAntidote', async () => {
+    const wrapper = mount(NightPhase, {
+      props: { ...BASE_PROPS, nightPhase: makeNight() },
+    })
+    await wrapper.find('[data-testid="switch-pass-antidote"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="witch-antidote"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="switch-pass-poison"]').exists()).toBe(false)
+    expect(wrapper.emitted('witchPassAntidote')).toHaveLength(1)
+  })
+
+  it('clicking switch-pass-poison hides everything and emits exactly one witchPassPoison', async () => {
+    const wrapper = mount(NightPhase, {
+      props: { ...BASE_PROPS, nightPhase: makeNight() },
+    })
+    await wrapper.find('[data-testid="switch-pass-poison"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="switch-pass-poison"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="witch-antidote"]').exists()).toBe(false)
+    expect(wrapper.emitted('witchPassPoison')).toHaveLength(1)
+  })
+
+  it('clicking witch-poison-confirm (after target select) hides everything and emits exactly one witchPoison', async () => {
+    const wrapper = mount(NightPhase, {
+      props: { ...BASE_PROPS, nightPhase: makeNight() },
+    })
+    // Enter poison-select mode
+    await wrapper.find('[data-testid="use-poison"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Click a target so the confirm button enables
+    await wrapper.find('.player-grid-sm .slot-alive').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="witch-poison-confirm"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="witch-antidote"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="switch-pass-poison"]').exists()).toBe(false)
+    expect(wrapper.emitted('witchPoison')).toHaveLength(1)
+  })
+
+  it('attempting a second click after the panel is hidden does NOT emit a second event', async () => {
+    const wrapper = mount(NightPhase, {
+      props: { ...BASE_PROPS, nightPhase: makeNight() },
+    })
+    const firstBtn = wrapper.find('[data-testid="witch-antidote"]')
+    await firstBtn.trigger('click')
+
+    // The second button is no longer in the DOM. Programmatically attempting
+    // to invoke a second emission via the disappeared DOM does nothing.
+    const stalePoisonBtn = wrapper.find('[data-testid="switch-pass-poison"]')
+    expect(stalePoisonBtn.exists()).toBe(false)
+
+    // The first emission stands alone.
+    expect(wrapper.emitted('witchAntidote')).toHaveLength(1)
+    expect(wrapper.emitted('witchPassPoison')).toBeUndefined()
+  })
+
+  it('when witch has no items (skip path), the sole witch-skip click hides the panel and emits witchSkip', async () => {
+    const wrapper = mount(NightPhase, {
+      props: {
+        ...BASE_PROPS,
+        nightPhase: makeNight({
+          hasAntidote: false,
+          hasPoison: false,
+          attackedSeatIndex: undefined,
+          attackedNickname: undefined,
+        }),
+      },
+    })
+    await wrapper.find('[data-testid="witch-skip"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="witch-skip"]').exists()).toBe(false)
+    expect(wrapper.emitted('witchSkip')).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/DayPhase.vue
+++ b/frontend/src/components/DayPhase.vue
@@ -12,7 +12,7 @@
     <!-- Fixed-height banner area — always rendered so grid position stays consistent -->
     <div class="banner-area">
       <template v-if="viewRole === 'DEAD'">
-        <div class="banner banner-info">
+        <div class="banner banner-info" data-testid="day-banner-self-eliminated">
           <span class="banner-icon">☑</span>
           <div>
             <div class="banner-title">你在上一晚被淘汰</div>
@@ -22,13 +22,16 @@
         <div
           v-if="dayPhase.subPhase === 'RESULT_REVEALED' && killedPlayers.length > 0"
           class="banner banner-kill"
+          data-testid="day-banner-kill"
         >
           <span class="banner-avatar">💀</span>
           <div class="banner-kill-text">
             <span class="banner-kill-muted">昨晚</span>
             <template v-for="(killed, idx) in killedPlayers" :key="killed.killedPlayerId">
               <span v-if="idx > 0" class="banner-kill-muted">、</span>
-              <span class="banner-kill-red"
+              <span
+                class="banner-kill-red"
+                :data-testid="`day-killed-seat-${killed.killedSeatIndex}`"
                 >{{ killed.killedSeatIndex }}号 · {{ killed.killedNickname }}</span
               >
             </template>
@@ -42,20 +45,26 @@
           (viewRole === 'ALIVE' || viewRole === 'HOST') && dayPhase.subPhase === 'RESULT_REVEALED'
         "
       >
-        <div v-if="killedPlayers.length > 0" class="banner banner-kill">
+        <div
+          v-if="killedPlayers.length > 0"
+          class="banner banner-kill"
+          data-testid="day-banner-kill"
+        >
           <span class="banner-avatar">💀</span>
           <div class="banner-kill-text">
             <span class="banner-kill-muted">昨晚</span>
             <template v-for="(killed, idx) in killedPlayers" :key="killed.killedPlayerId">
               <span v-if="idx > 0" class="banner-kill-muted">、</span>
-              <span class="banner-kill-red"
+              <span
+                class="banner-kill-red"
+                :data-testid="`day-killed-seat-${killed.killedSeatIndex}`"
                 >{{ killed.killedSeatIndex }}号 · {{ killed.killedNickname }}</span
               >
             </template>
             <span class="banner-kill-muted">出局了</span>
           </div>
         </div>
-        <div v-else class="banner banner-info">
+        <div v-else class="banner banner-info" data-testid="day-banner-peaceful">
           <span class="banner-icon">❤️</span>
           <div>
             <div class="banner-title">昨晚平安夜</div>

--- a/frontend/src/components/NightPhase.vue
+++ b/frontend/src/components/NightPhase.vue
@@ -126,7 +126,12 @@
       "
     >
       <div class="sr-wrap">
-        <div :class="['sr-card', nightPhase.seerResult.isWerewolf ? 'sr-wolf' : 'sr-village']">
+        <div
+          :class="['sr-card', nightPhase.seerResult.isWerewolf ? 'sr-wolf' : 'sr-village']"
+          data-testid="seer-result-card"
+          :data-alignment="nightPhase.seerResult.isWerewolf ? 'wolf' : 'village'"
+          :data-checked-seat="nightPhase.seerResult.checkedSeatIndex"
+        >
           <div class="sr-player">
             {{ nightPhase.seerResult.checkedSeatIndex }}号 ·
             {{ nightPhase.seerResult.checkedNickname }}

--- a/frontend/src/components/NightPhase.vue
+++ b/frontend/src/components/NightPhase.vue
@@ -451,34 +451,27 @@ function confirmWitchSkip() {
   emit('witchSkip')
 }
 
-// Witch has up to two potions and can decide each independently. Flip hasActed
-// only when the current click resolves the witch's FINAL pending decision —
-// otherwise the other potion panel would disappear behind the sleep screen.
-function witchActionIsFinal(otherPotionHeld: boolean, otherDecided: boolean) {
-  return !otherPotionHeld || otherDecided
-}
+// Each witch button click submits a COMPLETE WITCH_ACT (the GameView
+// handlers fix the other potion to "not used" when one is chosen — see
+// handleWitchAntidote / handleWitchPassAntidote / handleWitchPoison /
+// handleWitchPassPoison in GameView.vue). The witch's turn ends in one
+// click, same as wolf / seer / guard / hunter. Hide the UI immediately
+// to prevent a second click from racing the night-loop with a stale
+// WITCH_ACT during the inter-role-gap window.
 function confirmWitchAntidote() {
-  if (witchActionIsFinal(!!props.nightPhase.hasPoison, !!props.nightPhase.poisonDecided)) {
-    hasActed.value = true
-  }
+  hasActed.value = true
   emit('witchAntidote')
 }
 function confirmWitchPassAntidote() {
-  if (witchActionIsFinal(!!props.nightPhase.hasPoison, !!props.nightPhase.poisonDecided)) {
-    hasActed.value = true
-  }
+  hasActed.value = true
   emit('witchPassAntidote')
 }
 function confirmWitchPoison(targetId: string) {
-  if (witchActionIsFinal(!!props.nightPhase.hasAntidote, !!props.nightPhase.antidoteDecided)) {
-    hasActed.value = true
-  }
+  hasActed.value = true
   emit('witchPoison', targetId)
 }
 function confirmWitchPassPoison() {
-  if (witchActionIsFinal(!!props.nightPhase.hasAntidote, !!props.nightPhase.antidoteDecided)) {
-    hasActed.value = true
-  }
+  hasActed.value = true
   emit('witchPassPoison')
 }
 

--- a/frontend/src/components/PlayerSlot.vue
+++ b/frontend/src/components/PlayerSlot.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     :class="['player-slot', variantClass, mode === 'room' && 'slot-room']"
+    :data-seat="seat"
     @click="$emit('click')"
   >
     <!-- ── Room mode: square card with avatar circle ── -->

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -1,5 +1,26 @@
 <template>
-  <div :class="{ 'night-mode': isNight }" class="game-wrap">
+  <!-- E2E observability: data-phase / data-phase-sub / data-day-number
+       expose authoritative state so cross-browser tests can assert
+       phase delivery via testid-style attributes instead of inferring
+       phase from per-component CSS classes (which only cover the rough
+       grouping NIGHT/DAY/VOTING). -->
+  <div
+    :class="{ 'night-mode': isNight }"
+    class="game-wrap"
+    :data-phase="gameStore.state?.phase ?? ''"
+    :data-phase-sub="
+      gameStore.state?.nightPhase?.subPhase ??
+      gameStore.state?.votingPhase?.subPhase ??
+      gameStore.state?.dayPhase?.subPhase ??
+      gameStore.state?.sheriffElection?.subPhase ??
+      ''
+    "
+    :data-day-number="
+      gameStore.state?.nightPhase?.dayNumber ??
+      gameStore.state?.dayPhase?.dayNumber ??
+      ''
+    "
+  >
     <!-- Mute/unmute floating button -->
     <button class="audio-mute-btn" :title="isMuted ? 'Unmute' : 'Mute'" @click="toggleMute">
       {{ isMuted ? '🔇' : '🔊' }}

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -16,9 +16,7 @@
       ''
     "
     :data-day-number="
-      gameStore.state?.nightPhase?.dayNumber ??
-      gameStore.state?.dayPhase?.dayNumber ??
-      ''
+      gameStore.state?.nightPhase?.dayNumber ?? gameStore.state?.dayPhase?.dayNumber ?? ''
     "
   >
     <!-- Mute/unmute floating button -->

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "types": [
-      "vite/client"
+      "vite/client",
+      "node"
     ],
     "baseUrl": ".",
     "paths": {

--- a/scripts/roles.sh
+++ b/scripts/roles.sh
@@ -64,11 +64,19 @@ print(','.join(b['userId'] for b in bots))
 
 # ALL_PLAYERS = bots + manually-logged-in users (added via: dev-login.sh <nick> --room <code>)
 # Filter users to only those actually in the game (have valid seat from API)
-ALL_PLAYERS_JSON=$(python3 - "$STATE_FILE" "$FIRST_TOKEN" << 'PYEOF'
-import json, urllib.request, sys, base64
+ALL_PLAYERS_JSON=$(python3 - "$STATE_FILE" "$FIRST_TOKEN" "$BASE" << 'PYEOF'
+import json, urllib.request, sys
 
 path = sys.argv[1]
 token = sys.argv[2]
+base = sys.argv[3]
+# Note: f"{BASE}/..." here used to reference an undefined Python `BASE`,
+# raising NameError on every loop iteration → the bare `except: continue`
+# swallowed it → `valid_user_ids` stayed empty → manually-logged-in users
+# (including the test-host) were filtered out of every roles.sh report.
+# Fixed by passing $BASE as argv[3] and using lower-case `base` consistently
+# below (the heredoc is single-quoted so bash $-expansion is intentionally
+# disabled to keep the python literal stable).
 
 state = json.load(open(path))
 bots = state['bots']
@@ -82,7 +90,7 @@ try:
     for gid in range(1, 10000):
         try:
             req = urllib.request.Request(
-                f"{BASE}/game/{gid}/state",
+                f"{base}/game/{gid}/state",
                 headers={"Authorization": f"Bearer {token}"}
             )
             with urllib.request.urlopen(req) as r:
@@ -92,9 +100,9 @@ try:
                     if bot_ids.issubset(game_player_ids):
                         valid_user_ids = game_player_ids
                         break
-        except:
+        except Exception:
             continue
-except:
+except Exception:
     pass
 
 # Filter users to only those actually in the game


### PR DESCRIPTION
## Summary

Hardens `frontend/e2e/real/game-flow.spec.ts` along six design axes that together close categories of bug the existing test suite does not catch. Each axis lands as a single commit with focused unit-test coverage of its pure-logic surface so the design contract is enforced at every future change, not just on the day it was written.

| # | What it catches | Where |
|---|---|---|
| **0** Special-role + host actions go through the DOM | UI-render bugs, click-handler wiring, target-grid filter, reactive watchers | `game-flow.spec.ts` |
| **#3** Console + network sentinels (`pageerror`, `5xx`) on every browser | Silent JS exceptions / Sentry-only regressions | `helpers/error-sentinel.ts` |
| **#6** ERROR/FATAL backend log scan during the test window | Backend bugs that retried/recovered and were invisible to the frontend | `helpers/backend-log.ts` |
| **#2** All `waitForTimeout` replaced with effect waits | Flake (timeout too short) AND missed bugs (action silently never landed) | `helpers/state-polling.ts` |
| **#4** Game-state invariants asserted between every test step | Phase regressions, resurrections, sub-phase mismatches, dead-sheriff bugs | `helpers/invariants.ts` |
| **#5** Action observability — required DOM side-effect per action | Wrong target, lost result, STOMP payload regression | spec + new testids |
| **#1** Cross-browser phase via `data-phase` attribute | STOMP delivery regression on a single browser, masked by stale CSS class | `GameView.vue` + `verifyAllBrowsersPhase` |

Per-commit detail in the commit messages. Total: 8 commits, +1,800 / -490 LOC across 17 files, 224 vitest tests (all passing — adds 47 new test cases).

## What you actually get from this PR (in CI failure messages)

Before:
> P0: Browser stuck — expected phase NIGHT, .game-wrap.night-mode not visible after 15000ms

After:
> P0: Browser [SEER] stuck — expected phase NIGHT (data-phase ∈ {NIGHT}) but not visible after 30000ms.
> Current state: {"dataPhase":"DAY_DISCUSSION","dataPhaseSub":"RESULT_HIDDEN","dataDayNumber":"1",...}
> [browser-errors] [SEER] pageerror: TypeError: Cannot read properties of undefined (reading 'subPhase')
> [backend-errors] 2026-04-26 ... ERROR ... NullPointerException at SeerPhaseService.process(...)
> [invariants/04-night-seer] phase regressed: DAY_DISCUSSION/day1 (rank 1050) → NIGHT/day1 (rank 1030)

Three independent failure signals on every test instead of one ambiguous "phase didn't render" — each pointing at the actual cause.

## New testids and component attributes added

| Component | Addition | Purpose |
|---|---|---|
| `GameView.vue` | `data-phase` / `data-phase-sub` / `data-day-number` on `.game-wrap` | Cross-browser phase verification (#1) |
| `DayPhase.vue` | `day-banner-peaceful` / `day-banner-kill` testids; `day-killed-seat-N` per kill row | Day-result observability (#5) |
| `NightPhase.vue` | `seer-result-card` testid + `data-alignment` + `data-checked-seat` | Seer-correctness assertion (#5) |
| `PlayerSlot.vue` | `data-seat=N` on every slot | Test reads which seat `.first()` resolved to (#5) |

## Verification

- `cd frontend && npx tsc --noEmit -p tsconfig.json` — clean
- `cd frontend && npx vitest run` — 19 test files, 224 tests, all green
- 47 new test cases across 5 new test files exercise the pure-logic surface of every helper
- Every six design points has at least one unit test that fails if its contract drifts (e.g. PHASE_DATA_VALUES coverage of every backend GamePhase enum value, ERROR_LINE_PATTERNS not matching stack-frame lines, invariant rank monotonic across days, etc.)

## Test plan

- [ ] `E2E · Integration` shards 1/3, 2/3, 3/3 stay green on this branch
- [ ] All four sentinels surface useful artifacts (browser-errors, backend-errors, invariants/<step>) in any failure
- [ ] If green, follow-up PRs migrate `werewolf-win.spec.ts`, `idiot-flow.spec.ts`, `revote-flow.spec.ts`, `dead-role-audio.spec.ts`, `guard-audio-sequence.spec.ts`, and the sheriff specs to the same six-design-points pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)