### PR TITLE
feat: host can kick player during room stage + rejoin works at any game stage

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/controller/RoomController.kt
+++ b/backend/src/main/kotlin/com/werewolf/controller/RoomController.kt
@@ -4,6 +4,7 @@ import com.werewolf.auth.UserClaims
 import com.werewolf.dto.ClaimSeatRequest
 import com.werewolf.dto.CreateRoomRequest
 import com.werewolf.dto.JoinRoomRequest
+import com.werewolf.dto.KickPlayerRequest
 import com.werewolf.dto.SetReadyRequest
 import com.werewolf.service.*
 import org.springframework.http.ResponseEntity
@@ -87,6 +88,30 @@ class RoomController(private val roomService: RoomService) {
         } catch (e: RoomNotFoundException) {
             ResponseEntity.badRequest().body(mapOf("error" to e.message))
         }
+
+    @PostMapping("/kick")
+    fun kickPlayer(
+        @RequestBody body: KickPlayerRequest,
+        authentication: Authentication,
+    ): ResponseEntity<Any> {
+        if (body.targetUserId.isBlank())
+            return ResponseEntity.badRequest().body(mapOf("error" to "targetUserId must not be blank"))
+        val (userId, _, _) = authentication.userClaims()
+        return try {
+            roomService.kickPlayer(userId, body.roomId, body.targetUserId)
+            ResponseEntity.ok(mapOf("success" to true))
+        } catch (e: RoomNotFoundException) {
+            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+        } catch (e: RoomNotOpenException) {
+            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+        } catch (e: NotHostException) {
+            ResponseEntity.status(403).body(mapOf("error" to e.message))
+        } catch (e: CannotKickHostException) {
+            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+        } catch (e: PlayerNotInRoomException) {
+            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+        }
+    }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/backend/src/main/kotlin/com/werewolf/dto/RoomDtos.kt
+++ b/backend/src/main/kotlin/com/werewolf/dto/RoomDtos.kt
@@ -16,6 +16,7 @@ data class JoinRoomRequest(val roomCode: String)
 
 data class SetReadyRequest(val ready: Boolean, val roomId: Int)
 data class ClaimSeatRequest(val seatIndex: Int, val roomId: Int)
+data class KickPlayerRequest(val roomId: Int, val targetUserId: String)
 
 data class RoomPlayerDto(
     val userId: String,

--- a/backend/src/main/kotlin/com/werewolf/service/RoomService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/RoomService.kt
@@ -55,17 +55,61 @@ class RoomService(
 
         val room = roomRepository.findByRoomCode(roomCode).orElse(null)
             ?: throw RoomNotFoundException("Room not found")
-        if (room.status != RoomStatus.WAITING)
-            throw RoomNotOpenException("Room is not open")
-
         val roomId = room.roomId ?: error("Room has no ID")
-        if (!roomPlayerRepository.findByRoomIdAndUserId(roomId, userId).isPresent) {
-            val count = roomPlayerRepository.findByRoomId(roomId).size
-            if (count >= room.totalPlayers) throw RoomFullException("Room is full")
-            roomPlayerRepository.save(RoomPlayer(roomId = roomId, userId = userId))
+
+        // Existing member can rejoin at any game stage. Supports:
+        //   1. Network drop / mobile backgrounding mid-game — player navigates
+        //      back to /room/<code> from the lobby and gets a fresh room snapshot.
+        //   2. Page refresh during ROLE_REVEAL / NIGHT / DAY / SHERIFF_ELECTION.
+        //   3. Kick + re-add: a kicked player's row is deleted (kickPlayer below),
+        //      so they fall through to the "new player" branch and are bound
+        //      by the WAITING + full guards just like a brand-new joiner.
+        if (roomPlayerRepository.findByRoomIdAndUserId(roomId, userId).isPresent) {
+            return buildRoomDto(room)
         }
 
+        // New player: must be in WAITING and room not full.
+        if (room.status != RoomStatus.WAITING)
+            throw RoomNotOpenException("Room is not open")
+        val count = roomPlayerRepository.findByRoomId(roomId).size
+        if (count >= room.totalPlayers) throw RoomFullException("Room is full")
+        roomPlayerRepository.save(RoomPlayer(roomId = roomId, userId = userId))
+
         return buildRoomDto(room)
+    }
+
+    /**
+     * Host removes a player from the room. Only valid during the WAITING stage
+     * (room hasn't started a game yet). Deletes the player's row so they fall
+     * through to the "new player" branch on a re-join attempt — meaning they
+     * can re-join only if (a) the room is still WAITING and (b) the seat
+     * hasn't been filled by someone else, and they CANNOT re-join once the
+     * host clicks Start Game.
+     *
+     * Broadcasts:
+     *   - PLAYER_KICKED — kicked player's frontend redirects to lobby.
+     *   - ROOM_UPDATE   — other players see the seat empty.
+     */
+    @Transactional
+    fun kickPlayer(hostUserId: String, roomId: Int, targetUserId: String) {
+        val room = roomRepository.findById(roomId).orElse(null)
+            ?: throw RoomNotFoundException("Room not found")
+        if (room.status != RoomStatus.WAITING)
+            throw RoomNotOpenException("Cannot kick after the game has started")
+        if (room.hostUserId != hostUserId)
+            throw NotHostException("Only the host can kick players")
+        if (targetUserId == hostUserId)
+            throw CannotKickHostException("Host cannot kick themselves")
+
+        val target = roomPlayerRepository.findByRoomIdAndUserId(roomId, targetUserId).orElse(null)
+            ?: throw PlayerNotInRoomException("Player not in room")
+
+        roomPlayerRepository.delete(target)
+
+        stompPublisher.broadcastRoom(roomId, mapOf("type" to "PLAYER_KICKED",
+            "payload" to mapOf("userId" to targetUserId)))
+        stompPublisher.broadcastRoom(roomId, mapOf("type" to "ROOM_UPDATE",
+            "payload" to mapOf("players" to buildRoomDto(room).players)))
     }
 
     @Transactional
@@ -174,3 +218,5 @@ class RoomNotOpenException(message: String) : RuntimeException(message)
 class RoomFullException(message: String) : RuntimeException(message)
 class PlayerNotInRoomException(message: String) : RuntimeException(message)
 class SeatTakenException(message: String) : RuntimeException(message)
+class NotHostException(message: String) : RuntimeException(message)
+class CannotKickHostException(message: String) : RuntimeException(message)

--- a/backend/src/test/kotlin/com/werewolf/unit/service/RoomServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/RoomServiceTest.kt
@@ -121,12 +121,38 @@ class RoomServiceTest {
     }
 
     @Test
-    fun `joinRoom - throws RoomNotOpenException when room is IN_GAME`() {
+    fun `joinRoom - throws RoomNotOpenException when NEW user joins IN_GAME room`() {
+        // The WAITING guard only applies to brand-new joiners. Existing
+        // members (already in room_players) bypass it — see the rejoin
+        // tests below.
         val room = room(status = RoomStatus.IN_GAME)
         whenever(roomRepository.findByRoomCode("ABCD")).thenReturn(Optional.of(room))
+        whenever(roomPlayerRepository.findByRoomIdAndUserId(1, userId)).thenReturn(Optional.empty())
 
         assertThatThrownBy { roomService.joinRoom(userId, "Nick", null, "ABCD") }
             .isInstanceOf(RoomNotOpenException::class.java)
+    }
+
+    @Test
+    fun `joinRoom - existing member can rejoin IN_GAME room (mid-game resume)`() {
+        // Player who is already in room_players (whether they disconnected,
+        // backgrounded their phone, or just refreshed) re-runs joinRoom and
+        // gets back the current room snapshot — even after the host has
+        // started the game.
+        val room = room(status = RoomStatus.IN_GAME)
+        whenever(roomRepository.findByRoomCode("ABCD")).thenReturn(Optional.of(room))
+        whenever(roomPlayerRepository.findByRoomIdAndUserId(1, userId))
+            .thenReturn(Optional.of(RoomPlayer(roomId = 1, userId = userId)))
+        whenever(roomPlayerRepository.findByRoomId(1)).thenReturn(
+            listOf(RoomPlayer(roomId = 1, userId = userId))
+        )
+        whenever(userRepository.findAllById(any())).thenReturn(emptyList())
+
+        val result = roomService.joinRoom(userId, "Nick", null, "ABCD")
+
+        verify(roomPlayerRepository, never()).save(any<RoomPlayer>())
+        assertThat(result.roomCode).isEqualTo("ABCD")
+        assertThat(result.status).isEqualTo("IN_GAME")
     }
 
     @Test
@@ -201,5 +227,75 @@ class RoomServiceTest {
 
         assertThat(result.roomCode).isEqualTo("ABCD")
         assertThat(result.hostId).isEqualTo(hostId)
+    }
+
+    // ── kickPlayer ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `kickPlayer - throws RoomNotFoundException when room missing`() {
+        whenever(roomRepository.findById(999)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { roomService.kickPlayer(hostId, 999, userId) }
+            .isInstanceOf(RoomNotFoundException::class.java)
+    }
+
+    @Test
+    fun `kickPlayer - throws RoomNotOpenException after game has started`() {
+        val room = room(status = RoomStatus.IN_GAME)
+        whenever(roomRepository.findById(1)).thenReturn(Optional.of(room))
+
+        assertThatThrownBy { roomService.kickPlayer(hostId, 1, userId) }
+            .isInstanceOf(RoomNotOpenException::class.java)
+    }
+
+    @Test
+    fun `kickPlayer - throws NotHostException when caller is not the host`() {
+        val room = room()
+        whenever(roomRepository.findById(1)).thenReturn(Optional.of(room))
+
+        assertThatThrownBy { roomService.kickPlayer(userId, 1, "u2") }
+            .isInstanceOf(NotHostException::class.java)
+    }
+
+    @Test
+    fun `kickPlayer - throws CannotKickHostException when host targets themselves`() {
+        val room = room()
+        whenever(roomRepository.findById(1)).thenReturn(Optional.of(room))
+
+        assertThatThrownBy { roomService.kickPlayer(hostId, 1, hostId) }
+            .isInstanceOf(CannotKickHostException::class.java)
+    }
+
+    @Test
+    fun `kickPlayer - throws PlayerNotInRoomException when target is not in room`() {
+        val room = room()
+        whenever(roomRepository.findById(1)).thenReturn(Optional.of(room))
+        whenever(roomPlayerRepository.findByRoomIdAndUserId(1, userId)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { roomService.kickPlayer(hostId, 1, userId) }
+            .isInstanceOf(PlayerNotInRoomException::class.java)
+    }
+
+    @Test
+    fun `kickPlayer - deletes target row and broadcasts PLAYER_KICKED + ROOM_UPDATE`() {
+        val room = room()
+        val targetRow = RoomPlayer(roomId = 1, userId = userId)
+        whenever(roomRepository.findById(1)).thenReturn(Optional.of(room))
+        whenever(roomPlayerRepository.findByRoomIdAndUserId(1, userId)).thenReturn(Optional.of(targetRow))
+        whenever(roomPlayerRepository.findByRoomId(1)).thenReturn(
+            listOf(RoomPlayer(roomId = 1, userId = hostId))  // host left after kick
+        )
+        whenever(userRepository.findAllById(any())).thenReturn(emptyList())
+
+        roomService.kickPlayer(hostId, 1, userId)
+
+        verify(roomPlayerRepository).delete(targetRow)
+        verify(stompPublisher).broadcastRoom(eq(1), argThat<Map<String, Any>> {
+            this["type"] == "PLAYER_KICKED" &&
+            (this["payload"] as? Map<*, *>)?.get("userId") == userId
+        })
+        verify(stompPublisher).broadcastRoom(eq(1), argThat<Map<String, Any>> {
+            this["type"] == "ROOM_UPDATE"
+        })
     }
 }

--- a/frontend/src/__tests__/roomServiceKick.test.ts
+++ b/frontend/src/__tests__/roomServiceKick.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { roomService } from '@/services/roomService'
+
+vi.mock('@/services/http', () => ({
+  default: {
+    post: vi.fn().mockResolvedValue({ data: { success: true } }),
+  },
+}))
+
+import http from '@/services/http'
+
+/**
+ * Contract tests for the kick endpoint shape. The frontend's kickPlayer
+ * coerces the roomId to Number (the backend DTO is Int) and passes the
+ * targetUserId as-is. If the wire format ever changes, these tests fail
+ * before the live request hits the backend.
+ */
+describe('roomService.kickPlayer', () => {
+  it('POSTs /room/kick with numeric roomId and targetUserId', async () => {
+    await roomService.kickPlayer('42', 'guest:bot1-1234')
+
+    expect(http.post).toHaveBeenCalledWith('/room/kick', {
+      roomId: 42,
+      targetUserId: 'guest:bot1-1234',
+    })
+  })
+
+  it('coerces string-formatted roomId to a number', async () => {
+    await roomService.kickPlayer('7', 'u1')
+
+    expect(http.post).toHaveBeenCalledWith('/room/kick', {
+      roomId: 7,
+      targetUserId: 'u1',
+    })
+  })
+})

--- a/frontend/src/services/roomService.ts
+++ b/frontend/src/services/roomService.ts
@@ -33,4 +33,8 @@ export const roomService = {
   async claimSeat(seatIndex: number, roomId: string): Promise<void> {
     await http.post('/room/seat', { seatIndex, roomId: Number(roomId) })
   },
+
+  async kickPlayer(roomId: string, targetUserId: string): Promise<void> {
+    await http.post('/room/kick', { roomId: Number(roomId), targetUserId })
+  },
 }

--- a/frontend/src/views/RoomView.vue
+++ b/frontend/src/views/RoomView.vue
@@ -42,7 +42,25 @@
           :variant="slotVariant(seat)"
           mode="room"
           @click="handleSeatClick(seat)"
-        />
+        >
+          <!--
+            Host-only: × button on every occupied non-host seat.
+            Stops click propagation so the surrounding seat-click (seat
+            select / claim) doesn't fire. Available only during the
+            WAITING stage; the button isn't rendered after Start Game
+            because the room view isn't shown then.
+          -->
+          <template v-if="canKick(seat)" #overlay>
+            <button
+              class="kick-btn"
+              :data-testid="`kick-player-${seat}`"
+              :aria-label="`Kick ${playerAtSeat(seat)?.nickname}`"
+              @click.stop="handleKickPlayer(seat)"
+            >
+              ×
+            </button>
+          </template>
+        </PlayerSlot>
       </section>
 
       <!-- Debug panel (mock mode only) -->
@@ -179,6 +197,31 @@ async function handleSeatClick(seat: number) {
   }
 }
 
+// Host can kick: occupied seat, not the host themselves. Backend also
+// validates this server-side; the predicate just controls whether the
+// × button renders so the host doesn't see the option on themselves.
+function canKick(seat: number): boolean {
+  if (!isHost.value) return false
+  const player = playerAtSeat(seat)
+  if (!player) return false
+  return player.userId !== userStore.userId && !player.isHost
+}
+
+async function handleKickPlayer(seat: number) {
+  if (!roomStore.room) return
+  const player = playerAtSeat(seat)
+  if (!player) return
+  try {
+    await roomService.kickPlayer(roomStore.room.roomId, player.userId)
+    // STOMP PLAYER_KICKED + ROOM_UPDATE will land via the topic subscription;
+    // local store updates from there. No optimistic update — keeps the
+    // single source of truth on the server.
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[RoomView] kick failed', err)
+  }
+}
+
 async function handleReady(ready: boolean) {
   await roomService.setReady(ready, roomStore.room!.roomId)
   if (userStore.userId) {
@@ -273,6 +316,18 @@ onMounted(async () => {
         }
         if (data.type === 'GAME_STARTED') {
           router.push({ name: 'game', params: { gameId: data.payload.gameId } })
+        }
+        if (data.type === 'PLAYER_KICKED') {
+          // If THIS browser was the kicked player, clear local state and
+          // bounce to lobby. The backend has already deleted our row, so
+          // any further STOMP/HTTP calls would fail anyway. Other players'
+          // browsers ignore this event; the trailing ROOM_UPDATE will
+          // refresh their player list.
+          if (data.payload.userId === userStore.userId) {
+            roomStore.clearRoom()
+            disconnectStomp()
+            router.push({ name: 'lobby' })
+          }
         }
       })
     }
@@ -514,6 +569,32 @@ onUnmounted(() => {
 }
 
 .debug-start-btn:hover {
+  border-color: var(--red);
+  color: var(--red);
+}
+
+/* Host-only kick button overlaid on a player's seat card. */
+.kick-btn {
+  position: absolute;
+  top: 0.125rem;
+  right: 0.125rem;
+  width: 1.125rem;
+  height: 1.125rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--muted);
+  font-size: 0.875rem;
+  line-height: 1;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0;
+  z-index: 1;
+}
+.kick-btn:hover {
   border-color: var(--red);
   color: var(--red);
 }


### PR DESCRIPTION
## Summary

User-requested feature with two parts. The kick is the new capability; the `joinRoom` re-order is its prerequisite (and a bug fix the user spotted: the backend currently blocks every mid-game rejoin attempt — even from members whose row is still in `room_players` after a network drop).

> *Host has the power to kick off the player during the join room stage. Pre-conditions: (1) Players can join back to the room, load every required UI components at any game stage. (2) Acting as a reset function for the player who joins back in.*

## Backend

### `RoomService.joinRoom` — re-order

| Step | Old | New |
|---|---|---|
| 1 | `status != WAITING → RoomNotOpenException` | check existing membership first |
| 2 | check membership; new players → status check, full check | if member → return RoomDto regardless of status |
| 3 | new players → save | new players → status check, full check, save |

Existing members always rejoin — supports network drop / mobile background / page refresh / kicked-and-rebound flows. New users are still bound by the WAITING + room-full guards.

### `RoomService.kickPlayer` (new)

POST `/api/room/kick`. Body: `{ roomId: Int, targetUserId: String }`. Validates:
- room exists,
- `status == WAITING`,
- caller is host (`hostUserId == userId`) → 403 if not,
- target ≠ host,
- target is in `room_players`.

Then DELETEs the target's row and broadcasts:
- `PLAYER_KICKED { userId }` → kicked player's browser redirects to lobby.
- `ROOM_UPDATE { players }` → other browsers refresh their list.

Row deletion (not soft-mark) is what makes re-add symmetric with first join: kicked player falls through the new-user branch and is bound by the same WAITING + full guards. Once Start Game is clicked, kicked players are out for good.

### Tests

`RoomServiceTest` — 17 pass:
- Updated `joinRoom - throws RoomNotOpenException when NEW user joins IN_GAME room` (now stubs membership check explicitly).
- New `joinRoom - existing member can rejoin IN_GAME room` (mid-game resume).
- 6 new kickPlayer tests (each validation branch + happy path).

## Frontend

### `RoomView.vue`

Host-only `× kick-btn` rendered on every occupied non-host seat. Click is `@click.stop` so it doesn't trigger the surrounding seat-claim. `canKick(seat)` gate: `isHost && seat occupied && target != self && !target.isHost`.

STOMP listener handles `PLAYER_KICKED`:
- If the kicked userId matches the current browser → `clearRoom()` → `disconnectStomp()` → `router.push('lobby')`.
- Otherwise → no-op (the trailing ROOM_UPDATE handles the visible refresh).

No optimistic update — single source of truth stays on the server.

### Tests

`roomServiceKick.test.ts` (vitest) — 2 contract tests on the request shape (numeric `roomId`, string `targetUserId`). 233/233 vitest tests pass total.

## Verification

```bash
./gradlew test --tests com.werewolf.unit.service.RoomServiceTest      # 17/17 ✓
./gradlew test --tests com.werewolf.integration.controller.RoomControllerTest  # 15/15 ✓
npx vue-tsc --noEmit                                                  # clean
npx vitest run                                                        # 233/233 ✓
```

## Test plan

- [ ] CI · Lint & Test passes.
- [ ] CI · Backend Build & Test passes (runs `RoomServiceTest` + `RoomControllerTest`).
- [ ] CI · E2E · UI shards pass.
- [ ] CI · E2E · Integration shards pass.

## Out of scope

- Pre-condition 1's broader scope ("load every required UI component at any game stage") is unblocked at the backend by this PR's `joinRoom` re-order. The frontend GameView already calls `/api/game/{id}/state` on mount, which works for an existing member; full state-restoration polish (action history replay, audio sync) is a separate follow-up.
- The Playwright E2E for kick + rejoin is intentionally not in this PR — happy to add as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)