### PR TITLE
fix(audio): preserve role audio across high-priority phase clear (un-skip guard-audio-sequence)

### DIFF
--- a/frontend/e2e/real/guard-audio-sequence.spec.ts
+++ b/frontend/e2e/real/guard-audio-sequence.spec.ts
@@ -86,22 +86,7 @@ test.describe('Guard Audio Sequence — Regression Test', () => {
     }
   })
 
-  // SKIPPED: reveals a genuine product audio-queue-clear bug, not a test flake.
-  // Local reproduction (backend inter-role-gap-ms set to 0 to squeeze timing, or on
-  // any CI runner with the current shrunk e2e timings) shows guard_close_eyes.mp3
-  // getting queued ~15ms before the NIGHT→DAY AudioSequence arrives. The DAY
-  // sequence is high-priority (>=10) and calls audioService.clearQueue() at
-  // useAudioService.ts:46-52, wiping guard_close_eyes before it plays.
-  //
-  // Even bumping inter-role-gap-ms to production's 3000 doesn't help: the
-  // cumulative night audio (~15-20s across 4 roles' open+close files) exceeds
-  // the cumulative night backend budget, so the queue stays behind all night
-  // and DAY always clears lingering items.
-  //
-  // Real fix (product-side, separate PR): either make NIGHT→DAY audio append
-  // rather than clearQueue, or wait for the queue to drain before firing the
-  // DAY high-priority sequence. Re-enable this test once that lands.
-  test.skip('guard as last role - guard_close_eyes plays exactly once', async ({}, testInfo) => {
+  test('guard as last role - guard_close_eyes plays exactly once', async ({}, testInfo) => {
     const hostPage = ctx.hostPage
     const gameId = ctx.gameId
 
@@ -231,8 +216,26 @@ test.describe('Guard Audio Sequence — Regression Test', () => {
     await captureSnapshot(ctx.pages, testInfo, '05-guard-completed-day-started')
 
     // ── Step 6: Verify audio sequence integrity ───────────────────────────
-    // Wait a bit for any delayed audio events
-    await hostPage.waitForTimeout(3_000)
+    // Wait until rooster_crowing ACTUALLY starts playing through the queue.
+    // Under e2e timings the role-owned audio queue can carry 9+ files
+    // (wolf/seer/witch/guard open+close + transitions); rooster_crowing is
+    // the LAST item appended after guard_close_eyes (DAY sequence is high-
+    // priority but now appends rather than clearing, per useAudioService.ts
+    // fix). Once rooster_crowing has started, guard_close_eyes has provably
+    // already played (queue is FIFO). Polling the sentinel that comes
+    // last lets us assert both files in one wait. Budget 45s in CI, 30s
+    // locally — wolf_howl alone is ~5s and 9 files at ~1.5s each is the
+    // headroom we need.
+    const lastSentinel = (e: string): boolean =>
+      e.includes('Starting playback') && e.includes('rooster_crowing.mp3')
+    const sentinelDeadline = Date.now() + (process.env.CI ? 45_000 : 30_000)
+    while (Date.now() < sentinelDeadline) {
+      if (audioEvents.some(lastSentinel)) break
+      await hostPage.waitForTimeout(250)
+    }
+    // Settle so any duplicate guard_close_eyes (the bug we're hunting)
+    // has time to surface in the buffer.
+    await hostPage.waitForTimeout(1_000)
 
     // Two audio log sources:
     //   audioService.ts:    `[AudioService] Starting playback: ${filename}` — template literal, filename inline
@@ -275,14 +278,7 @@ test.describe('Guard Audio Sequence — Regression Test', () => {
     expect(guardCloseIndex).toBeLessThan(roosterIndex)
   })
 
-  // SKIPPED alongside the sister test above. Its only strict assertion was
-  // .toBeGreaterThanOrEqual(0) (always-true), so in prior runs it passed
-  // vacuously — the useful failure was really about the guard action never
-  // reaching the backend when the host was assigned the guard role. Rather
-  // than keep a vacuous pass alive that masks the product bug the other test
-  // names, skip both together; the whole file can re-enable when the audio
-  // clearQueue() behavior is addressed.
-  test.skip('rapid phase transitions - no duplicate or stale audio playback', async ({}, testInfo) => {
+  test('rapid phase transitions - no duplicate or stale audio playback', async ({}, testInfo) => {
     // This test verifies that rapid state updates don't cause stale audio to replay.
     // "Rapid" here means "no arbitrary sleeps between actions" — but we still
     // gate each action on the backend sub-phase to avoid silent rejections.

--- a/frontend/src/__tests__/gameViewAudioEventOrder.test.ts
+++ b/frontend/src/__tests__/gameViewAudioEventOrder.test.ts
@@ -16,10 +16,12 @@ const mockStopAll = vi.fn()
 const mockIsMuted = vi.fn().mockReturnValue(false)
 const mockToggleMute = vi.fn()
 
+const mockIsQueueActive = vi.fn().mockReturnValue(false)
 vi.mock('@/services/audioService', () => ({
   audioService: {
     playSequential: (...args: unknown[]) => mockPlaySequential(...args),
     clearQueue: () => mockClearQueue(),
+    isQueueActive: () => mockIsQueueActive(),
     stopAll: () => mockStopAll(),
     isMuted: () => mockIsMuted(),
     toggleMute: () => mockToggleMute(),

--- a/frontend/src/__tests__/useAudioService.test.ts
+++ b/frontend/src/__tests__/useAudioService.test.ts
@@ -15,6 +15,7 @@ const mockClearQueue = vi.fn()
 const mockStopAll = vi.fn()
 const mockIsMuted = vi.fn().mockReturnValue(false)
 const mockToggleMute = vi.fn()
+const mockIsQueueActive = vi.fn().mockReturnValue(false)
 
 vi.mock('@/services/audioService', () => ({
   audioService: {
@@ -23,6 +24,7 @@ vi.mock('@/services/audioService', () => ({
     stopAll: () => mockStopAll(),
     isMuted: () => mockIsMuted(),
     toggleMute: () => mockToggleMute(),
+    isQueueActive: () => mockIsQueueActive(),
     setGlobalVolume: vi.fn(),
     getGlobalVolume: vi.fn().mockReturnValue(1),
   },
@@ -147,6 +149,32 @@ describe('useAudioService', () => {
   })
 
   // ── Queue behavior: priority-aware to guarantee sequential, non-overlapping playback ─
+
+  it('high-priority sequence (>=10) APPENDS when queue still has role-owned audio in flight', async () => {
+    // Regression: when DAY's rooster_crowing arrives while the role-owned
+    // queue is still draining (e.g. guard_close_eyes queued ~15ms before),
+    // the previous behavior unconditionally clearQueue()'d and dropped
+    // guard_close_eyes — verified end-to-end in
+    // /tmp/werewolf-e2e-backend.log on 2026-04-27. The queue-active branch
+    // appends instead, preserving narrative integrity.
+    mockIsQueueActive.mockReturnValue(true)
+
+    const gameStore = useGameStore()
+    setupComposable()
+
+    gameStore.setState(
+      makeState({
+        audioSequence: { ...makeSequence(['rooster_crowing.mp3'], 'day-arrives'), priority: 10 },
+      }),
+    )
+    await nextTick()
+
+    expect(mockClearQueue).not.toHaveBeenCalled()
+    expect(mockPlaySequential).toHaveBeenCalledWith(['rooster_crowing.mp3'])
+
+    // Reset for any later test in this file that depends on queue-idle default.
+    mockIsQueueActive.mockReturnValue(false)
+  })
 
   it('high-priority sequence (>=10) clears the queue so it plays immediately', async () => {
     // Phase-boundary audio (DAY→NIGHT, NIGHT→DAY) must interrupt any lingering audio

--- a/frontend/src/composables/useAudioService.ts
+++ b/frontend/src/composables/useAudioService.ts
@@ -37,19 +37,34 @@ export function useAudioService() {
         return
       }
 
-      // Phase-level audio (priority >= 10) replaces the queue — e.g. DAY→NIGHT rooster
-      // must interrupt any lingering night audio. Lower-priority sequences (role open/
-      // close eyes, dead-role sim) APPEND to the queue so they play sequentially after
-      // whatever is currently playing. This is what guarantees wolf_open_eyes.mp3
-      // never overlaps with goes_dark_close_eyes.mp3 or wolf_howl.mp3, even if the
-      // backend's NIGHT_INIT_AUDIO_DELAY_MS timing underestimates the combined duration.
+      // Phase-level audio (priority >= 10) is meant to replace the queue —
+      // e.g. DAY→NIGHT rooster_crowing should interrupt any lingering night
+      // audio. But an unconditional clearQueue() drops role-owned audio that
+      // is queued but hasn't started yet — the most common offender:
+      // guard_close_eyes.mp3 gets queued ~15ms before the DAY AudioSequence
+      // arrives, and clearQueue wipes it before audio.play() ever fires.
+      // Result: the audible role-narrative ("all roles done → day breaks")
+      // is silently truncated.
+      //
+      // Fix: only clear when the queue is idle (no harm done). When it is
+      // still draining low-priority role audio, APPEND the high-priority
+      // files so they play after the role-narrative audio finishes —
+      // preserves narrative integrity while still ensuring the high-priority
+      // sequence eventually plays.
       const isHighPriority = (newSequence.priority ?? 0) >= 10
       if (isHighPriority) {
-        console.log(
-          '[useAudioService] High-priority sequence — clearing queue:',
-          newSequence.audioFiles,
-        )
-        audioService.clearQueue()
+        if (audioService.isQueueActive()) {
+          console.log(
+            '[useAudioService] High-priority sequence — queue active, appending after current items:',
+            newSequence.audioFiles,
+          )
+        } else {
+          console.log(
+            '[useAudioService] High-priority sequence — clearing idle queue:',
+            newSequence.audioFiles,
+          )
+          audioService.clearQueue()
+        }
       } else {
         console.log(
           '[useAudioService] Low-priority sequence — appending to queue:',

--- a/frontend/src/services/audioService.ts
+++ b/frontend/src/services/audioService.ts
@@ -318,6 +318,16 @@ class AudioService {
     this.stopAll()
     this.isPlayingQueue = false
   }
+
+  /**
+   * True when an item is currently playing OR queued and pending.
+   * Callers that want to interrupt mid-narrative use this to decide between
+   * a "clear-and-replace" hard reset (queue idle) and a "wait-then-play"
+   * append (queue still draining role-owned audio).
+   */
+  isQueueActive(): boolean {
+    return this.isPlayingQueue || this.audioQueue.length > 0
+  }
 }
 
 // Export singleton instance


### PR DESCRIPTION
## Summary

- Fixes the audio queue-clear product bug that quarantined both `guard-audio-sequence.spec.ts` tests on 2026-04-19. `useAudioService` now appends rather than `clearQueue()`-ing when a high-priority phase sequence arrives while the queue still has role-owned audio in flight.
- Un-skips both regression tests in the spec.

## Root cause

Reproduced locally 2026-04-27 (host browser console capture): when DAY's `rooster_crowing` AudioSequence (priority ≥ 10) arrives ~15ms after `guard_close_eyes` is queued, the previous code unconditionally called `audioService.clearQueue()` and wiped the role audio mid-narrative. Test assertion: `guard_close_eyes.mp3 played 0 times, expected 1`.

## Fix

- `audioService.ts` — new `isQueueActive(): boolean` (true while an item is playing or queued).
- `useAudioService.ts` — high-priority branch only calls `clearQueue()` when `isQueueActive()` is false. When the queue is still draining low-priority role audio, append instead — narrative integrity preserved, high-priority audio plays after current items finish.
- Spec poll updated to wait for the last sentinel (`rooster_crowing`) rather than a blanket 3s, since post-fix the queue takes ~15s to drain on e2e timings.

## Verification

- `npx vue-tsc --noEmit` clean.
- `npx vitest run` — 231/231 unit tests pass (added 1 new regression test for the queue-active append contract).
- Playwright real-backend: 3/3 stability runs of `Guard Audio Sequence` pass at ~1.0 min each.

## Test plan

- [ ] CI · Lint & Test passes.
- [ ] CI · Backend Build & Test passes.
- [ ] CI · E2E · UI shards pass.
- [ ] CI · E2E · Integration shards pass (the guard-audio-sequence spec runs in this matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)