### PR TITLE
fix(ws): negotiate STOMP broker heartbeats + add mobile lifecycle hooks

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/config/WebSocketConfig.kt
+++ b/backend/src/main/kotlin/com/werewolf/config/WebSocketConfig.kt
@@ -1,8 +1,10 @@
 package com.werewolf.config
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
@@ -21,10 +23,20 @@ class WebSocketConfig(
     }
 
     override fun configureMessageBroker(registry: MessageBrokerRegistry) {
-        // /topic  → broadcast (public game events, room updates)
-        // /user/queue → per-player private messages (role, werewolf channel)
+        // 10s/10s broker heartbeats keep idle mobile sockets alive past NATs and cellular proxies; without them the broker negotiates [0,0] and idle connections silently die.
         registry.enableSimpleBroker("/topic", "/user/queue")
+            .setHeartbeatValue(longArrayOf(10_000, 10_000))
+            .setTaskScheduler(webSocketHeartbeatScheduler())
         registry.setApplicationDestinationPrefixes("/app")
         registry.setUserDestinationPrefix("/user")
+    }
+
+    @Bean
+    fun webSocketHeartbeatScheduler(): ThreadPoolTaskScheduler {
+        val scheduler = ThreadPoolTaskScheduler()
+        scheduler.poolSize = 1
+        scheduler.setThreadNamePrefix("ws-heartbeat-")
+        scheduler.initialize()
+        return scheduler
     }
 }

--- a/backend/src/test/kotlin/com/werewolf/integration/StompHeartbeatTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/StompHeartbeatTest.kt
@@ -1,0 +1,56 @@
+package com.werewolf.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.messaging.simp.stomp.StompHeaders
+import org.springframework.messaging.simp.stomp.StompSession
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.web.socket.client.standard.StandardWebSocketClient
+import org.springframework.web.socket.messaging.WebSocketStompClient
+import org.springframework.web.socket.sockjs.client.SockJsClient
+import org.springframework.web.socket.sockjs.client.WebSocketTransport
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * Without server heartbeats the broker advertises [0,0] and idle sockets across
+ * mobile NATs / cellular proxies silently die — this test pins the configured
+ * value so the regression that caused production "stuck at stage" reports
+ * cannot return unnoticed.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class StompHeartbeatTest {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Test
+    fun `CONNECTED frame advertises 10s_10s heartbeat`() {
+        val transports = listOf(WebSocketTransport(StandardWebSocketClient()))
+        val stompClient = WebSocketStompClient(SockJsClient(transports))
+        val negotiated = CompletableFuture<String?>()
+
+        val handler = object : StompSessionHandlerAdapter() {
+            override fun afterConnected(session: StompSession, connectedHeaders: StompHeaders) {
+                negotiated.complete(connectedHeaders.getFirst("heart-beat"))
+            }
+        }
+
+        val session: StompSession = stompClient
+            .connectAsync("ws://localhost:$port/ws", handler)
+            .get(5, TimeUnit.SECONDS)
+
+        try {
+            assertThat(negotiated.get(5, TimeUnit.SECONDS))
+                .`as`("Server must advertise 10s/10s heartbeats so idle mobile sockets stay alive")
+                .isEqualTo("10000,10000")
+        } finally {
+            session.disconnect()
+        }
+    }
+}

--- a/frontend/e2e/real/game-flow.spec.ts
+++ b/frontend/e2e/real/game-flow.spec.ts
@@ -566,9 +566,13 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     const guardBots = aliveActorsOf('GUARD')
     const villagerBots = aliveActorsOf('VILLAGER')
 
-    // Targets exclude wolves (a wolf can't kill another wolf). Host may be
-    // included as a target if they hold a non-wolf role.
-    const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots]
+    // Targets exclude wolves (a wolf can't kill another wolf) AND the host. The
+    // host drives later steps that require host-alive UI — `.skip-btn` in
+    // VotingPhase.vue is gated on `viewRole === 'ALIVE'`, so killing the host
+    // here makes the day-2 abstain wait time out and tests 9-10 cascade-fail.
+    const allTargets = [...villagerBots, ...seerBots, ...guardBots, ...witchBots].filter(
+      (b) => b.nick !== 'Host',
+    )
 
     // Locator visibility helper — Playwright's isVisible() does NOT retry,
     // so wrapping waitFor lets us return a boolean after a real wait.
@@ -815,7 +819,9 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // chosen.
     const aliveIds = await ctx.hostPage.evaluate(async (id: string) => {
       const token = localStorage.getItem('jwt')
-      const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
       if (!res.ok) return [] as string[]
       const state = await res.json()
       return ((state?.players ?? []) as Array<{ isAlive?: boolean; userId: string }>)
@@ -945,7 +951,9 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
     // Read live alive set from the API for live filtering of role bots.
     const aliveIds = await ctx.hostPage.evaluate(async (id: string) => {
       const token = localStorage.getItem('jwt')
-      const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
       if (!res.ok) return [] as string[]
       const state = await res.json()
       return ((state?.players ?? []) as Array<{ isAlive?: boolean; userId: string }>)
@@ -1008,7 +1016,10 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
           !(ctx.roleMap.WEREWOLF ?? []).some((w) => w.userId === b.userId),
       )
       if (wolfBot && wolfTargetCandidate) {
-        tryAct('WOLF_KILL', actName(wolfBot), { target: String(wolfTargetCandidate.seat), room: ctx.roomCode })
+        tryAct('WOLF_KILL', actName(wolfBot), {
+          target: String(wolfTargetCandidate.seat),
+          room: ctx.roomCode,
+        })
         await waitForNightSubPhaseChange(ctx.hostPage, ctx.gameId, 'WEREWOLF_PICK', 8_000)
       }
     }
@@ -1021,7 +1032,10 @@ test.describe('Game flow — multi-browser STOMP verification', () => {
           (b) => b.userId !== seerBot.userId && b.nick !== 'Host' && aliveSet.has(b.userId),
         )
         if (checkTarget) {
-          tryAct('SEER_CHECK', actName(seerBot), { target: String(checkTarget.seat), room: ctx.roomCode })
+          tryAct('SEER_CHECK', actName(seerBot), {
+            target: String(checkTarget.seat),
+            room: ctx.roomCode,
+          })
           await waitForNightSubPhase(ctx.hostPage, ctx.gameId, 'SEER_RESULT', 8_000)
           tryAct('SEER_CONFIRM', actName(seerBot), { room: ctx.roomCode })
         }
@@ -1112,7 +1126,7 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
       // host token (act.sh:378), so a host-as-WITCH/SEER/WEREWOLF row is
       // driveable through the same script path. The role lookup just needs
       // to return whoever holds the role, host or bot.
-      const wolves = (localCtx.roleMap.WEREWOLF ?? [])
+      const wolves = localCtx.roleMap.WEREWOLF ?? []
       const seer = (localCtx.roleMap.SEER ?? [])[0]
       const witch = (localCtx.roleMap.WITCH ?? [])[0]
       expect(wolves.length, 'kit must have 2 wolves').toBe(2)
@@ -1137,14 +1151,19 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
       // wolves[0] then closes out the wolves → villager-win.
       const wolfIds = new Set(wolves.map((w) => w.userId))
       const victim =
-        (localCtx.roleMap.VILLAGER ?? []).find((b) => !wolfIds.has(b.userId))
-        ?? localCtx.allBots.find((b) => !wolfIds.has(b.userId) && b.userId !== seer.userId && b.userId !== witch.userId)
+        (localCtx.roleMap.VILLAGER ?? []).find((b) => !wolfIds.has(b.userId)) ??
+        localCtx.allBots.find(
+          (b) => !wolfIds.has(b.userId) && b.userId !== seer.userId && b.userId !== witch.userId,
+        )
       expect(victim, 'need a non-wolf victim for the wolves to kill').toBeDefined()
       expect(
         await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000),
         'expected NIGHT/WEREWOLF_PICK before firing WOLF_KILL',
       ).toBe(true)
-      act('WOLF_KILL', actName(wolves[0]), { target: String(victim!.seat), room: localCtx.roomCode })
+      act('WOLF_KILL', actName(wolves[0]), {
+        target: String(victim!.seat),
+        room: localCtx.roomCode,
+      })
 
       // Seer checks (just to advance the phase deterministically). Assert
       // each gate so a wrong-sub-phase doesn't silently fire act() with
@@ -1205,7 +1224,9 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
       await hostPage.waitForURL(/\/result\//, { timeout: 30_000 })
       const finalState = await hostPage.evaluate(async (id: string) => {
         const token = localStorage.getItem('jwt')
-        const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+        const res = await fetch(`/api/game/${id}/state`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
         return res.ok ? res.json() : null
       }, localCtx.gameId)
       expect(finalState?.phase, 'phase=GAME_OVER expected').toBe('GAME_OVER')
@@ -1250,7 +1271,10 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
         await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000),
         'expected NIGHT/WEREWOLF_PICK before firing WOLF_KILL',
       ).toBe(true)
-      act('WOLF_KILL', actName(wolves[0]), { target: String(villagers[0].seat), room: localCtx.roomCode })
+      act('WOLF_KILL', actName(wolves[0]), {
+        target: String(villagers[0].seat),
+        room: localCtx.roomCode,
+      })
 
       expect(
         await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000),
@@ -1296,7 +1320,9 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
       await hostPage.waitForURL(/\/result\//, { timeout: 30_000 })
       const finalState = await hostPage.evaluate(async (id: string) => {
         const token = localStorage.getItem('jwt')
-        const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+        const res = await fetch(`/api/game/${id}/state`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
         return res.ok ? res.json() : null
       }, localCtx.gameId)
       expect(finalState?.phase, 'phase=GAME_OVER expected').toBe('GAME_OVER')
@@ -1345,7 +1371,10 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
         await waitForNightSubPhase(hostPage, localCtx.gameId, 'WEREWOLF_PICK', 15_000),
         'expected NIGHT/WEREWOLF_PICK before firing WOLF_KILL',
       ).toBe(true)
-      act('WOLF_KILL', actName(wolves[0]), { target: String(villagers[0].seat), room: localCtx.roomCode })
+      act('WOLF_KILL', actName(wolves[0]), {
+        target: String(villagers[0].seat),
+        room: localCtx.roomCode,
+      })
 
       expect(
         await waitForNightSubPhase(hostPage, localCtx.gameId, 'SEER_PICK', 15_000),
@@ -1396,7 +1425,9 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
         'HUNTER_SHOOT',
         15_000,
       )
-      expect(reachedHunterShoot, 'expected DAY_VOTING/HUNTER_SHOOT after voting hunter out').toBe(true)
+      expect(reachedHunterShoot, 'expected DAY_VOTING/HUNTER_SHOOT after voting hunter out').toBe(
+        true,
+      )
       await captureSnapshot(localCtx.pages, testInfo, 'row4-hunter-shoot-entered')
 
       // Drive the hunter's pass (no shoot) so the game can advance — the
@@ -1412,7 +1443,9 @@ test.describe('Day 1 outcome scenarios — explicit end-state coverage', () => {
         async () => {
           const state = await hostPage.evaluate(async (id: string) => {
             const token = localStorage.getItem('jwt')
-            const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+            const res = await fetch(`/api/game/${id}/state`, {
+              headers: { Authorization: `Bearer ${token}` },
+            })
             return res.ok ? res.json() : null
           }, localCtx.gameId)
           return state?.votingPhase?.subPhase !== 'HUNTER_SHOOT'

--- a/frontend/src/__tests__/connectionLifecycle.test.ts
+++ b/frontend/src/__tests__/connectionLifecycle.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { useConnectionLifecycle } from '@/composables/useConnectionLifecycle'
+import { useWakeLock } from '@/composables/useWakeLock'
+
+// Auto-unmount between tests so document/window listeners from one test
+// don't leak into the next. Without this, lifecycle composables stack up
+// and a single dispatched event hits every previous test's mounted component.
+enableAutoUnmount(afterEach)
+
+// ── useConnectionLifecycle ────────────────────────────────────────────────────
+
+function mountWithLifecycle(onResume: () => void) {
+  const Stub = defineComponent({
+    setup() {
+      useConnectionLifecycle({ onResume })
+      return () => h('div')
+    },
+  })
+  return mount(Stub)
+}
+
+function setVisibility(state: 'hidden' | 'visible') {
+  Object.defineProperty(document, 'visibilityState', {
+    value: state,
+    configurable: true,
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('useConnectionLifecycle', () => {
+  beforeEach(() => {
+    setVisibility('visible')
+  })
+
+  it('calls onResume when the tab returns to foreground after being hidden', () => {
+    const onResume = vi.fn()
+    mountWithLifecycle(onResume)
+
+    setVisibility('hidden')
+    setVisibility('visible')
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call onResume when becoming visible without ever having been hidden', () => {
+    const onResume = vi.fn()
+    mountWithLifecycle(onResume)
+
+    setVisibility('visible')
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it('calls onResume when network returns from offline to online', () => {
+    const onResume = vi.fn()
+    mountWithLifecycle(onResume)
+
+    window.dispatchEvent(new Event('offline'))
+    window.dispatchEvent(new Event('online'))
+
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call onResume on initial online without prior offline', () => {
+    const onResume = vi.fn()
+    mountWithLifecycle(onResume)
+
+    window.dispatchEvent(new Event('online'))
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it('removes all listeners on unmount', () => {
+    const onResume = vi.fn()
+    const wrapper = mountWithLifecycle(onResume)
+
+    wrapper.unmount()
+
+    setVisibility('hidden')
+    setVisibility('visible')
+    window.dispatchEvent(new Event('offline'))
+    window.dispatchEvent(new Event('online'))
+
+    expect(onResume).not.toHaveBeenCalled()
+  })
+
+  it('handles repeated hide/show cycles, calling onResume each time visibility flips back', () => {
+    const onResume = vi.fn()
+    mountWithLifecycle(onResume)
+
+    setVisibility('hidden')
+    setVisibility('visible')
+    setVisibility('hidden')
+    setVisibility('visible')
+
+    expect(onResume).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── useWakeLock ───────────────────────────────────────────────────────────────
+
+interface FakeSentinel {
+  release: ReturnType<typeof vi.fn>
+  released: boolean
+}
+
+function installFakeWakeLock(): { request: ReturnType<typeof vi.fn>; sentinel: FakeSentinel } {
+  const sentinel: FakeSentinel = {
+    release: vi.fn(async () => {
+      sentinel.released = true
+    }),
+    released: false,
+  }
+  const request = vi.fn(async () => sentinel)
+  Object.defineProperty(navigator, 'wakeLock', {
+    value: { request },
+    configurable: true,
+  })
+  return { request, sentinel }
+}
+
+function uninstallWakeLock() {
+  // Some environments forbid deleting; assigning undefined on a configurable
+  // property keeps later tests honest about the API being absent.
+  Object.defineProperty(navigator, 'wakeLock', {
+    value: undefined,
+    configurable: true,
+  })
+}
+
+function mountWithWakeLock() {
+  const Stub = defineComponent({
+    setup() {
+      useWakeLock()
+      return () => h('div')
+    },
+  })
+  return mount(Stub)
+}
+
+describe('useWakeLock', () => {
+  afterEach(() => {
+    uninstallWakeLock()
+  })
+
+  it("requests a 'screen' wake lock on mount", async () => {
+    const { request } = installFakeWakeLock()
+    mountWithWakeLock()
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(request).toHaveBeenCalledWith('screen')
+  })
+
+  it('releases the sentinel on unmount', async () => {
+    const { sentinel } = installFakeWakeLock()
+    const wrapper = mountWithWakeLock()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    wrapper.unmount()
+
+    await Promise.resolve()
+    expect(sentinel.release).toHaveBeenCalled()
+  })
+
+  it('re-acquires the lock when the tab returns to foreground (Wake Lock auto-releases when hidden)', async () => {
+    const { request } = installFakeWakeLock()
+    mountWithWakeLock()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(request).toHaveBeenCalledTimes(1)
+
+    setVisibility('visible')
+    await Promise.resolve()
+
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('silently no-ops when navigator.wakeLock is unavailable', () => {
+    uninstallWakeLock()
+    expect(() => mountWithWakeLock()).not.toThrow()
+  })
+
+  it('silently swallows request rejections (e.g. denied, low battery)', async () => {
+    const sentinel: FakeSentinel = {
+      release: vi.fn(),
+      released: false,
+    }
+    const request = vi.fn(async () => {
+      throw new Error('NotAllowedError')
+    })
+    Object.defineProperty(navigator, 'wakeLock', { value: { request }, configurable: true })
+
+    expect(() => mountWithWakeLock()).not.toThrow()
+    await Promise.resolve()
+    await Promise.resolve()
+    // sentinel never assigned because request rejected; release is a no-op
+    expect(sentinel.release).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/composables/useConnectionLifecycle.ts
+++ b/frontend/src/composables/useConnectionLifecycle.ts
@@ -1,0 +1,55 @@
+import { onMounted, onUnmounted } from 'vue'
+
+export interface ConnectionLifecycleOptions {
+  /**
+   * Called when the page transitions back to foreground after being hidden,
+   * or when the browser regains network after being offline. Caller should
+   * force-reconnect the STOMP client and refetch authoritative state.
+   */
+  onResume: () => void | Promise<void>
+}
+
+/**
+ * iOS Safari freezes WebSockets when tabs are backgrounded and cellular
+ * handovers can drop sockets without surfacing a close event — STOMP's
+ * heartbeat watchdog only catches this 20-30s later, leaving the UI
+ * "stuck" until the next action fails. Force-reconnecting the moment the
+ * tab/network resumes closes that gap.
+ */
+export function useConnectionLifecycle(options: ConnectionLifecycleOptions) {
+  let wasHidden = false
+  let wasOffline = false
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === 'hidden') {
+      wasHidden = true
+      return
+    }
+    if (document.visibilityState === 'visible' && wasHidden) {
+      wasHidden = false
+      void options.onResume()
+    }
+  }
+
+  function handleOnline() {
+    if (!wasOffline) return
+    wasOffline = false
+    void options.onResume()
+  }
+
+  function handleOffline() {
+    wasOffline = true
+  }
+
+  onMounted(() => {
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+    window.removeEventListener('online', handleOnline)
+    window.removeEventListener('offline', handleOffline)
+  })
+}

--- a/frontend/src/composables/useWakeLock.ts
+++ b/frontend/src/composables/useWakeLock.ts
@@ -1,0 +1,63 @@
+import { onMounted, onUnmounted } from 'vue'
+
+interface WakeLockSentinel {
+  release(): Promise<void>
+  released: boolean
+}
+
+interface WakeLockNavigator {
+  wakeLock?: {
+    request(type: 'screen'): Promise<WakeLockSentinel>
+  }
+}
+
+/**
+ * Holds a screen Wake Lock for the lifetime of the calling component so the
+ * device doesn't dim or lock during long phases (a 12-player game can run 15+
+ * minutes between meaningful taps). Wake Locks are auto-released when the tab
+ * is hidden; we re-acquire on visibilitychange so a backgrounded-then-resumed
+ * tab keeps the screen on for the rest of the game.
+ *
+ * Silently no-ops when navigator.wakeLock is missing (insecure context, older
+ * Safari before iOS 16.4) — degrade gracefully rather than blocking the view.
+ */
+export function useWakeLock() {
+  let sentinel: WakeLockSentinel | null = null
+
+  async function acquire() {
+    const nav = navigator as Navigator & WakeLockNavigator
+    if (!nav.wakeLock) return
+    try {
+      sentinel = await nav.wakeLock.request('screen')
+    } catch {
+      // user gesture required, low-battery mode, denied — degrade silently
+    }
+  }
+
+  async function release() {
+    if (sentinel && !sentinel.released) {
+      try {
+        await sentinel.release()
+      } catch {
+        /* tab already gone */
+      }
+    }
+    sentinel = null
+  }
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === 'visible') {
+      void acquire()
+    }
+  }
+
+  onMounted(() => {
+    void acquire()
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+    void release()
+  })
+}

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -470,7 +470,7 @@ import { useUserStore } from '@/stores/userStore'
 import { useGameStore } from '@/stores/gameStore'
 import { useRoomStore } from '@/stores/roomStore'
 import { gameService } from '@/services/gameService'
-import { createStompClient, disconnectStomp, subscribeToTopic } from '@/services/stompClient'
+import { createStompClient, disconnectStomp, getStompClient, subscribeToTopic } from '@/services/stompClient'
 import http from '@/services/http'
 import PlayerSlot from '@/components/PlayerSlot.vue'
 import RoleRevealCard from '@/components/RoleRevealCard.vue'
@@ -480,6 +480,8 @@ import NightPhase from '@/components/NightPhase.vue'
 import VotingPhase from '@/components/VotingPhase.vue'
 import { useNavigationGuard } from '@/composables/useNavigationGuard'
 import { useAudioService } from '@/composables/useAudioService'
+import { useConnectionLifecycle } from '@/composables/useConnectionLifecycle'
+import { useWakeLock } from '@/composables/useWakeLock'
 import type { GamePlayer } from '@/types'
 
 const route = useRoute()
@@ -530,6 +532,22 @@ const isHost = computed(() => {
 })
 
 useNavigationGuard()
+
+// Keep the screen on for the duration of the game; mobile players hold their
+// phones for 15+ minutes between meaningful taps, far past any default timeout.
+useWakeLock()
+
+// On tab resume / network resume, force a fresh STOMP connection so the
+// existing `onConnect` reconnect handler refetches authoritative state. Closes
+// the "stuck UI after backgrounding" gap that heartbeats alone can't reach.
+useConnectionLifecycle({
+  onResume: () => {
+    const client = getStompClient()
+    if (client?.active) {
+      client.forceDisconnect()
+    }
+  },
+})
 
 const isNight = computed(() => gameStore.state?.phase === 'NIGHT')
 

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -470,7 +470,12 @@ import { useUserStore } from '@/stores/userStore'
 import { useGameStore } from '@/stores/gameStore'
 import { useRoomStore } from '@/stores/roomStore'
 import { gameService } from '@/services/gameService'
-import { createStompClient, disconnectStomp, getStompClient, subscribeToTopic } from '@/services/stompClient'
+import {
+  createStompClient,
+  disconnectStomp,
+  getStompClient,
+  subscribeToTopic,
+} from '@/services/stompClient'
 import http from '@/services/http'
 import PlayerSlot from '@/components/PlayerSlot.vue'
 import RoleRevealCard from '@/components/RoleRevealCard.vue'

--- a/frontend/src/views/RoomView.vue
+++ b/frontend/src/views/RoomView.vue
@@ -146,10 +146,11 @@ import { useUserStore } from '@/stores/userStore'
 import { useRoomStore } from '@/stores/roomStore'
 import { roomService } from '@/services/roomService'
 import { gameService } from '@/services/gameService'
-import { createStompClient, disconnectStomp, subscribeToTopic } from '@/services/stompClient'
+import { createStompClient, disconnectStomp, getStompClient, subscribeToTopic } from '@/services/stompClient'
 import PlayerSlot from '@/components/PlayerSlot.vue'
 import { useNavigationGuard } from '@/composables/useNavigationGuard'
 import { useRoomStatus } from '@/composables/useRoomStatus'
+import { useConnectionLifecycle } from '@/composables/useConnectionLifecycle'
 
 const route = useRoute()
 const router = useRouter()
@@ -268,11 +269,20 @@ async function checkActiveGame() {
   }
 }
 
-function onVisibilityChange() {
-  if (document.visibilityState === 'visible') {
-    checkActiveGame()
-  }
-}
+useConnectionLifecycle({
+  onResume: () => {
+    // iOS Safari may have frozen the WebSocket while we were backgrounded.
+    // Force-reconnect so the auto-reconnect path fires `onConnect`, which
+    // re-subscribes and calls checkActiveGame for us. If the client is
+    // already inactive (initial mount, post-leave), just probe room state.
+    const client = getStompClient()
+    if (client?.active) {
+      client.forceDisconnect()
+    } else {
+      void checkActiveGame()
+    }
+  },
+})
 
 onMounted(async () => {
   const roomId = route.params.roomId as string
@@ -293,10 +303,6 @@ onMounted(async () => {
     router.push({ name: 'game', params: { gameId: roomStore.room.activeGameId } })
     return
   }
-
-  // Trigger 3 — visibility change: Safari suspends background tabs, killing the
-  // WebSocket. When the tab returns to foreground, re-check room status.
-  document.addEventListener('visibilitychange', onVisibilityChange)
 
   if (userStore.token && roomStore.room) {
     const client = createStompClient(userStore.token)
@@ -336,7 +342,6 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  document.removeEventListener('visibilitychange', onVisibilityChange)
   disconnectStomp()
 })
 </script>

--- a/frontend/src/views/RoomView.vue
+++ b/frontend/src/views/RoomView.vue
@@ -146,7 +146,12 @@ import { useUserStore } from '@/stores/userStore'
 import { useRoomStore } from '@/stores/roomStore'
 import { roomService } from '@/services/roomService'
 import { gameService } from '@/services/gameService'
-import { createStompClient, disconnectStomp, getStompClient, subscribeToTopic } from '@/services/stompClient'
+import {
+  createStompClient,
+  disconnectStomp,
+  getStompClient,
+  subscribeToTopic,
+} from '@/services/stompClient'
 import PlayerSlot from '@/components/PlayerSlot.vue'
 import { useNavigationGuard } from '@/composables/useNavigationGuard'
 import { useRoomStatus } from '@/composables/useRoomStatus'


### PR DESCRIPTION
## Summary

- Mobile players reported intermittent **stuck at stage / missing-audio** that clears after a manual reload. Root cause: the simple broker had no `setHeartbeatValue`, so it advertised `heart-beat:0,0` in the CONNECTED frame. The frontend's `CONNECT heart-beat:10000,10000` was negotiated down to "no heartbeats", idle sockets across mobile NATs / cellular proxies died silently, and the client's heartbeat watchdog never tripped (no heartbeats to time out on). This PR ships items (1), (2), and (4) of the 4-part reliability plan.
- **(1) Backend STOMP heartbeats** — `setHeartbeatValue([10s, 10s])` on the simple broker plus a `ThreadPoolTaskScheduler` bean (required once broker heartbeats are on). Verified via new `StompHeartbeatTest` integration test that pins the CONNECTED frame's `heart-beat` header to `10000,10000`.
- **(2) Nginx WSS proxy** — already correct in `deploy/nginx-site.conf` (`proxy_read_timeout 3600s`, Upgrade headers). Read-only audit, no edits.
- **(4) Mobile lifecycle hooks** — new `useConnectionLifecycle` (visibilitychange + online/offline → `forceDisconnect` so the existing `onConnect` rehydrate handler fires immediately rather than after the 30s heartbeat watchdog) and `useWakeLock` (holds a screen Wake Lock during the game so phones don't dim through long phases).
- Out of scope here, deliberately deferred: **(3)** the user-visible "重连/refresh" safety button + on-mount rehydrate audit gets its own branch and plan.

## Why this fixes "stuck at stage"

| Layer | Before | After |
|---|---|---|
| Frontend STOMP CONNECT request | `heart-beat:10000,10000` | unchanged |
| **Backend STOMP CONNECTED reply** | **`heart-beat:0,0`** | **`heart-beat:10000,10000`** |
| Idle socket on cellular NAT | dies silently in 30-60s; no event surfaces | kept alive by `\n` byte every 10s, OR client detects within ~30s and reconnects |
| iOS Safari background → foreground | wait up to 30s for heartbeat watchdog | force-reconnect on `visibilitychange` → instant rehydrate |
| Mobile screen | dims after default OS timeout | held on by Wake Lock for the duration of `/game` |

## Test plan

- [x] `cd backend && ./gradlew test --tests StompHeartbeatTest` passes (new test green)
- [x] `cd backend && ./gradlew test` — 533/533 pass
- [x] `cd frontend && npx vitest run` — 244/244 pass (11 new cases in `connectionLifecycle.test.ts`)
- [x] `cd frontend && npx vue-tsc --noEmit` — clean
- [ ] CI green (Integration shards, UI shards, Lint, Type-check)
- [ ] Post-merge: SSH to prod VM, confirm `nginx-site.conf` matches repo, tail backend log for `heart-beat=10000,10000` on CONNECT, run `prod-smoke-test` 3-bot smoke

## Out of scope

- Item **(3)** — user-visible "重连/refresh" safety button + on-mount rehydrate audit. Separate branch + plan.
- SockJS → raw WebSocket migration (SockJS fallback still useful for proxies that mangle Upgrade headers).
- Exponential backoff on `reconnectDelay` (current 3s adequate; revisit if monitoring shows reconnect storms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)