### PR TITLE
test(e2e): un-skip sheriff-flow test 2 + extend game-flow to day 2/3 + Day 1 end-state rows

### DIFF
--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -58,7 +58,7 @@ function roleOfSeat(seat: number): RoleName | null {
 }
 
 test.describe('Game flow — multi-browser STOMP verification', () => {
-  test.setTimeout(60_000) // 3 minutes for the full flow
+  test.setTimeout(180_000) // 3 min per test — N1 + N2 + N3 nights each cycle 4 roles
 
   test.beforeAll(async ({ browser }, testInfo) => {
     testInfo.setTimeout(120_000) // setup can take a while with shell scripts
@@ -530,15 +530,41 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       }
     }
 
-    const wolfBots = ctx.roleMap.WEREWOLF ?? []
-    const seerBots = ctx.roleMap.SEER ?? []
-    const witchBots = ctx.roleMap.WITCH ?? []
-    const guardBots = ctx.roleMap.GUARD ?? []
-    const villagerBots = ctx.roleMap.VILLAGER ?? []
+    // Read the live-alive set from /api/game/state so the API fallback only
+    // tries actors / targets that are actually alive on the backend. Without
+    // this filter, a wolf voted out at D1 stays in roleMap (which is built
+    // at game start) and the inner loop fans 4 targets × act.sh's 3 retries
+    // = 12-15 s burned per dead actor before reaching a live wolf.
+    //
+    // act.sh now short-circuits "Actor is dead" via PERMANENT_REJECTION_RE,
+    // but cutting the dead-actor call upstream is faster AND surfaces the
+    // intent ("we know who's alive") in the test code.
+    const aliveIds = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) return [] as string[]
+      const state = await res.json()
+      return ((state?.players ?? []) as Array<{ isAlive?: boolean; userId: string }>)
+        .filter((p) => p.isAlive !== false)
+        .map((p) => p.userId)
+    }, ctx.gameId)
+    const aliveSet = new Set(aliveIds)
+    const aliveBotsOf = (role: RoleName) =>
+      (ctx.roleMap[role] ?? []).filter((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
 
-    const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots].filter(
-      (b) => b.nick !== 'Host',
-    )
+    const wolfBots = aliveBotsOf('WEREWOLF')
+    const seerBots = aliveBotsOf('SEER')
+    const witchBots = aliveBotsOf('WITCH')
+    const guardBots = aliveBotsOf('GUARD')
+    const villagerBots = aliveBotsOf('VILLAGER')
+
+    // Targets exclude wolves (a wolf can't kill another wolf) and Host (the
+    // wolf-page DOM-first path covers host-as-wolf). Filter by alive too —
+    // the role-page DOM-first paths target `.slot-alive` already, so the
+    // API fallback should match that contract.
+    const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots]
 
     // Locator visibility helper — Playwright's isVisible() does NOT retry,
     // so wrapping waitFor lets us return a boolean after a real wait.
@@ -720,10 +746,17 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     }
 
     // After night, the backend transitions NIGHT → DAY_PENDING → DAY_DISCUSSION.
-    // Poll the backend rather than guess a 10-second buffer; if the game
-    // ended (GAME_OVER), the page URL will already be /result/...
-    const isOver = ctx.hostPage.url().includes('/result/')
-    if (!isOver) {
+    // Poll the backend's `phase` field rather than the URL — STOMP-driven
+    // /result/ redirect lags backend commit, so URL-only check misses
+    // GAME_OVER on CI. /api/game/state is the authoritative signal.
+    const phaseAfterNight = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? (await res.json())?.phase : null
+    }, ctx.gameId)
+    if (phaseAfterNight !== 'GAME_OVER') {
       await waitForPhase(ctx.hostPage, ctx.gameId, 'DAY_DISCUSSION', 20_000)
       await verifyAllBrowsersPhase(ctx.pages, 'DAY', 20_000)
     }
@@ -823,7 +856,19 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // possible if a witch poisoned earlier). Both are valid outcomes;
     // this test asserts the deterministic part: the vote machinery
     // produced a sub-phase transition.
-    if (!hostPage.url().includes('/result/')) {
+    //
+    // Use API state, not URL, to detect game-end. The URL → /result/ redirect
+    // is driven by a STOMP GameOverEvent → router.push, which lags backend
+    // commit by 200-500 ms locally and longer under CI load. Polling
+    // /api/game/state.phase === 'GAME_OVER' is the authoritative signal.
+    const phaseAfterContinue = await hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? (await res.json())?.phase : null
+    }, ctx.gameId)
+    if (phaseAfterContinue !== 'GAME_OVER') {
       await waitForPhase(hostPage, ctx.gameId, 'NIGHT', 15_000)
       await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 15_000)
     }
@@ -842,13 +887,21 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // nothing to test here — assert that fact and exit cleanly. NOT a
     // skip: a clean exit with a captured screenshot is the correct
     // outcome for the early-end branch.
-    if (ctx.hostPage.url().includes('/result/')) {
-      const finalState = await ctx.hostPage.evaluate(async (id: string) => {
-        const token = localStorage.getItem('jwt')
-        const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
-        return res.ok ? res.json() : null
-      }, ctx.gameId)
-      expect(finalState?.phase, 'game ended at D2 — expected GAME_OVER').toBe('GAME_OVER')
+    //
+    // Detect via API state.phase, NOT URL. STOMP-driven router.push to
+    // /result/ lags backend commit; on CI the URL can still be /game/N
+    // even after phase=GAME_OVER, which then makes this guard miss the
+    // early-end and the NIGHT precondition assertion below fail with
+    // "expected NIGHT day=3 after test 9" — exactly the shape of the
+    // CI shard-1 failure on commit f757f1e.
+    const initialState = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? res.json() : null
+    }, ctx.gameId)
+    if (initialState?.phase === 'GAME_OVER') {
       await captureSnapshot(ctx.pages, testInfo, '10-game-over-at-d2')
       return
     }
@@ -988,11 +1041,20 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       }
     }
 
-    // Backend transitions to DAY day=3 (or GAME_OVER if last wolf died at N3,
-    // which is impossible since wolves don't kill themselves — so DAY is
-    // the only valid outcome here).
-    await waitForPhase(ctx.hostPage, ctx.gameId, 'DAY_DISCUSSION', 20_000)
-    await verifyAllBrowsersPhase(ctx.pages, 'DAY', 20_000)
+    // Backend transitions to DAY day=3, OR to GAME_OVER if a witch poison
+    // at N3 kills the last wolf (rare but possible). Check API state first
+    // so the GAME_OVER branch doesn't time out on waitForPhase DAY.
+    const phaseAfterN3 = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? (await res.json())?.phase : null
+    }, ctx.gameId)
+    if (phaseAfterN3 !== 'GAME_OVER') {
+      await waitForPhase(ctx.hostPage, ctx.gameId, 'DAY_DISCUSSION', 20_000)
+      await verifyAllBrowsersPhase(ctx.pages, 'DAY', 20_000)
+    }
     await captureSnapshot(ctx.pages, testInfo, '10-night3-complete')
   })
 })

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -488,23 +488,25 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
   // ── Test 8: Night 2 cycle ────────────────────────────────────────────
 
   test('8. Night 2 — phase cycling works, transitions back to DAY', async ({}, testInfo) => {
-    // 9p game starts with 3 wolves (GameService.kt:316 — wolfCount=3 when
-    // playerCount<=9). Test 7 votes out the first wolf at D1, leaving 2
-    // wolves alive — POST_VOTE check is `wolves >= humans` for CLASSIC and
-    // 2 < 6 humans, so no win triggers and the game advances to N2. The
-    // earlier `if (isGameOver) test.skip()` guard never fired in practice
-    // and was speculative; if a future change reduces the wolf count or
-    // adds another elimination, surface the impossibility here so the
-    // root cause is visible instead of silently skipping.
-    if (ctx.hostPage.url().includes('/result/')) {
-      throw new Error(
-        `Test 8 reached with game already over after D1 — unexpected for 9p (3 wolves). ` +
-          `Either Test 7's vote target reduced wolves to 0 or another mechanic eliminated ` +
-          `wolves at N1. Inspect the latest game.state lines in /tmp/werewolf-e2e-backend.log.`,
-      )
-    }
-    // eslint-disable-next-line no-console
-    console.warn(`[game-flow test 8] starting Night 2 — game URL=${ctx.hostPage.url()}`)
+    // Precondition contract: by this point, tests 1–7 have driven the game
+    // through ROLE_REVEAL → NIGHT (day=1) → DAY → DAY_VOTING (day=1) →
+    // NIGHT (day=2). 9p kit has 3 wolves (GameService.kt:316), test 7 voted
+    // out 1 wolf, the POST_VOTE check sees 2 wolves vs 6 humans, no win
+    // triggers, and the backend transitions to NIGHT day=2.
+    //
+    // Assert the contract explicitly. If a future change in test 7 (or in
+    // role distribution) leaves the game in any other state, this assertion
+    // fails with the actual phase/sub-phase from /api/game/{id}/state, and
+    // the failure points straight at the violated invariant.
+    const reachedNight = await waitForPhase(ctx.hostPage, ctx.gameId, 'NIGHT', 15_000)
+    expect(reachedNight, 'expected NIGHT day=2 after test 7').toBe(true)
+    const reachedWolfPick = await waitForNightSubPhase(
+      ctx.hostPage,
+      ctx.gameId,
+      'WEREWOLF_PICK',
+      15_000,
+    )
+    expect(reachedWolfPick, 'expected NIGHT/WEREWOLF_PICK on day=2 entry').toBe(true)
 
     // Night 2: some browser-bound role bots may have been voted out on
     // Day 1. Each role tries DOM-first via its browser; if that browser's
@@ -727,5 +729,559 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     }
 
     await captureSnapshot(ctx.pages, testInfo, '08-night2-complete')
+  })
+
+  // ── Test 9: Day 2 voting cycle ────────────────────────────────────────
+  // Verifies the voting machinery still works on day 2: host reveals N2
+  // results, opens the vote, bots vote a wolf out, tally → VOTE_RESULT,
+  // continue → NIGHT day=3. This catches regressions where the second
+  // voting round breaks (e.g. day-counter off-by-one, sub-phase reset
+  // missing, allVoted check uses stale day-1 voter set).
+
+  test('9. Day 2 voting — vote second wolf, transition to NIGHT day=3', async ({}, testInfo) => {
+    const hostPage = ctx.hostPage
+
+    // Precondition: test 8 left us in DAY_DISCUSSION (day=2) with the
+    // night-2 result hidden.
+    await waitForPhase(hostPage, ctx.gameId, 'DAY_DISCUSSION', 15_000)
+
+    // Host reveals N2 result (whatever it was — depends on whether witch
+    // had antidote remaining; in this spec test 4 spent it, so N2 kills land).
+    const revealBtn = hostPage.getByTestId('day-reveal-result')
+    await revealBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await revealBtn.click()
+    await captureSnapshot(ctx.pages, testInfo, '09-day2-reveal')
+
+    // Host opens voting.
+    const startVoteBtn = hostPage.getByTestId('day-start-vote')
+    await startVoteBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await startVoteBtn.click()
+    await waitForVotingSubPhase(hostPage, ctx.gameId, 'VOTING', 10_000)
+
+    // Host abstains first so the bot fan-out doesn't burn act.sh's retry
+    // quota on the host (already-voted check).
+    const hostId = await readHostUserId(hostPage)
+    const abstainBtn = hostPage.locator('.skip-btn').first()
+    await abstainBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await abstainBtn.click()
+    if (hostId) {
+      await waitForVoteRegistered(hostPage, ctx.gameId, hostId, 5_000)
+    }
+
+    // Pick the next alive wolf as target. roleMap is from setup-time, but
+    // we filter by the live-alive set so a dead bot from test 7 isn't
+    // chosen.
+    const aliveIds = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+      if (!res.ok) return [] as string[]
+      const state = await res.json()
+      return ((state?.players ?? []) as Array<{ isAlive?: boolean; userId: string }>)
+        .filter((p) => p.isAlive !== false)
+        .map((p) => p.userId)
+    }, ctx.gameId)
+    const aliveSet = new Set(aliveIds)
+    const wolfTarget = (ctx.roleMap.WEREWOLF ?? []).find(
+      (b) => b.nick !== 'Host' && aliveSet.has(b.userId),
+    )
+    expect(wolfTarget, 'expected an alive non-host wolf for D2 vote').toBeDefined()
+
+    // Fan out the vote across alive non-host bots that haven't already voted.
+    const unvoted = await readUnvotedAlivePlayerIds(hostPage, ctx.gameId)
+    const expectedVoterIds: string[] = []
+    for (const bot of ctx.allBots) {
+      if (bot.nick === 'Host' || bot.userId === hostId) continue
+      if (!unvoted.has(bot.userId)) continue
+      act('SUBMIT_VOTE', bot.nick, { target: String(wolfTarget!.seat), room: ctx.roomCode })
+      expectedVoterIds.push(bot.userId)
+    }
+    if (expectedVoterIds.length > 0) {
+      await waitForAllVotesRegistered(hostPage, ctx.gameId, expectedVoterIds, 10_000)
+    }
+
+    // Reveal tally.
+    const revealTallyBtn = hostPage.getByTestId('voting-reveal')
+    await revealTallyBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await revealTallyBtn.click()
+    await waitForVotingSubPhase(hostPage, ctx.gameId, 'VOTE_RESULT', 6_000)
+
+    await captureSnapshot(ctx.pages, testInfo, '09-day2-tally')
+
+    // Continue to night.
+    const continueBtn = hostPage.getByTestId('voting-continue')
+    const continueVisible = await continueBtn
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false)
+    if (continueVisible) {
+      await continueBtn.click()
+    }
+
+    // Either game continues to N3 (wolves > 0), or it ends right here
+    // (POST_VOTE check fired villager-win because we voted the second
+    // wolf and the third was killed somewhere already — unusual but
+    // possible if a witch poisoned earlier). Both are valid outcomes;
+    // this test asserts the deterministic part: the vote machinery
+    // produced a sub-phase transition.
+    if (!hostPage.url().includes('/result/')) {
+      await waitForPhase(hostPage, ctx.gameId, 'NIGHT', 15_000)
+      await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 15_000)
+    }
+    await captureSnapshot(ctx.pages, testInfo, '09-day2-complete')
+  })
+
+  // ── Test 10: Night 3 cycle ────────────────────────────────────────────
+  // Verifies the night machinery still cycles on day 3 — same loop as
+  // test 8 but one round later, after another wolf and another villager
+  // have been eliminated. The browser-bound role bot may have died at
+  // any point; each role tries DOM first, then falls back to API on
+  // remaining live bots.
+
+  test('10. Night 3 — cycle continues past day 2, transitions back to DAY day=3', async ({}, testInfo) => {
+    // If the game ended at D2 (test 9 hit a villager-win edge), there's
+    // nothing to test here — assert that fact and exit cleanly. NOT a
+    // skip: a clean exit with a captured screenshot is the correct
+    // outcome for the early-end branch.
+    if (ctx.hostPage.url().includes('/result/')) {
+      const finalState = await ctx.hostPage.evaluate(async (id: string) => {
+        const token = localStorage.getItem('jwt')
+        const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+        return res.ok ? res.json() : null
+      }, ctx.gameId)
+      expect(finalState?.phase, 'game ended at D2 — expected GAME_OVER').toBe('GAME_OVER')
+      await captureSnapshot(ctx.pages, testInfo, '10-game-over-at-d2')
+      return
+    }
+
+    // Precondition: NIGHT day=3 / WEREWOLF_PICK after test 9.
+    expect(
+      await waitForPhase(ctx.hostPage, ctx.gameId, 'NIGHT', 15_000),
+      'expected NIGHT day=3 after test 9',
+    ).toBe(true)
+    expect(
+      await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 15_000),
+      'expected NIGHT/WEREWOLF_PICK on day=3 entry',
+    ).toBe(true)
+
+    // Helper: wrap script call to surface rejections (same idiom as test 8).
+    const tryAct = (...args: Parameters<typeof act>): boolean => {
+      try {
+        const out = act(...args)
+        const rejected = out.includes('rejected')
+        if (rejected) {
+          // eslint-disable-next-line no-console
+          console.warn(`[tryAct rejected] args=${JSON.stringify(args)} output=\n${out}`)
+        }
+        return !rejected
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn(`[tryAct threw] args=${JSON.stringify(args)} err=${(e as Error).message}`)
+        return false
+      }
+    }
+
+    // Read live alive set from the API for live filtering of role bots.
+    const aliveIds = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+      if (!res.ok) return [] as string[]
+      const state = await res.json()
+      return ((state?.players ?? []) as Array<{ isAlive?: boolean; userId: string }>)
+        .filter((p) => p.isAlive !== false)
+        .map((p) => p.userId)
+    }, ctx.gameId)
+    const aliveSet = new Set(aliveIds)
+
+    const wolfBot = (ctx.roleMap.WEREWOLF ?? []).find((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
+    const seerBot = (ctx.roleMap.SEER ?? []).find((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
+    const witchBot = (ctx.roleMap.WITCH ?? []).find((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
+    const guardBot = (ctx.roleMap.GUARD ?? []).find((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
+
+    const isVisibleSoon = async (page: Page, testId: string, timeoutMs = 5_000) =>
+      page
+        .getByTestId(testId)
+        .waitFor({ state: 'visible', timeout: timeoutMs })
+        .then(() => true)
+        .catch(() => false)
+
+    // ── Wolf kill ──
+    // After 2 day votes (test 7 + test 9), the originally browser-bound
+    // WEREWOLF bot may be dead (voted out). The remaining alive wolf can
+    // be the host (when host rolled WEREWOLF) — in which case `wolfBot`
+    // (filtered to non-host) is undefined, but ctx.pages.get('WEREWOLF')
+    // === hostPage (per setupGame's mapping at multi-browser.ts:362-364)
+    // and the host's wolf-kill UI is rendered. DOM-first via the wolf
+    // page handles host-as-wolf cleanly; API fallback handles the case
+    // where the wolf page's bot is dead but another wolf bot is alive.
+    const wolfPage = ctx.pages.get('WEREWOLF')
+    let wolfDone = false
+    if (wolfPage && (await isVisibleSoon(wolfPage, 'wolf-confirm-kill'))) {
+      const targetSlot = wolfPage.locator('.player-grid .slot-alive').first()
+      const slotReady = await targetSlot
+        .waitFor({ state: 'visible', timeout: 2_000 })
+        .then(() => true)
+        .catch(() => false)
+      if (slotReady) {
+        await targetSlot.click()
+        await wolfPage.getByTestId('wolf-confirm-kill').click()
+        wolfDone = true
+        await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 8_000)
+      }
+    }
+    if (!wolfDone) {
+      // wolfPage's bot is dead OR UI didn't render. Try API on remaining
+      // alive non-host wolf bots.
+      const wolfTargetCandidate = ctx.allBots.find(
+        (b) =>
+          b.nick !== 'Host' &&
+          aliveSet.has(b.userId) &&
+          !(ctx.roleMap.WEREWOLF ?? []).some((w) => w.userId === b.userId),
+      )
+      if (wolfBot && wolfTargetCandidate) {
+        tryAct('WOLF_KILL', actName(wolfBot), { target: String(wolfTargetCandidate.seat), room: ctx.roomCode })
+        await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 8_000)
+      }
+    }
+
+    // ── Seer check (just to advance the phase) ──
+    if (seerBot) {
+      const reached = await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'SEER_PICK', 10_000)
+      if (reached) {
+        const checkTarget = ctx.allBots.find(
+          (b) => b.userId !== seerBot.userId && b.nick !== 'Host' && aliveSet.has(b.userId),
+        )
+        if (checkTarget) {
+          tryAct('SEER_CHECK', actName(seerBot), { target: String(checkTarget.seat), room: ctx.roomCode })
+          await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'SEER_RESULT', 8_000)
+          tryAct('SEER_CONFIRM', actName(seerBot), { room: ctx.roomCode })
+        }
+      }
+    }
+
+    // ── Witch act: by N3 the antidote is spent (test 4 used it). Just decline. ──
+    if (witchBot) {
+      const reached = await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'WITCH_ACT', 10_000)
+      if (reached) {
+        tryAct('WITCH_ACT', actName(witchBot), {
+          room: ctx.roomCode,
+          payload: '{"useAntidote":false}',
+        })
+      }
+    }
+
+    // ── Guard skip ──
+    // GUARD_PROTECT carries a "cannot protect the same player two nights in
+    // a row" rule (verified empirically — backend log on N3 with bot3
+    // chosen at N2 returned `REJECTED reason="Cannot protect the same
+    // player two nights in a row"`). Picking a deterministic-different
+    // target across nights is brittle (the UI's `.slot-alive .first()`
+    // ordering changes once kill targets are recorded). GUARD_SKIP doesn't
+    // have this constraint — same as test 8's API fallback. Use it here to
+    // advance the night cleanly.
+    if (guardBot) {
+      const reached = await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'GUARD_PICK', 10_000)
+      if (reached) {
+        const advanced = tryAct('GUARD_SKIP', actName(guardBot), { room: ctx.roomCode })
+        if (advanced) {
+          await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'GUARD_PICK', 8_000)
+        }
+      }
+    }
+
+    // Backend transitions to DAY day=3 (or GAME_OVER if last wolf died at N3,
+    // which is impossible since wolves don't kill themselves — so DAY is
+    // the only valid outcome here).
+    await waitForPhase(ctx.hostPage, ctx.gameId, 'DAY_DISCUSSION', 20_000)
+    await verifyAllBrowsersPhase(ctx.pages, 'DAY', 20_000)
+    await captureSnapshot(ctx.pages, testInfo, '10-night3-complete')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Day 1 outcome scenarios — each reachable post-D1 end-state from the table in
+// PR #75's review thread, asserted explicitly.
+//
+//   Row 1 (NIGHT/day=2)         — covered by the main flow's test 8.
+//   Row 2 (GAME_OVER, villager) — this section.
+//   Row 3 (GAME_OVER, wolves)   — this section.
+//   Row 4 (HUNTER_SHOOT)        — this section.
+//   Row 5 (BADGE_HANDOVER)      — covered by `flow-12p-sheriff.spec.ts` (CLASSIC + HARD_MODE).
+//                                 Not reachable here: this spec uses hasSheriff=false.
+//
+// Each scenario starts a fresh `setupGame` because the kill plan needed to
+// produce that end-state is incompatible with the prior test's game state.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
+  test.setTimeout(180_000)
+
+  // ── Row 2: villager-win when D1 vote eliminates the last wolf ──
+  test('row 2 — villager-win after D1 vote kills the last wolf', async ({ browser }, testInfo) => {
+    testInfo.setTimeout(240_000)
+    // 6p kit: GameService.kt:316 → 2 wolves. Plus SEER + WITCH + 2 villagers
+    // (HUNTER and GUARD intentionally off so D1's elimination cleanly
+    // resolves to a win check, no HUNTER_SHOOT detour).
+    const localCtx = await setupGame(browser, {
+      totalPlayers: 6,
+      hasSheriff: false,
+      roles: ['WEREWOLF', 'SEER', 'WITCH', 'VILLAGER'] as RoleName[],
+      browserRoles: ['WEREWOLF', 'SEER', 'WITCH'] as RoleName[],
+    })
+    try {
+      const hostPage = localCtx.hostPage
+      // Don't filter host out: act.sh handles PLAYER='HOST' via the cached
+      // host token (act.sh:378), so a host-as-WITCH/SEER/WEREWOLF row is
+      // driveable through the same script path. The role lookup just needs
+      // to return whoever holds the role, host or bot.
+      const wolves = (localCtx.roleMap.WEREWOLF ?? [])
+      const seer = (localCtx.roleMap.SEER ?? [])[0]
+      const witch = (localCtx.roleMap.WITCH ?? [])[0]
+      expect(wolves.length, 'kit must have 2 wolves').toBe(2)
+      expect(seer, 'kit must have 1 seer').toBeDefined()
+      expect(witch, 'kit must have 1 witch').toBeDefined()
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[row 2] hostRole=${localCtx.hostRole} wolves=${wolves.map((b) => b.nick).join(',')} ` +
+          `seer=${seer.nick} witch=${witch.nick}`,
+      )
+
+      // Start night
+      await hostPage.getByTestId('start-night').click()
+      await waitForPhase(hostPage, localCtx.gameId, 'NIGHT', 15_000)
+
+      // ── N1 ──
+      // Wolves kill SOME victim. Backend rule (verified by log on a prior
+      // run: REJECTED reason="Cannot use antidote and poison on the same
+      // night"): witch can't use BOTH potions in one WITCH_ACT. So we
+      // use poison only — the wolf-kill victim dies, AND wolves[1] dies
+      // from poison. After N1: 2 deaths. wolves=1, humans=3. D1 vote of
+      // wolves[0] then closes out the wolves → villager-win.
+      const wolfIds = new Set(wolves.map((w) => w.userId))
+      const victim =
+        (localCtx.roleMap.VILLAGER ?? []).find((b) => !wolfIds.has(b.userId))
+        ?? localCtx.allBots.find((b) => !wolfIds.has(b.userId) && b.userId !== seer.userId && b.userId !== witch.userId)
+      expect(victim, 'need a non-wolf victim for the wolves to kill').toBeDefined()
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000)
+      act('WOLF_KILL', actName(wolves[0]), { target: String(victim!.seat), room: localCtx.roomCode })
+
+      // Seer checks (just to advance the phase deterministically).
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000)
+      act('SEER_CHECK', actName(seer), { target: String(wolves[0].seat), room: localCtx.roomCode })
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000)
+      act('SEER_CONFIRM', actName(seer), { room: localCtx.roomCode })
+
+      // Witch: poison-only on wolves[1]. No antidote (backend forbids
+      // combined antidote+poison in a single WITCH_ACT).
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000)
+      act('WITCH_ACT', actName(witch), {
+        room: localCtx.roomCode,
+        payload: JSON.stringify({
+          useAntidote: false,
+          poisonTargetUserId: wolves[1].userId,
+        }),
+      })
+
+      // Night resolves. victim dead (wolf kill, no save), wolves[1] dead (poison).
+      await waitForPhase(hostPage, localCtx.gameId, 'DAY_DISCUSSION', 20_000)
+
+      // ── D1 ──
+      await hostPage.getByTestId('day-reveal-result').click()
+      await hostPage.getByTestId('day-start-vote').click()
+      await waitForVotingSubPhase(hostPage, localCtx.gameId, 'VOTING', 10_000)
+
+      // Vote out wolves[0] (the surviving wolf). All bots vote target=seat.
+      // act.sh's "all" fan-out + the host's UI abstain combine to total all
+      // alive voters.
+      act('SUBMIT_VOTE', undefined, { target: String(wolves[0].seat), room: localCtx.roomCode })
+      const hostAbstain = hostPage.locator('.skip-btn').first()
+      if (await hostAbstain.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await hostAbstain.click()
+      }
+
+      // Reveal tally → wolf eliminated → POST_VOTE check sees wolves=0 → villager_win.
+      await hostPage.getByTestId('voting-reveal').click()
+
+      // Assert game-over state via the API (authoritative) AND the result URL.
+      await hostPage.waitForURL(/\/result\//, { timeout: 30_000 })
+      const finalState = await hostPage.evaluate(async (id: string) => {
+        const token = localStorage.getItem('jwt')
+        const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+        return res.ok ? res.json() : null
+      }, localCtx.gameId)
+      expect(finalState?.phase, 'phase=GAME_OVER expected').toBe('GAME_OVER')
+      expect(finalState?.winner, 'winner=VILLAGER expected').toBe('VILLAGER')
+      await captureSnapshot(localCtx.pages, testInfo, 'row2-villager-win')
+    } finally {
+      await localCtx.cleanup()
+    }
+  })
+
+  // ── Row 3: wolf-win at parity when D1 vote eliminates a villager ──
+  test('row 3 — wolf-win at parity after D1 mis-vote', async ({ browser }, testInfo) => {
+    testInfo.setTimeout(240_000)
+    const localCtx = await setupGame(browser, {
+      totalPlayers: 6,
+      hasSheriff: false,
+      roles: ['WEREWOLF', 'SEER', 'WITCH', 'VILLAGER'] as RoleName[],
+      browserRoles: ['WEREWOLF', 'SEER', 'WITCH'] as RoleName[],
+    })
+    try {
+      const hostPage = localCtx.hostPage
+      const wolves = localCtx.roleMap.WEREWOLF ?? []
+      const seer = (localCtx.roleMap.SEER ?? [])[0]
+      const witch = (localCtx.roleMap.WITCH ?? [])[0]
+      const villagers = localCtx.roleMap.VILLAGER ?? []
+      expect(wolves.length, 'kit must have 2 wolves').toBe(2)
+      expect(seer, 'kit must have 1 seer').toBeDefined()
+      expect(witch, 'kit must have 1 witch').toBeDefined()
+      expect(villagers.length, 'kit must have 2 villagers').toBe(2)
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[row 3] hostRole=${localCtx.hostRole} villagers=${villagers.map((b) => b.nick).join(',')}`,
+      )
+
+      await hostPage.getByTestId('start-night').click()
+      await waitForPhase(hostPage, localCtx.gameId, 'NIGHT', 15_000)
+
+      // ── N1 ── wolves kill villager-1, witch declines (villager-1 dies).
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000)
+      act('WOLF_KILL', actName(wolves[0]), { target: String(villagers[0].seat), room: localCtx.roomCode })
+
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000)
+      act('SEER_CHECK', actName(seer), { target: String(wolves[0].seat), room: localCtx.roomCode })
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000)
+      act('SEER_CONFIRM', actName(seer), { room: localCtx.roomCode })
+
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000)
+      act('WITCH_ACT', actName(witch), {
+        room: localCtx.roomCode,
+        payload: '{"useAntidote":false}',
+      })
+
+      // After N1: 2 wolves + 3 humans (host + seer + witch + villagers[1] minus villagers[0]).
+      await waitForPhase(hostPage, localCtx.gameId, 'DAY_DISCUSSION', 20_000)
+
+      // ── D1 ── vote villagers[1] (NOT a wolf). After D1: 2 wolves + 2 humans → parity.
+      await hostPage.getByTestId('day-reveal-result').click()
+      await hostPage.getByTestId('day-start-vote').click()
+      await waitForVotingSubPhase(hostPage, localCtx.gameId, 'VOTING', 10_000)
+
+      act('SUBMIT_VOTE', undefined, { target: String(villagers[1].seat), room: localCtx.roomCode })
+      const hostAbstain = hostPage.locator('.skip-btn').first()
+      if (await hostAbstain.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await hostAbstain.click()
+      }
+      await hostPage.getByTestId('voting-reveal').click()
+
+      await hostPage.waitForURL(/\/result\//, { timeout: 30_000 })
+      const finalState = await hostPage.evaluate(async (id: string) => {
+        const token = localStorage.getItem('jwt')
+        const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+        return res.ok ? res.json() : null
+      }, localCtx.gameId)
+      expect(finalState?.phase, 'phase=GAME_OVER expected').toBe('GAME_OVER')
+      expect(finalState?.winner, 'winner=WEREWOLF expected (parity)').toBe('WEREWOLF')
+      await captureSnapshot(localCtx.pages, testInfo, 'row3-wolf-win')
+    } finally {
+      await localCtx.cleanup()
+    }
+  })
+
+  // ── Row 4: HUNTER_SHOOT subPhase fires when hunter is voted out at D1 ──
+  test('row 4 — HUNTER_SHOOT subPhase when D1 votes the hunter', async ({ browser }, testInfo) => {
+    testInfo.setTimeout(240_000)
+    const localCtx = await setupGame(browser, {
+      totalPlayers: 9,
+      hasSheriff: false,
+      roles: ['WEREWOLF', 'SEER', 'WITCH', 'HUNTER', 'VILLAGER'] as RoleName[],
+      browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'HUNTER'] as RoleName[],
+    })
+    try {
+      const hostPage = localCtx.hostPage
+      // Don't filter host out: act.sh handles PLAYER='HOST' via host token.
+      const wolves = localCtx.roleMap.WEREWOLF ?? []
+      const seer = (localCtx.roleMap.SEER ?? [])[0]
+      const witch = (localCtx.roleMap.WITCH ?? [])[0]
+      const hunter = (localCtx.roleMap.HUNTER ?? [])[0]
+      const villagers = localCtx.roleMap.VILLAGER ?? []
+      expect(wolves.length, 'kit must have wolves').toBeGreaterThan(0)
+      expect(seer, 'kit must have a seer').toBeDefined()
+      expect(witch, 'kit must have a witch').toBeDefined()
+      expect(hunter, 'kit must have a hunter').toBeDefined()
+      expect(villagers.length, 'kit must have a villager for the wolf to kill').toBeGreaterThan(0)
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[row 4] hostRole=${localCtx.hostRole} hunter=${hunter.nick}(seat=${hunter.seat})`,
+      )
+
+      await hostPage.getByTestId('start-night').click()
+      await waitForPhase(hostPage, localCtx.gameId, 'NIGHT', 15_000)
+
+      // ── N1 ── wolves kill a villager. Witch saves them (no death) so D1
+      // alive count is full and the hunter-vote elimination is the only D1
+      // event.
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000)
+      act('WOLF_KILL', actName(wolves[0]), { target: String(villagers[0].seat), room: localCtx.roomCode })
+
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000)
+      act('SEER_CHECK', actName(seer), { target: String(wolves[0].seat), room: localCtx.roomCode })
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000)
+      act('SEER_CONFIRM', actName(seer), { room: localCtx.roomCode })
+
+      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000)
+      act('WITCH_ACT', actName(witch), {
+        room: localCtx.roomCode,
+        payload: '{"useAntidote":true}',
+      })
+
+      await waitForPhase(hostPage, localCtx.gameId, 'DAY_DISCUSSION', 20_000)
+
+      // ── D1 ── vote the hunter.
+      await hostPage.getByTestId('day-reveal-result').click()
+      await hostPage.getByTestId('day-start-vote').click()
+      await waitForVotingSubPhase(hostPage, localCtx.gameId, 'VOTING', 10_000)
+
+      act('SUBMIT_VOTE', undefined, { target: String(hunter.seat), room: localCtx.roomCode })
+      const hostAbstain = hostPage.locator('.skip-btn').first()
+      if (await hostAbstain.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await hostAbstain.click()
+      }
+      await hostPage.getByTestId('voting-reveal').click()
+
+      // Backend transitions to HUNTER_SHOOT (not VOTE_RESULT or GAME_OVER yet).
+      const reachedHunterShoot = await waitForVotingSubPhase(
+        hostPage,
+        localCtx.gameId,
+        'HUNTER_SHOOT',
+        15_000,
+      )
+      expect(reachedHunterShoot, 'expected DAY_VOTING/HUNTER_SHOOT after voting hunter out').toBe(true)
+      await captureSnapshot(localCtx.pages, testInfo, 'row4-hunter-shoot-entered')
+
+      // Drive the hunter's pass (no shoot) so the game can advance — the
+      // important contract here is the SUB-PHASE TRANSITION, not which seat
+      // hunter targets.
+      act('HUNTER_PASS', actName(hunter), { room: localCtx.roomCode })
+
+      // Sub-phase advances out of HUNTER_SHOOT (to VOTE_RESULT, NIGHT, or
+      // GAME_OVER depending on remaining state). Either is acceptable —
+      // we're not asserting a specific downstream state, only that the
+      // transition out of HUNTER_SHOOT happened.
+      await waitForCondition(
+        async () => {
+          const state = await hostPage.evaluate(async (id: string) => {
+            const token = localStorage.getItem('jwt')
+            const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+            return res.ok ? res.json() : null
+          }, localCtx.gameId)
+          return state?.votingPhase?.subPhase !== 'HUNTER_SHOOT'
+        },
+        'sub-phase to leave HUNTER_SHOOT after HUNTER_PASS',
+        10_000,
+      )
+      await captureSnapshot(localCtx.pages, testInfo, 'row4-hunter-shoot-resolved')
+    } finally {
+      await localCtx.cleanup()
+    }
   })
 })

--- a/frontend/e2e/real/helpers/shell-runner.ts
+++ b/frontend/e2e/real/helpers/shell-runner.ts
@@ -181,18 +181,33 @@ export function readStateFile(roomCode: string): StateFile {
 }
 
 /**
+ * Permanent rejection reasons — rule / state-violation rejections that retrying
+ * cannot fix (the actor is dead, the action was already taken, the target was
+ * already eliminated, etc.). When the backend emits one of these, retries
+ * waste ~1.8 s each AND mask the bug — the test was wrong to call act() with
+ * those args, and the right fix is upstream filtering, not retry-and-pray.
+ *
+ * Transient rejections (sub-phase commit lag, brief coroutine races) are NOT
+ * matched here and still get the 3-attempt retry. Add new permanent reasons
+ * here as the backend grows, but don't add anything that can become valid on
+ * retry.
+ */
+const PERMANENT_REJECTION_RE =
+  /Actor is dead|Target is dead|Cannot protect the same player two nights in a row|Cannot use antidote and poison on the same night|Action already taken|Already (voted|campaigned|signed up)|Only host can|No active (night|voting) phase|Player not found|already exists/i
+
+/**
  * Run act.sh with the given action.
  *
  * Returns raw stdout (stripped of ANSI codes).
  *
- * On CI, retries up to 3 times on "rejected" output with a 600ms gap. This
- * absorbs the well-known race where a bot action fires faster than the
- * role-loop coroutine advances, lands in the wrong sub-phase, and is
- * rejected. Locally the coroutine is fast enough that retries rarely trigger.
+ * On CI, retries up to 3 times on "rejected" output with a 600ms gap, but
+ * ONLY for transient rejections (sub-phase commit lag race). Permanent
+ * rejections — see PERMANENT_REJECTION_RE — short-circuit on the first
+ * attempt: retry won't change a dead actor or a duplicate action, and the
+ * 1.8 s retry budget hides upstream filtering bugs. Locally maxAttempts=1.
  *
- * Every rejection — whether recovered or not — is logged via console.warn so
- * genuine rejections (target dead, action already taken, etc.) still surface
- * in CI logs rather than being absorbed silently.
+ * Every rejection — recovered, fast-failed, or final — is logged via
+ * console.warn so they still surface in CI logs rather than being silent.
  */
 export function act(
   action: string,
@@ -217,12 +232,14 @@ export function act(
     // current phase/sub-phase. Cuts the "Target not found or dead" mystery
     // down to "target was already killed in N1" without manual digging.
     const context = describeRejectionContext(opts?.room, player, opts?.target)
+    const isPermanent = PERMANENT_REJECTION_RE.test(output)
     // eslint-disable-next-line no-console
     console.warn(
       `[act rejected] attempt ${attempt}/${maxAttempts} action=${action} ` +
         `player=${player ?? '-'} target=${opts?.target ?? '-'} ` +
-        `room=${opts?.room ?? '-'}${context}\noutput:\n${output}`,
+        `room=${opts?.room ?? '-'}${isPermanent ? ' (permanent — no retry)' : ''}${context}\noutput:\n${output}`,
     )
+    if (isPermanent) return output
     if (attempt < maxAttempts) {
       // Synchronous sleep — act() is sync and changing it to async would
       // ripple through every spec. execSync('sleep 0.6') blocks this worker

--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -52,11 +52,23 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
   // ── Test 2: Players sign up, button changes ────────────────────────────
 
   test('2. Sheriff signup — browser player signs up, button changes', async ({}, testInfo) => {
-    // Use seer browser to sign up for sheriff
+    // Use seer browser to sign up for sheriff. setupGame is invariably
+    // configured with browserRoles including 'SEER' (line 23 of beforeAll),
+    // and helpers/multi-browser.ts:362-405 either maps hostPage to the SEER
+    // entry (when host rolled SEER) or opens a new context for the first
+    // non-host SEER bot. roleMap.SEER is always non-empty because the 9p
+    // role distribution always includes one SEER (GameService.kt:322 runs
+    // when room.hasSeer is true, the CreateRoom default). So `seerPage`
+    // can never be undefined here. Replace the dead `test.skip()` with a
+    // throw that surfaces the diagnostic if a future change ever
+    // invalidates that invariant.
     const seerPage = ctx.pages.get('SEER')
     if (!seerPage) {
-      test.skip()
-      return
+      throw new Error(
+        `ctx.pages.get('SEER') is undefined — setupGame did not assign a SEER page. ` +
+          `Check beforeAll's browserRoles (must include 'SEER') and the role kit ` +
+          `(room.hasSeer must be true). hostRole=${ctx.hostRole}.`,
+      )
     }
 
     // Click "Run for Sheriff" button

--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -6,9 +6,10 @@
  */
 import {expect, test} from '@playwright/test'
 import {type GameContext, setupGame} from './helpers/multi-browser'
-import {act, type RoleName, sheriff} from './helpers/shell-runner'
+import {act, actName, type RoleName, sheriff} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase,} from './helpers/assertions'
 import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
+import {waitForCondition} from './helpers/state-polling'
 
 let ctx: GameContext
 
@@ -52,16 +53,20 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
   // ── Test 2: Players sign up, button changes ────────────────────────────
 
   test('2. Sheriff signup — browser player signs up, button changes', async ({}, testInfo) => {
-    // Use seer browser to sign up for sheriff. setupGame is invariably
-    // configured with browserRoles including 'SEER' (line 23 of beforeAll),
-    // and helpers/multi-browser.ts:362-405 either maps hostPage to the SEER
-    // entry (when host rolled SEER) or opens a new context for the first
-    // non-host SEER bot. roleMap.SEER is always non-empty because the 9p
-    // role distribution always includes one SEER (GameService.kt:322 runs
-    // when room.hasSeer is true, the CreateRoom default). So `seerPage`
-    // can never be undefined here. Replace the dead `test.skip()` with a
-    // throw that surfaces the diagnostic if a future change ever
-    // invalidates that invariant.
+    // Strong contract — three things this test exercises that no other
+    // sheriff-flow test does:
+    //   (a) The seer's browser shows `sheriff-run` while in SIGNUP.
+    //   (b) Clicking it round-trips through STOMP and the same browser
+    //       sees `sheriff-withdraw` (proves signup registered + state
+    //       broadcast back to the originating browser).
+    //   (c) Bot campaigns submitted via the REST script appear in the
+    //       seer's candidate list (cross-browser STOMP fan-out).
+    //
+    // Earlier versions wrapped (b) in `if (await runBtn.isVisible())` and
+    // (c) in `try { ... } catch {}`, so the test passed silently even when
+    // the signup feature was completely broken. Same anti-pattern as
+    // `test.skip()` — replaced with positive assertions.
+
     const seerPage = ctx.pages.get('SEER')
     if (!seerPage) {
       throw new Error(
@@ -71,29 +76,57 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
       )
     }
 
-    // Click "Run for Sheriff" button
+    // Wait for SHERIFF_ELECTION/SIGNUP — only sub-phase where `sheriff-run`
+    // renders. Backend may take a moment after role-reveal-end to enter it.
+    await waitForCondition(
+      async () => {
+        const state = await seerPage.evaluate(async (id: string) => {
+          const token = localStorage.getItem('jwt')
+          const res = await fetch(`/api/game/${id}/state`, {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          return res.ok ? res.json() : null
+        }, ctx.gameId)
+        return state?.sheriffElection?.subPhase === 'SIGNUP'
+      },
+      'sheriffElection.subPhase to reach SIGNUP',
+      15_000,
+    )
+
+    // (a) sheriff-run must render. If it doesn't, that's a regression in
+    //     SheriffElection.vue's signup template (or an aliveness bug).
     const runBtn = seerPage.getByTestId('sheriff-run')
-    if (await runBtn.isVisible().catch(() => false)) {
-      await runBtn.click()
+    await expect(runBtn).toBeVisible({ timeout: 10_000 })
 
-      // Verify: button should change to "Withdraw"
-      await expect(
-        seerPage.getByTestId('sheriff-withdraw'),
-      ).toBeVisible({ timeout: 5_000 })
-    }
+    // (b) Click → button toggles to "Withdraw" (signup confirmed).
+    await runBtn.click()
+    await expect(seerPage.getByTestId('sheriff-withdraw')).toBeVisible({
+      timeout: 10_000,
+    })
 
-    // Have some bots campaign via script
+    // (c) Drive 3 bot campaigns via script and assert all 3 appear in the
+    //     seer's candidate list (1 self-signup + 3 bots = 4 candidates).
+    //     Filter Host out: the seer just signed up via the seerPage click;
+    //     if host rolled SEER, seerPage IS hostPage and the host is already
+    //     in the list — feeding host into `sheriff campaign` here would be
+    //     a duplicate signup that the backend rejects.
     const wolfBots = ctx.roleMap.WEREWOLF ?? []
     const villagerBots = ctx.roleMap.VILLAGER ?? []
-    const campaigners = [...wolfBots.slice(0, 1), ...villagerBots.slice(0, 2)]
-
+    const campaigners = [...wolfBots.slice(0, 1), ...villagerBots.slice(0, 2)].filter(
+      (b) => b.nick !== 'Host',
+    )
+    expect(campaigners.length, 'need at least one non-host bot to campaign').toBeGreaterThan(0)
     for (const bot of campaigners) {
-      try {
-        sheriff('campaign', { player: bot.nick, room: ctx.roomCode })
-      } catch {
-        // Some may already have signed up or phase moved on
-      }
+      sheriff('campaign', { player: actName(bot), room: ctx.roomCode })
     }
+
+    // Candidate count on the seer's UI = 1 (self) + campaigners.length,
+    // propagated via STOMP. toHaveCount retries until the count matches
+    // or the timeout expires, so this naturally waits for STOMP delivery.
+    await expect(seerPage.locator('.cand-row-running')).toHaveCount(
+      1 + campaigners.length,
+      { timeout: 10_000 },
+    )
 
     await captureSnapshot(ctx.pages, testInfo, 'sheriff-02-signup-done')
   })


### PR DESCRIPTION
## Summary

Two related changes shipped together — both un-skip / harden the real-backend E2E suite around the day-1 → day-2 transition and beyond.

### 1. `sheriff-flow.spec.ts` test 2 — remove dead `!seerPage` guard

```typescript
const seerPage = ctx.pages.get('SEER')
if (!seerPage) {
  test.skip()
  return
}
```

Branch is unreachable in the spec's 9p config: `beforeAll` always sets `browserRoles: ['WEREWOLF', 'SEER', 'VILLAGER']`, `multi-browser.ts:362-405` always assigns a SEER page (host or bot), and `GameService.kt:322` always produces one SEER (CreateRoomView defaults `hasSeer=true`). Replaced with a defensive `throw new Error(...)` that surfaces a diagnostic if a future change invalidates the invariant. Same pattern as PR #74.

### 2. `game-flow.spec.ts` — day 2/3 cycling tests + Day 1 end-state rows

Added 5 new tests across two describes:

**Main describe (continuation of tests 1-7):**
- **Test 8 (modified)** — replaced the existing `throw new Error(...)` bypass with explicit `expect(waitForPhase / waitForNightSubPhase).toBe(true)` assertions. The throw was a CI-coverage hole (same as `test.skip()`); the assertions surface the actual phase/sub-phase from `/api/game/state` when the precondition contract breaks.
- **Test 9 (new)** — Day 2 voting cycle: host reveals N2 result, opens vote, abstains via UI, fans the vote across alive non-host non-voted bots (`waitForAllVotesRegistered`), reveals tally, continues to N3.
- **Test 10 (new)** — Night 3 cycle: same DOM-first / API-fallback pattern as test 8 ported one round later. Uses `GUARD_SKIP` not `GUARD_PROTECT` because the backend rejects two-night-same-target with `Cannot protect the same player two nights in a row` (verified from prior backend log).

**New `Day 1 outcome scenarios` describe — explicit per-row coverage:**
Each row from PR #75's review-thread post-D1 outcome table gets its own `setupGame` because the kill plan to reach each end-state is incompatible with the prior test's game state.

| Row | End state | Kit | Plan |
|---|---|---|---|
| 2 | `GAME_OVER` / VILLAGER | 6p (2W + S + Wi + 2V) | N1: wolf kill V1 + witch poison W2 (poison-only — backend forbids combined antidote+poison in one `WITCH_ACT`). D1: vote W1 → wolves=0 → villager-win. |
| 3 | `GAME_OVER` / WEREWOLF | 6p | N1: wolf kill V1, witch declines. D1: vote V2 → 2W vs 2H parity → wolf-win. |
| 4 | `DAY_VOTING / HUNTER_SHOOT` | 9p (2W + S + Wi + Hu + Vs) | N1: witch saves wolf-killed villager. D1: vote hunter → asserts `votingPhase.subPhase=HUNTER_SHOOT`, drives `HUNTER_PASS`, asserts sub-phase leaves HUNTER_SHOOT. |

Row 1 (NIGHT/day=2) is covered by the main flow's test 8. Row 5 (BADGE_HANDOVER) requires `hasSheriff=true` and lives in `flow-12p-sheriff.spec.ts` (CLASSIC + HARD_MODE, PRs #67 + #68).

None of the rows filter `b.nick !== 'Host'` — `act.sh:378` resolves `PLAYER='HOST'` to the cached host token, so all host-as-special-role permutations route through the same script path.

## Verification

- `npx vue-tsc --noEmit` clean (exit 0).
- `npx playwright test --config=playwright.real.config.ts e2e/real/game-flow.spec.ts` — **13 passed (3.0m)** in one local run, covering tests 1-10 + rows 2/3/4.
- Row 2 alone re-run after the witch payload fix: **1 passed (34.8s)**. Original failure was `REJECTED reason="Cannot use antidote and poison on the same night"` triangulated from `/tmp/werewolf-e2e-backend.log`; fix is poison-only.

## Test plan

- [ ] CI · Lint & Test passes.
- [ ] CI · Backend Build & Test passes.
- [ ] CI · E2E · UI shards pass.
- [ ] CI · E2E · Integration shards pass (game-flow + sheriff-flow both run in this matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)