### PR TITLE
test(e2e): un-skip game-flow Night 2 — replace dead isGameOver guard

### DIFF
--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -488,12 +488,23 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
   // ── Test 8: Night 2 cycle ────────────────────────────────────────────
 
   test('8. Night 2 — phase cycling works, transitions back to DAY', async ({}, testInfo) => {
-    // Check if game is over first
-    const isGameOver = ctx.hostPage.url().includes('/result/')
-    if (isGameOver) {
-      test.skip()
-      return
+    // 9p game starts with 3 wolves (GameService.kt:316 — wolfCount=3 when
+    // playerCount<=9). Test 7 votes out the first wolf at D1, leaving 2
+    // wolves alive — POST_VOTE check is `wolves >= humans` for CLASSIC and
+    // 2 < 6 humans, so no win triggers and the game advances to N2. The
+    // earlier `if (isGameOver) test.skip()` guard never fired in practice
+    // and was speculative; if a future change reduces the wolf count or
+    // adds another elimination, surface the impossibility here so the
+    // root cause is visible instead of silently skipping.
+    if (ctx.hostPage.url().includes('/result/')) {
+      throw new Error(
+        `Test 8 reached with game already over after D1 — unexpected for 9p (3 wolves). ` +
+          `Either Test 7's vote target reduced wolves to 0 or another mechanic eliminated ` +
+          `wolves at N1. Inspect the latest game.state lines in /tmp/werewolf-e2e-backend.log.`,
+      )
     }
+    // eslint-disable-next-line no-console
+    console.warn(`[game-flow test 8] starting Night 2 — game URL=${ctx.hostPage.url()}`)
 
     // Night 2: some browser-bound role bots may have been voted out on
     // Day 1. Each role tries DOM-first via its browser; if that browser's


### PR DESCRIPTION
## Summary

Removes a speculative `test.skip()` from game-flow's Night 2 test. The skip can never fire in the test's standard 9p configuration:

- `GameService.kt:316` assigns 3 wolves for `playerCount <= 9`.
- Test 7 votes 1 wolf out at D1 → 2 wolves remain → `wolves >= humans` is `2 < 6`, no win triggers, game advances to N2.
- Test 4 cancels witch poison and uses antidote on the wolf-killed villager — no wolf dies at N1.

## Root cause analysis (no speculation)

The skip pattern was:

```typescript
const isGameOver = ctx.hostPage.url().includes('/result/')
if (isGameOver) {
  test.skip()
  return
}
```

This branch is unreachable given the role distribution + test plan above. Three local stability runs of the full game-flow spec confirm:

```
[game-flow test 8] starting Night 2 — game URL=http://localhost:5174/game/1
8 passed (1.2m)

[game-flow test 8] starting Night 2 — game URL=http://localhost:5174/game/1
8 passed (59.3s)

[game-flow test 8] starting Night 2 — game URL=http://localhost:5174/game/1
8 passed (1.2m)
```

Every run has `game URL=/game/{id}`, never `/result/`.

## Fix

- Drop the `test.skip()` early-return.
- Replace with a `throw new Error(...)` that surfaces a diagnostic if a future change reduces the wolf count below the safe threshold (e.g. a smaller `wolfCount` formula or an extra elimination at N1). The invariant becomes explicit: by the time test 8 runs, the game is mid-flow.
- Add `console.warn` recording the URL at entry so any future regression is one log line away.

## Verification

- `npx vue-tsc --noEmit` clean.
- `npx vitest run` — 231/231 unit tests pass.
- Playwright real-backend: 3/3 stability runs of `Game flow` pass at ~1.0-1.2 min each.

## Test plan

- [ ] CI · Lint & Test passes.
- [ ] CI · Backend Build & Test passes.
- [ ] CI · E2E · UI shards pass.
- [ ] CI · E2E · Integration shards pass (game-flow runs in this matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)