### PR TITLE
test(e2e): replace silent-pass anti-patterns + eliminate act-rejection log spam

### DIFF
--- a/frontend/e2e/real/flow-12p-sheriff.spec.ts
+++ b/frontend/e2e/real/flow-12p-sheriff.spec.ts
@@ -35,6 +35,17 @@ interface RolePlayer {
 }
 
 /**
+ * `expect(value).not.toBeNull()` doesn't narrow via TypeScript flow analysis,
+ * so callers still see `T | null` after the assertion. This helper uses a TS
+ * assertion signature so subsequent reads of `value` are non-null without
+ * resorting to a non-null bang at every call site.
+ */
+function assertNonNull<T>(value: T | null | undefined, msg: string): asserts value is T {
+  expect(value, msg).not.toBeNull()
+  expect(value, msg).not.toBeUndefined()
+}
+
+/**
  * Resolve `role` to its bot OR to the host (whoever holds it). Returns null
  * only if neither holds the role (impossible if the role is in the kit).
  */
@@ -836,19 +847,24 @@ test.describe('12p sheriff — CLASSIC villager win', () => {
       round++
     }
 
-    // Expect GAME_OVER — verify result screen
-    await ctx.hostPage.waitForURL(/\/result\//, { timeout: 60_000 }).catch(() => {})
-    await captureSnapshot(ctx.pages, testInfo, 'classic-99-result-screen')
-
-    const onResult = ctx.hostPage.url().includes('/result/')
-    if (!onResult) {
-      // Not necessarily a failure — capture diagnostic and flag it
-      const currentPhase = await ctx.hostPage.evaluate(() => {
-        const el = document.querySelector('[data-testid="current-phase"]')
-        return el?.textContent ?? document.body.className
+    // Expect GAME_OVER — assert via authoritative API state, not URL.
+    // STOMP-driven router.push to /result lags backend commit by 200-500ms
+    // (longer on CI), so URL-only detection is racy.
+    const finalPhase = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
       })
-      throw new Error(`Villager-win scenario did not reach /result in 6 rounds. Current host state: ${currentPhase}`)
-    }
+      return res.ok ? (await res.json())?.phase : null
+    }, ctx.gameId)
+    expect(
+      finalPhase,
+      `villager-win plan must reach GAME_OVER within ${maxRounds} rounds — actual phase=${finalPhase}`,
+    ).toBe('GAME_OVER')
+
+    // Wait for the result-screen redirect so the outcome title renders.
+    await ctx.hostPage.waitForURL(/\/result\//, { timeout: 60_000 })
+    await captureSnapshot(ctx.pages, testInfo, 'classic-99-result-screen')
 
     await expect(ctx.hostPage.locator('.outcome-title')).toBeVisible({ timeout: 10_000 })
     const winner = (await ctx.hostPage.locator('.outcome-title').textContent()) ?? ''
@@ -905,11 +921,9 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     const seer = await resolveRolePlayer(ctx, 'SEER')
     const guard = await resolveRolePlayer(ctx, 'GUARD')
     const witch = await resolveRolePlayer(ctx, 'WITCH')
-    if (!seer || !guard || !witch) {
-      throw new Error(
-        `Missing special role player — seer=${!!seer} guard=${!!guard} witch=${!!witch} (hostRole=${ctx.hostRole})`,
-      )
-    }
+    assertNonNull(seer, `kit must have a SEER (bot or host=${ctx.hostRole})`)
+    assertNonNull(guard, `kit must have a GUARD (bot or host=${ctx.hostRole})`)
+    assertNonNull(witch, `kit must have a WITCH (bot or host=${ctx.hostRole})`)
     // eslint-disable-next-line no-console
     console.warn(
       `[hard-mode test] resolved roles — seer=${seer.nick}(seat=${seer.seat},host=${seer.isHost}) ` +
@@ -922,9 +936,10 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
       .filter((b) => b.nick !== 'Host')
       .map((b) => b.seat)
       .filter((s) => !wolfSeats.has(s))
-    if (villagerSeats.length < 1) {
-      throw new Error(`Need at least one non-host villager seat for D2 vote-out; got ${villagerSeats.length}`)
-    }
+    expect(
+      villagerSeats.length,
+      `D2 vote-out plan needs at least one non-host non-wolf villager seat`,
+    ).toBeGreaterThanOrEqual(1)
 
     // Sheriff election — only the seer campaigns. After speeches + votes
     // the seer holds the badge.
@@ -958,13 +973,15 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     // badge UI. Park the badge on a non-host wolf so the sheriff never
     // moves again (wolves don't get voted, don't kill themselves).
     const seerPage = ctx.pages.get('SEER')
-    if (!seerPage) {
-      throw new Error('No SEER browser page in ctx — cannot drive badge handover via DOM')
-    }
+    assertNonNull(
+      seerPage,
+      'badge-handover needs the SEER browser page — only the eliminated sheriff sees the pass-badge UI',
+    )
     const badgeWolfBot = wolfBots.find((b) => b.nick !== 'Host')
-    if (!badgeWolfBot) {
-      throw new Error('No non-host wolf available to receive the badge')
-    }
+    assertNonNull(
+      badgeWolfBot,
+      'a non-host wolf is needed as the badge recipient so the badge stays put for the rest of the test',
+    )
     await completeDay(
       ctx,
       testInfo,
@@ -975,9 +992,20 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     )
     await ctx.hostPage.waitForTimeout(2_000)
 
-    if (ctx.hostPage.url().includes('/result/')) {
-      throw new Error('Game ended at D1 vote-out — wolf-win plan expected to need 2 nights')
-    }
+    // Plan needs 2 nights: D1 vote-out fires BADGE_HANDOVER + post-vote win
+    // check, but counterplay (witch + alive humans) keeps it from ending.
+    // Use API state, not URL — STOMP /result/ redirect lags backend commit.
+    const phaseAfterD1 = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? (await res.json())?.phase : null
+    }, ctx.gameId)
+    expect(
+      phaseAfterD1,
+      'wolf-win plan needs 2 nights — D1 vote-out should NOT end the game',
+    ).not.toBe('GAME_OVER')
 
     // N2: wolves kill the WITCH. Witch sees herself as the wolves' target
     // during WITCH_ACT but the `useAntidote: false` payload (in
@@ -987,10 +1015,18 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     await ctx.hostPage.waitForTimeout(2_500)
     await captureSnapshot(ctx.pages, testInfo, 'hard-06-night-2-done')
 
-    if (ctx.hostPage.url().includes('/result/')) {
-      // Edge: witch self-action timing meant POST_NIGHT literal-humans-zero
-      // didn't apply, but if the game already wrapped (e.g. wolves got
-      // parity post-night via cascading death) capture and assert.
+    // Edge: if N2 already wrapped the game (wolves got parity via cascading
+    // death), capture and assert wolf-win here. Use API state — STOMP
+    // /result/ redirect lags backend GAME_OVER commit.
+    const phaseAfterN2 = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? (await res.json())?.phase : null
+    }, ctx.gameId)
+    if (phaseAfterN2 === 'GAME_OVER') {
+      await ctx.hostPage.waitForURL(/\/result\//, { timeout: 30_000 })
       await captureSnapshot(ctx.pages, testInfo, 'hard-99-result-screen')
       await expect(ctx.hostPage.locator('.outcome-title')).toBeVisible({ timeout: 10_000 })
       const winnerEarly = (await ctx.hostPage.locator('.outcome-title').textContent()) ?? ''
@@ -1006,15 +1042,21 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     await completeDay(ctx, testInfo, villagerSeats[0], 'hard-07-day-2')
     await ctx.hostPage.waitForTimeout(2_000)
 
-    await ctx.hostPage.waitForURL(/\/result\//, { timeout: 60_000 }).catch(() => {})
-    await captureSnapshot(ctx.pages, testInfo, 'hard-99-result-screen')
+    // Authoritative GAME_OVER assertion via API, not URL.
+    const phaseAfterD2 = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? (await res.json())?.phase : null
+    }, ctx.gameId)
+    expect(
+      phaseAfterD2,
+      `HARD_MODE plan must reach GAME_OVER after N1(guard)+D1(seer)+N2(witch)+D2(villager) — actual=${phaseAfterD2}`,
+    ).toBe('GAME_OVER')
 
-    if (!ctx.hostPage.url().includes('/result/')) {
-      throw new Error(
-        `HARD_MODE wolf-win scenario did not reach /result after N1(guard)+D1(seer)+N2(witch)+D2(villager). ` +
-          `Current URL=${ctx.hostPage.url()}`,
-      )
-    }
+    await ctx.hostPage.waitForURL(/\/result\//, { timeout: 60_000 })
+    await captureSnapshot(ctx.pages, testInfo, 'hard-99-result-screen')
 
     await expect(ctx.hostPage.locator('.outcome-title')).toBeVisible({ timeout: 10_000 })
     const winner = (await ctx.hostPage.locator('.outcome-title').textContent()) ?? ''

--- a/frontend/e2e/real/flow-12p-sheriff.spec.ts
+++ b/frontend/e2e/real/flow-12p-sheriff.spec.ts
@@ -443,7 +443,14 @@ async function completeNight(ctx: GameContext, targetSeat: number, seerCheckSeat
   const resolvedTargetSeatNum = typeof resolvedTargetSeat === 'string' ? Number(resolvedTargetSeat) : resolvedTargetSeat
 
   // ── WEREWOLF_PICK ──
-  await waitForSubPhase(hostPage, gameId, 'WEREWOLF_PICK', 20_000)
+  // Only fire the kill if the backend actually reached the WEREWOLF_PICK
+  // sub-phase. waitForSubPhase returns false when the game already left
+  // NIGHT (e.g. someone won at post-night-resolve before this call ran)
+  // or the gate timed out — in either case there's nothing for the role
+  // actor to do, and firing anyway produces a "Not in WEREWOLF_PICK
+  // sub-phase" rejection in the CI log.
+  const reachedWolfPick = await waitForSubPhase(hostPage, gameId, 'WEREWOLF_PICK', 20_000)
+  if (!reachedWolfPick) return
   if (wolfBot) {
     tryAct('WOLF_KILL', actName(wolfBot), { target: String(resolvedTargetSeatNum), room: ctx.roomCode })
   } else {

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -551,19 +551,23 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
         .map((p) => p.userId)
     }, ctx.gameId)
     const aliveSet = new Set(aliveIds)
-    const aliveBotsOf = (role: RoleName) =>
-      (ctx.roleMap[role] ?? []).filter((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
+    // Don't filter Host out. When host has a special role (e.g. host=WITCH)
+    // and the role's DOM-first path doesn't fire (browser stale, slot
+    // selector mismatch), the API fallback needs the host as the actor —
+    // otherwise the night stalls at that sub-phase forever. actName(host)
+    // returns 'HOST' and act.sh resolves to the cached host token, so
+    // host-as-X works through the same script path.
+    const aliveActorsOf = (role: RoleName) =>
+      (ctx.roleMap[role] ?? []).filter((b) => aliveSet.has(b.userId))
 
-    const wolfBots = aliveBotsOf('WEREWOLF')
-    const seerBots = aliveBotsOf('SEER')
-    const witchBots = aliveBotsOf('WITCH')
-    const guardBots = aliveBotsOf('GUARD')
-    const villagerBots = aliveBotsOf('VILLAGER')
+    const wolfBots = aliveActorsOf('WEREWOLF')
+    const seerBots = aliveActorsOf('SEER')
+    const witchBots = aliveActorsOf('WITCH')
+    const guardBots = aliveActorsOf('GUARD')
+    const villagerBots = aliveActorsOf('VILLAGER')
 
-    // Targets exclude wolves (a wolf can't kill another wolf) and Host (the
-    // wolf-page DOM-first path covers host-as-wolf). Filter by alive too —
-    // the role-page DOM-first paths target `.slot-alive` already, so the
-    // API fallback should match that contract.
+    // Targets exclude wolves (a wolf can't kill another wolf). Host may be
+    // included as a target if they hold a non-wolf role.
     const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots]
 
     // Locator visibility helper — Playwright's isVisible() does NOT retry,
@@ -950,10 +954,18 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     }, ctx.gameId)
     const aliveSet = new Set(aliveIds)
 
-    const wolfBot = (ctx.roleMap.WEREWOLF ?? []).find((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
-    const seerBot = (ctx.roleMap.SEER ?? []).find((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
-    const witchBot = (ctx.roleMap.WITCH ?? []).find((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
-    const guardBot = (ctx.roleMap.GUARD ?? []).find((b) => b.nick !== 'Host' && aliveSet.has(b.userId))
+    // Don't filter Host out of role actors. When host has a special role
+    // and is the only alive actor (e.g. host=WITCH, witch is the sole
+    // witch in the kit), filtering out the host leaves the role unactioned
+    // and the night stalls at that sub-phase forever (CI shard-1 failure
+    // on commit 67fb784 hit this with host-as-WITCH at N3 — game stuck at
+    // NIGHT/WITCH_ACT day=3). actName() returns 'HOST' for the host bot
+    // and act.sh resolves that to the cached host token, so host-as-X
+    // routes through the same script path as a bot-as-X.
+    const wolfBot = (ctx.roleMap.WEREWOLF ?? []).find((b) => aliveSet.has(b.userId))
+    const seerBot = (ctx.roleMap.SEER ?? []).find((b) => aliveSet.has(b.userId))
+    const witchBot = (ctx.roleMap.WITCH ?? []).find((b) => aliveSet.has(b.userId))
+    const guardBot = (ctx.roleMap.GUARD ?? []).find((b) => aliveSet.has(b.userId))
 
     const isVisibleSoon = async (page: Page, testId: string, timeoutMs = 5_000) =>
       page

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -650,9 +650,14 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
       }
     }
     if (!seerDone) {
-      // Browser-seer is dead. Try API on remaining seer bots.
+      // Browser-seer is dead. Try API on remaining seer bots. Exclude the
+      // seer's own seat from candidate targets — `allTargets` includes
+      // seerBots, so without this filter the inner loop tries SEER_CHECK
+      // self-check, backend rejects "Cannot check yourself" (3× retries
+      // pollute the log), then moves to the next target.
       for (const sb of seerBots) {
         for (const tgt of allTargets) {
+          if (tgt.userId === sb.userId) continue
           if (tryAct('SEER_CHECK', actName(sb), { target: String(tgt.seat), room: ctx.roomCode })) {
             // Backend transitions SEER_PICK → SEER_RESULT after CHECK,
             // then SEER_RESULT → next sub-phase after CONFIRM.
@@ -1151,10 +1156,17 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
       await hostPage.getByTestId('day-start-vote').click()
       await waitForVotingSubPhase(hostPage, localCtx.gameId, 'VOTING', 10_000)
 
-      // Vote out wolves[0] (the surviving wolf). All bots vote target=seat.
-      // act.sh's "all" fan-out + the host's UI abstain combine to total all
-      // alive voters.
-      act('SUBMIT_VOTE', undefined, { target: String(wolves[0].seat), room: localCtx.roomCode })
+      // Vote out wolves[0] (the surviving wolf). Iterate alive non-host
+      // unvoted bots explicitly — `act('SUBMIT_VOTE', undefined, ...)` does
+      // act.sh's full bot fan-out which includes dead bots, producing
+      // "Dead players cannot vote" rejections in the CI log (the wolf
+      // killed villagers[0] at N1, so by D1 they're dead).
+      const unvoted1 = await readUnvotedAlivePlayerIds(hostPage, localCtx.gameId)
+      for (const bot of localCtx.allBots) {
+        if (bot.nick === 'Host') continue
+        if (!unvoted1.has(bot.userId)) continue
+        act('SUBMIT_VOTE', bot.nick, { target: String(wolves[0].seat), room: localCtx.roomCode })
+      }
       const hostAbstain = hostPage.locator('.skip-btn').first()
       if (await hostAbstain.isVisible({ timeout: 3_000 }).catch(() => false)) {
         await hostAbstain.click()
@@ -1228,7 +1240,13 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
       await hostPage.getByTestId('day-start-vote').click()
       await waitForVotingSubPhase(hostPage, localCtx.gameId, 'VOTING', 10_000)
 
-      act('SUBMIT_VOTE', undefined, { target: String(villagers[1].seat), room: localCtx.roomCode })
+      // Per-bot fan-out filtering dead bots (villagers[0] died at N1).
+      const unvoted2 = await readUnvotedAlivePlayerIds(hostPage, localCtx.gameId)
+      for (const bot of localCtx.allBots) {
+        if (bot.nick === 'Host') continue
+        if (!unvoted2.has(bot.userId)) continue
+        act('SUBMIT_VOTE', bot.nick, { target: String(villagers[1].seat), room: localCtx.roomCode })
+      }
       const hostAbstain = hostPage.locator('.skip-btn').first()
       if (await hostAbstain.isVisible({ timeout: 3_000 }).catch(() => false)) {
         await hostAbstain.click()
@@ -1303,7 +1321,15 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
       await hostPage.getByTestId('day-start-vote').click()
       await waitForVotingSubPhase(hostPage, localCtx.gameId, 'VOTING', 10_000)
 
-      act('SUBMIT_VOTE', undefined, { target: String(hunter.seat), room: localCtx.roomCode })
+      // Per-bot fan-out — witch saved villagers[0] at N1 so all bots alive,
+      // but iterate explicitly to match the pattern (and to surface any
+      // dead bot via a positive readUnvotedAlivePlayerIds gate).
+      const unvotedRow4 = await readUnvotedAlivePlayerIds(hostPage, localCtx.gameId)
+      for (const bot of localCtx.allBots) {
+        if (bot.nick === 'Host') continue
+        if (!unvotedRow4.has(bot.userId)) continue
+        act('SUBMIT_VOTE', bot.nick, { target: String(hunter.seat), room: localCtx.roomCode })
+      }
       const hostAbstain = hostPage.locator('.skip-btn').first()
       if (await hostAbstain.isVisible({ timeout: 3_000 }).catch(() => false)) {
         await hostAbstain.click()

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -1128,18 +1128,32 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
         (localCtx.roleMap.VILLAGER ?? []).find((b) => !wolfIds.has(b.userId))
         ?? localCtx.allBots.find((b) => !wolfIds.has(b.userId) && b.userId !== seer.userId && b.userId !== witch.userId)
       expect(victim, 'need a non-wolf victim for the wolves to kill').toBeDefined()
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000),
+        'expected NIGHT/WEREWOLF_PICK before firing WOLF_KILL',
+      ).toBe(true)
       act('WOLF_KILL', actName(wolves[0]), { target: String(victim!.seat), room: localCtx.roomCode })
 
-      // Seer checks (just to advance the phase deterministically).
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000)
+      // Seer checks (just to advance the phase deterministically). Assert
+      // each gate so a wrong-sub-phase doesn't silently fire act() with
+      // a "Not in <X> sub-phase" rejection in the CI log.
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000),
+        'expected NIGHT/SEER_PICK before firing SEER_CHECK',
+      ).toBe(true)
       act('SEER_CHECK', actName(seer), { target: String(wolves[0].seat), room: localCtx.roomCode })
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000),
+        'expected NIGHT/SEER_RESULT before firing SEER_CONFIRM',
+      ).toBe(true)
       act('SEER_CONFIRM', actName(seer), { room: localCtx.roomCode })
 
       // Witch: poison-only on wolves[1]. No antidote (backend forbids
       // combined antidote+poison in a single WITCH_ACT).
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000),
+        'expected NIGHT/WITCH_ACT before firing WITCH_ACT',
+      ).toBe(true)
       act('WITCH_ACT', actName(witch), {
         room: localCtx.roomCode,
         payload: JSON.stringify({
@@ -1218,15 +1232,29 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
       await waitForPhase(hostPage, localCtx.gameId, 'NIGHT', 15_000)
 
       // ── N1 ── wolves kill villager-1, witch declines (villager-1 dies).
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000)
+      // Assert each sub-phase gate so a wrong-sub-phase doesn't silently
+      // fire act() with a "Not in <X> sub-phase" rejection in CI logs.
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000),
+        'expected NIGHT/WEREWOLF_PICK before firing WOLF_KILL',
+      ).toBe(true)
       act('WOLF_KILL', actName(wolves[0]), { target: String(villagers[0].seat), room: localCtx.roomCode })
 
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000),
+        'expected NIGHT/SEER_PICK before firing SEER_CHECK',
+      ).toBe(true)
       act('SEER_CHECK', actName(seer), { target: String(wolves[0].seat), room: localCtx.roomCode })
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000),
+        'expected NIGHT/SEER_RESULT before firing SEER_CONFIRM',
+      ).toBe(true)
       act('SEER_CONFIRM', actName(seer), { room: localCtx.roomCode })
 
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000),
+        'expected NIGHT/WITCH_ACT before firing WITCH_ACT',
+      ).toBe(true)
       act('WITCH_ACT', actName(witch), {
         room: localCtx.roomCode,
         payload: '{"useAntidote":false}',
@@ -1299,16 +1327,29 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
 
       // ── N1 ── wolves kill a villager. Witch saves them (no death) so D1
       // alive count is full and the hunter-vote elimination is the only D1
-      // event.
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000)
+      // event. Assert each sub-phase gate so a wrong-sub-phase doesn't
+      // silently fire act() with a "Not in <X> sub-phase" rejection.
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000),
+        'expected NIGHT/WEREWOLF_PICK before firing WOLF_KILL',
+      ).toBe(true)
       act('WOLF_KILL', actName(wolves[0]), { target: String(villagers[0].seat), room: localCtx.roomCode })
 
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000),
+        'expected NIGHT/SEER_PICK before firing SEER_CHECK',
+      ).toBe(true)
       act('SEER_CHECK', actName(seer), { target: String(wolves[0].seat), room: localCtx.roomCode })
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_RESULT', 10_000),
+        'expected NIGHT/SEER_RESULT before firing SEER_CONFIRM',
+      ).toBe(true)
       act('SEER_CONFIRM', actName(seer), { room: localCtx.roomCode })
 
-      await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000)
+      expect(
+        await waitForNightSubPhase(hostPage, localCtx.gameId, 'WITCH_ACT', 15_000),
+        'expected NIGHT/WITCH_ACT before firing WITCH_ACT',
+      ).toBe(true)
       act('WITCH_ACT', actName(witch), {
         room: localCtx.roomCode,
         payload: '{"useAntidote":true}',

--- a/frontend/e2e/real/helpers/multi-browser.ts
+++ b/frontend/e2e/real/helpers/multi-browser.ts
@@ -274,7 +274,25 @@ export async function setupGame(
 
   // ── Step 5: All bots confirm roles ─────────────────────────────────────
   // Note: this confirms ALL users in the state file, including the host.
-  // The game logic relies on STMP synchronization to handle state transitions.
+  // The game logic relies on STOMP synchronization to handle state transitions.
+  //
+  // BEFORE the act() call, write gameId to the state file. Without this,
+  // act.sh's first call hits the no-cache path (act.sh:287-330) and scans
+  // games 1..10000 looking for one whose `players` set contains all our
+  // bot userIds. On CI that scan races with the game's DB commit: the
+  // host's URL redirect to /game/N happens as soon as the backend assigns
+  // the gameId, but the game.players row write may lag a few hundred ms.
+  // The scan iterates IDs faster than that, fails to find a match, and
+  // exits with "Could not find active game for room <CODE>". Fix: write
+  // the gameId we already extracted from the URL into the state file —
+  // act.sh's cache hit path (act.sh:268-281) just probes /game/N/state
+  // and uses it, which is far more tolerant of commit lag.
+  {
+    const stateFilePath = path.join('/tmp', `werewolf-${roomCode.toUpperCase()}.json`)
+    const stateData = JSON.parse(readFileSync(stateFilePath, 'utf-8'))
+    stateData.gameId = Number(gameId)
+    writeFileSync(stateFilePath, JSON.stringify(stateData, null, 2))
+  }
 
   act('CONFIRM_ROLE', undefined, { room: roomCode })
 

--- a/frontend/e2e/real/helpers/shell-runner.ts
+++ b/frontend/e2e/real/helpers/shell-runner.ts
@@ -193,7 +193,7 @@ export function readStateFile(roomCode: string): StateFile {
  * retry.
  */
 const PERMANENT_REJECTION_RE =
-  /Actor is dead|Target is dead|Cannot protect the same player two nights in a row|Cannot use antidote and poison on the same night|Action already taken|Already (voted|campaigned|signed up)|Only host can|No active (night|voting) phase|Player not found|already exists/i
+  /Actor is dead|Target is dead|Dead players cannot vote|Cannot check yourself|Cannot vote for yourself|Cannot protect the same player two nights in a row|Cannot use antidote and poison on the same night|Action already taken|Already voted this round|Already (voted|campaigned|signed up)|Only host can|No active (night|voting) phase|Not in (WEREWOLF_PICK|SEER_PICK|SEER_RESULT|WITCH_ACT|GUARD_PICK|VOTE_RESULT|VOTING|SPEECH|SIGNUP|RESULT) sub-phase|Player not found|Target not found or dead|already exists/i
 
 /**
  * Run act.sh with the given action.

--- a/frontend/e2e/real/revote-flow.spec.ts
+++ b/frontend/e2e/real/revote-flow.spec.ts
@@ -382,14 +382,28 @@ test.describe('Voting tie → revote → game proceeds', () => {
 
     await hostPage.waitForTimeout(2_000)
 
-    // Host reveals tally
+    // Host reveals tally. Backend's next sub-phase depends on the tally:
+    //   - decisive vote → VOTE_RESULT (VOTING_CONTINUE applies)
+    //   - tied vote   → RE_VOTING auto-fires (VOTING_CONTINUE doesn't apply,
+    //                   firing it returns "Not in VOTE_RESULT sub-phase")
+    // Poll for whichever sub-phase the backend lands on, then fire
+    // VOTING_CONTINUE only when it's appropriate.
     tryAct('VOTING_REVEAL_TALLY', 'HOST', { room: ctx.roomCode })
-    await hostPage.waitForTimeout(2_000)
+    let postRevealSub: string | null = null
+    for (let i = 0; i < 20; i++) {
+      postRevealSub = await readVotingSubPhase(hostPage, ctx.gameId)
+      if (postRevealSub === 'VOTE_RESULT' || postRevealSub === 'RE_VOTING') break
+      await hostPage.waitForTimeout(300)
+    }
 
     await captureSnapshot(ctx.pages, testInfo, '03-vote-tally-tied')
 
-    // Host continues — should trigger RE_VOTING if tied
-    tryAct('VOTING_CONTINUE', 'HOST', { room: ctx.roomCode })
+    // Only fire VOTING_CONTINUE when VOTE_RESULT was reached. RE_VOTING is
+    // auto-triggered by the backend on a tie; VOTING_CONTINUE doesn't apply
+    // there and would be rejected with "Not in VOTE_RESULT sub-phase".
+    if (postRevealSub === 'VOTE_RESULT') {
+      tryAct('VOTING_CONTINUE', 'HOST', { room: ctx.roomCode })
+    }
     await hostPage.waitForTimeout(3_000)
 
     await captureSnapshot(ctx.pages, testInfo, '03-after-continue')
@@ -484,14 +498,24 @@ test.describe('Voting tie → revote → game proceeds', () => {
       }
     }
 
-    /** Host reveals tally then clicks continue. */
+    /** Host reveals tally, then fires VOTING_CONTINUE only if the backend
+     *  reached VOTE_RESULT. RE_VOTING auto-fires on a tie and doesn't
+     *  accept VOTING_CONTINUE (rejected as "Not in VOTE_RESULT sub-phase"
+     *  — the spam in /tmp/werewolf-e2e-backend.log on this spec). */
     async function revealAndContinue() {
       const revealBtn = ctx.hostPage.getByTestId('voting-reveal')
       await revealBtn.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {})
       await expect(revealBtn).toBeEnabled({ timeout: 15_000 }).catch(() => {})
       tryAct('VOTING_REVEAL_TALLY', 'HOST', { room: ctx.roomCode })
-      await ctx.hostPage.waitForTimeout(1_500)
-      tryAct('VOTING_CONTINUE', 'HOST', { room: ctx.roomCode })
+      let postRevealSub: string | null = null
+      for (let i = 0; i < 20; i++) {
+        postRevealSub = await readVotingSubPhase(ctx.hostPage, ctx.gameId)
+        if (postRevealSub === 'VOTE_RESULT' || postRevealSub === 'RE_VOTING') break
+        await ctx.hostPage.waitForTimeout(300)
+      }
+      if (postRevealSub === 'VOTE_RESULT') {
+        tryAct('VOTING_CONTINUE', 'HOST', { room: ctx.roomCode })
+      }
       await ctx.hostPage.waitForTimeout(1_500)
     }
 

--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -4,9 +4,9 @@
  * Opens 4 browser contexts (host + wolf + seer + villager) and verifies
  * the sheriff election sub-game: signup → speech → vote → result.
  */
-import {expect, test} from '@playwright/test'
+import {expect, type Page, test} from '@playwright/test'
 import {type GameContext, setupGame} from './helpers/multi-browser'
-import {act, actName, type RoleName, sheriff} from './helpers/shell-runner'
+import {actName, type RoleName, sheriff} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase,} from './helpers/assertions'
 import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
 import {waitForCondition} from './helpers/state-polling'
@@ -131,41 +131,72 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
     await captureSnapshot(ctx.pages, testInfo, 'sheriff-02-signup-done')
   })
 
+  // Helper: read the sheriff election sub-phase from /api/game/{id}/state.
+  // Returns null if the response shape is missing the field (e.g. the
+  // election already wrapped). Used to gate every host-only action so the
+  // backend isn't spammed with "Not in <X> sub-phase" rejections.
+  const readSheriffSubPhase = async (page: Page, gameId: string): Promise<string | null> =>
+    page.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? ((await res.json())?.sheriffElection?.subPhase ?? null) : null
+    }, gameId)
+
   // ── Test 3: Speeches — host advances, speaker shown ────────────────────
 
   test('3. Sheriff speeches — host advances, current speaker updates', async ({}, testInfo) => {
-    // Host starts speeches. Pass 'Host' explicitly: SHERIFF_START_SPEECH and
-    // SHERIFF_ADVANCE_SPEECH are host-only — without a player arg, act.sh
-    // fans out across every bot, each call rejected with "Only host can
-    // start speeches", and the test burns ~30 s of REJECTED rows in the
-    // backend log before the catch{} short-circuits. Passing 'Host'
-    // routes the action through the cached host token in one call.
-    try {
-      act('SHERIFF_START_SPEECH', 'Host', { room: ctx.roomCode })
-    } catch {
-      // May already be in speech phase
-    }
+    // Host starts speeches via the dedicated UI button (DOM-driven, no act.sh
+    // fan-out). The button is visible only in SIGNUP — wait for that
+    // sub-phase before clicking so the action lands cleanly.
+    await waitForCondition(
+      async () => (await readSheriffSubPhase(ctx.hostPage, ctx.gameId)) === 'SIGNUP',
+      'sheriff election to reach SIGNUP before starting speeches',
+      15_000,
+    )
+    const startBtn = ctx.hostPage.getByTestId('sheriff-start-campaign')
+    await expect(startBtn).toBeVisible({ timeout: 10_000 })
+    await expect(startBtn).toBeEnabled({ timeout: 10_000 })
+    await startBtn.click()
 
-    // Wait for SPEECH sub-phase
-    await ctx.hostPage.waitForTimeout(2_000)
+    // Backend transitions SIGNUP → SPEECH. Assert it.
+    await waitForCondition(
+      async () => (await readSheriffSubPhase(ctx.hostPage, ctx.gameId)) === 'SPEECH',
+      'sheriff election to reach SPEECH after sheriff-start-campaign click',
+      15_000,
+    )
 
-    // Verify all browsers show speech UI
-    for (const [role, page] of Array.from(ctx.pages.entries())) {
+    // Verify all browsers show the speech UI.
+    for (const [, page] of Array.from(ctx.pages.entries())) {
       await expect(page.locator('.sheriff-wrap')).toBeVisible({ timeout: 10_000 })
     }
 
-    // Host advances speeches until all done
-    let advances = 0
-    while (advances < 10) {
-      try {
-        act('SHERIFF_ADVANCE_SPEECH', 'Host', { room: ctx.roomCode })
-        advances++
-        await ctx.hostPage.waitForTimeout(500)
-      } catch {
-        // No more speeches to advance, or phase moved to VOTING
-        break
-      }
+    // Advance every speech via the DOM `sheriff-advance-speech` button. Loop
+    // until the sub-phase auto-transitions out of SPEECH (backend advances
+    // to VOTING after the last speaker) — NOT a fixed iteration count.
+    // SheriffElection.vue:115,128,182 only renders the button while in
+    // SPEECH, so its disappearance is the same signal as the sub-phase
+    // change. 20 is just a safety cap.
+    const advanceBtn = ctx.hostPage.getByTestId('sheriff-advance-speech')
+    for (let i = 0; i < 20; i++) {
+      const sub = await readSheriffSubPhase(ctx.hostPage, ctx.gameId)
+      if (sub !== 'SPEECH') break
+      const reappeared = await advanceBtn
+        .waitFor({ state: 'visible', timeout: 5_000 })
+        .then(() => true)
+        .catch(() => false)
+      if (!reappeared) continue
+      await advanceBtn.click()
     }
+
+    // After all speeches, backend should be in VOTING. Assert it — if not,
+    // the test fails loudly instead of silently leaving the phase wrong.
+    await waitForCondition(
+      async () => (await readSheriffSubPhase(ctx.hostPage, ctx.gameId)) === 'VOTING',
+      'sheriff election to reach VOTING after last speaker',
+      15_000,
+    )
 
     await captureSnapshot(ctx.pages, testInfo, 'sheriff-03-speeches')
   })
@@ -173,36 +204,44 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
   // ── Test 4: Voting + result ────────────────────────────────────────────
 
   test('4. Sheriff voting — bots vote, result revealed on all browsers', async ({}, testInfo) => {
-    // Wait for voting sub-phase
-    await ctx.hostPage.waitForTimeout(2_000)
+    // Test 3 left us in VOTING. Assert that explicitly.
+    await waitForCondition(
+      async () => (await readSheriffSubPhase(ctx.hostPage, ctx.gameId)) === 'VOTING',
+      'sheriff election VOTING sub-phase reached after test 3',
+      15_000,
+    )
 
-    // All bots vote for the first candidate (seer if they signed up)
+    // All non-host non-candidate bots vote for the seer (the candidate
+    // signed up in test 2). Candidates can't vote for themselves
+    // (SheriffService.kt:385), so they abstain instead.
     const seerBots = ctx.roleMap.SEER ?? []
     const targetNick = seerBots[0]?.nick
+    expect(targetNick, 'kit must include a SEER candidate to vote for').toBeDefined()
+    sheriff('vote', { target: targetNick!, room: ctx.roomCode })
+    sheriff('abstain', { player: targetNick!, room: ctx.roomCode })
 
-    if (targetNick) {
-      try {
-        sheriff('vote', { target: targetNick, room: ctx.roomCode })
-      } catch {
-        // Some may fail to vote
-      }
-    }
+    // Host abstains via DOM so allVoted flips true (host is never a
+    // candidate; sheriff.sh's bot fan-out doesn't include the host).
+    const abstainBtn = ctx.hostPage.getByTestId('sheriff-abstain')
+    await abstainBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await abstainBtn.click()
 
-    // Wait for all votes
-    await ctx.hostPage.waitForTimeout(2_000)
+    // Host reveals result via DOM. Wait for the button to enable so we
+    // never click before the backend's allVoted gate flips.
+    const revealBtn = ctx.hostPage.getByTestId('sheriff-reveal-result')
+    await revealBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await expect(revealBtn).toBeEnabled({ timeout: 15_000 })
+    await revealBtn.click()
 
-    // Host reveals result. SHERIFF_REVEAL_RESULT is host-only — pass 'Host'
-    // explicitly so act.sh uses the cached host token (otherwise it fans
-    // out across bots, each rejected as "Only host can reveal sheriff
-    // result").
-    try {
-      act('SHERIFF_REVEAL_RESULT', 'Host', { room: ctx.roomCode })
-    } catch {
-      // May fail if tied — try appoint instead
-    }
-
-    // Wait for result to propagate
-    await ctx.hostPage.waitForTimeout(3_000)
+    // Backend transitions VOTING → RESULT (or TIED). Assert it.
+    await waitForCondition(
+      async () => {
+        const sub = await readSheriffSubPhase(ctx.hostPage, ctx.gameId)
+        return sub === 'RESULT' || sub === 'TIED'
+      },
+      'sheriff election RESULT/TIED reached after sheriff-reveal-result',
+      15_000,
+    )
 
     await captureSnapshot(ctx.pages, testInfo, 'sheriff-04-result')
   })
@@ -210,26 +249,15 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
   // ── Test 5: Sheriff → Night transition ─────────────────────────────────
 
   test('5. Sheriff result → Night transition', async ({}, testInfo) => {
-    // The transition to night may happen:
-    // 1. Host clicks "Start Night" button in the sheriff result screen
-    // 2. Or via script
-
-    // Try clicking the button first
+    // After sheriff RESULT, the host has a "start-night" button on the
+    // result screen. The button is the contract — fail loudly if it
+    // doesn't render in 10s rather than silently fall back to a script
+    // that may also fail.
     const startNightBtn = ctx.hostPage.getByTestId('start-night')
-    const btnVisible = await startNightBtn.isVisible().catch(() => false)
+    await startNightBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await startNightBtn.click()
 
-    if (btnVisible) {
-      await startNightBtn.click()
-    } else {
-      // Use script
-      try {
-        act('START_NIGHT', 'Host', { room: ctx.roomCode })
-      } catch {
-        // Might auto-advance
-      }
-    }
-
-    // All browsers should transition to NIGHT
+    // All browsers transition to NIGHT.
     await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 15_000)
 
     await captureSnapshot(ctx.pages, testInfo, 'sheriff-05-night-transition')

--- a/frontend/e2e/real/werewolf-win.spec.ts
+++ b/frontend/e2e/real/werewolf-win.spec.ts
@@ -280,10 +280,28 @@ test.describe('Werewolf win — result screen shows all roles', () => {
       }
       await hostPage.waitForTimeout(2_000)
 
+      // Reveal tally → backend's next sub-phase depends on the tally:
+      //   - decisive → VOTE_RESULT (VOTING_CONTINUE applies)
+      //   - tied     → RE_VOTING auto-fires (VOTING_CONTINUE doesn't apply,
+      //                firing it returns "Not in VOTE_RESULT sub-phase")
+      // Poll for either; only fire VOTING_CONTINUE on VOTE_RESULT.
       tryAct('VOTING_REVEAL_TALLY', 'HOST', { room: ctx.roomCode })
-      await hostPage.waitForTimeout(2_000)
+      let postRevealSub: string | null = null
+      for (let i = 0; i < 20; i++) {
+        postRevealSub = await ctx.hostPage.evaluate(async (id: string) => {
+          const token = localStorage.getItem('jwt')
+          const res = await fetch(`/api/game/${id}/state`, {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          return res.ok ? ((await res.json())?.votingPhase?.subPhase ?? null) : null
+        }, ctx.gameId)
+        if (postRevealSub === 'VOTE_RESULT' || postRevealSub === 'RE_VOTING') break
+        await hostPage.waitForTimeout(300)
+      }
 
-      tryAct('VOTING_CONTINUE', 'HOST', { room: ctx.roomCode })
+      if (postRevealSub === 'VOTE_RESULT') {
+        tryAct('VOTING_CONTINUE', 'HOST', { room: ctx.roomCode })
+      }
       await hostPage.waitForTimeout(3_000)
 
       // Check if still in voting (revote) — if skip-btn reappears, another round needed


### PR DESCRIPTION
## Summary

Same anti-pattern cleanup as PRs #74-#76 applied to `flow-12p-sheriff.spec.ts`, then expanded to address the user's stronger criterion: rejection lines in the CI integration log (`[act rejected]` entries) should not be tolerated, even when retries pass the test.

Started as 7× `throw new Error` → `expect()` cleanup. Grew to address every retry-and-pray + silent-skip pattern producing rejection-log spam across 7 spec files.

## Files changed

| File | Change |
|---|---|
| `helpers/shell-runner.ts` | New `PERMANENT_REJECTION_RE` short-circuits permanent rejections (Actor is dead, Already voted, Cannot check yourself, Cannot vote for yourself, Not in <X> sub-phase, etc.) — saves ~1.8s per call AND stops the helper from masking upstream filter bugs. |
| `helpers/multi-browser.ts` | Cache `gameId` from URL into state file before first `act()` call — fixes the CONFIRM_ROLE-during-setup race where act.sh's bot-userIds-subset scan races the game's DB commit. |
| `flow-12p-sheriff.spec.ts` | 7× `throw new Error` → `expect()` (added `assertNonNull<T>` helper for TS narrowing). URL-based GAME_OVER detection → API state. `completeNight` checks `waitForSubPhase` return value to avoid firing into wrong sub-phase. |
| `sheriff-flow.spec.ts` | Tests 3-5 rewritten DOM-first + sub-phase polled — eliminates 10× retry-loop on `SHERIFF_ADVANCE_SPEECH`. |
| `revote-flow.spec.ts` | `VOTING_CONTINUE` only fires when sub-phase is actually `VOTE_RESULT` (not on tied → `RE_VOTING`). |
| `werewolf-win.spec.ts` | Same `VOTING_CONTINUE` fix as revote-flow. |
| `game-flow.spec.ts` | Test 8/10: drop `nick !== 'Host'` from special-role actor finder so host-as-WITCH/SEER drives via API (`actName(host)` returns 'HOST'). Test 8 seer fallback excludes self. Rows 2/3/4: per-bot SUBMIT_VOTE (filter dead bots), `expect()` on every sub-phase gate. |

## Verification

`npx tsc --project tsconfig.e2e.json --noEmit` clean.

CI on `8703c23` — **all 10 checks pass**:
- Lint & Test, Backend Build & Test, UI 1-3, Integration 1-3, Merge E2E + Integration Reports.

## Rejection-log spam reduction

| Run | Total `[act rejected]` lines per Integration shard |
|---|---|
| Pre-PR (run 25006137991) | shard 1: ~30 + shard 2: 5 + shard 3: 36 |
| `ce8b05c` | shard 1: 1 + shard 2: 5 + shard 3: 0 |
| `7f4fdd2` | shard 1: 1 + shard 2: 5 + shard 3: 0 |
| `8703c23` | shard 1: 1 + shard 2: 5 + shard 3: 0 |

The remaining 6 rejections per run are race-based: the test's sub-phase gate succeeded at moment T, but by the time `act.sh`'s API call arrived at the backend, the game state had advanced. They short-circuit on the first attempt (no retry waste) and don't fail the test, but they do still appear in CI logs.

Eliminating these would require either (a) DOM-driven role actions everywhere (would need browser pages for every special role in every spec), (b) backend-side action retry, or (c) a longer pre-check sleep before each act call (defeats the rejection-log goal). Future work — the bulk of the spam is gone.

## Test plan

- [ ] CI · Lint & Test passes.
- [ ] CI · Backend Build & Test passes.
- [ ] CI · E2E · UI shards pass.
- [ ] CI · E2E · Integration shards pass.
- [ ] Integration shard logs show ≤ 6 `[act rejected]` lines per shard (down from 36+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)