### PR TITLE
fix(werewolf): lock wolf target on confirmed WOLF_KILL — reject teammate WOLF_SELECT after

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/game/role/WerewolfHandler.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/role/WerewolfHandler.kt
@@ -58,12 +58,19 @@ class WerewolfHandler(
         if (nightPhase.subPhase != NightSubPhase.WEREWOLF_PICK)
             return GameActionResult.Rejected("Not in WEREWOLF_PICK sub-phase")
 
-        // Only the first WOLF_KILL per night advances the phase.
-        // Reject duplicates so submitAction is called exactly once.
+        // Once any wolf has confirmed via WOLF_KILL, the target is locked for
+        // the rest of WEREWOLF_PICK. Reject BOTH further WOLF_KILL and
+        // WOLF_SELECT — the latter would silently overwrite wolfTargetUserId
+        // and disagree with the first wolf's confirmed pick.
+        // Regression: prod game 15 (2026-05-01) — wolf1 confirmed kill on
+        // player A, wolf2 then SELECTed player B; B died, contradicting the
+        // confirmation.
         if (action.actionType == ActionType.WOLF_KILL) {
             if (killConfirmed.putIfAbsent(action.gameId, true) != null) {
                 return GameActionResult.Rejected("Kill already confirmed by teammate")
             }
+        } else if (killConfirmed.containsKey(action.gameId)) {
+            return GameActionResult.Rejected("Kill already confirmed by teammate")
         }
 
         val target = action.targetUserId

--- a/backend/src/test/kotlin/com/werewolf/unit/role/RoleHandlerTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/role/RoleHandlerTest.kt
@@ -134,6 +134,33 @@ class RoleHandlerTest {
         }
 
         @Test
+        fun `wolf select - rejected after teammate's WOLF_KILL is confirmed (game-15 regression)`() {
+            val np = nightPhase(NightSubPhase.WEREWOLF_PICK)
+            val wolf1 = player("wolf1", 1, PlayerRole.WEREWOLF)
+            val wolf2 = player("wolf2", 2, PlayerRole.WEREWOLF)
+            val firstTarget = player("u3", 3, PlayerRole.VILLAGER)
+            val secondTarget = player("u4", 4, PlayerRole.VILLAGER)
+            val ctx = GameContext(game(), room(), listOf(wolf1, wolf2, firstTarget, secondTarget), nightPhase = np)
+            whenever(nightPhaseRepository.save(any<NightPhase>())).thenAnswer { it.arguments[0] }
+
+            // wolf1 confirms kill on u3
+            val killResult = handler.handle(req("wolf1", ActionType.WOLF_KILL, "u3"), ctx)
+            assertThat(killResult).isInstanceOf(GameActionResult.Success::class.java)
+
+            // wolf2 attempts to SELECT a different target — must be rejected,
+            // wolfTargetUserId must NOT be overwritten.
+            val selectResult = handler.handle(req("wolf2", ActionType.WOLF_SELECT, "u4"), ctx)
+            assertThat(selectResult).isInstanceOf(GameActionResult.Rejected::class.java)
+            assertThat((selectResult as GameActionResult.Rejected).reason).contains("already confirmed")
+
+            // Only one save (from the WOLF_KILL); the rejected SELECT did not
+            // touch the repository.
+            val captor = argumentCaptor<NightPhase>()
+            verify(nightPhaseRepository).save(captor.capture())
+            assertThat(captor.firstValue.wolfTargetUserId).isEqualTo("u3")
+        }
+
+        @Test
         fun `wolf kill - lock resets for new night`() {
             val np = nightPhase(NightSubPhase.WEREWOLF_PICK)
             val wolf1 = player("wolf1", 1, PlayerRole.WEREWOLF)


### PR DESCRIPTION
## Summary

- Once any wolf submits a confirmed `WOLF_KILL`, lock the target for the remainder of `WEREWOLF_PICK` — reject **both** subsequent `WOLF_KILL` *and* `WOLF_SELECT` from teammates this night.
- Adds a regression test that reproduces the exact prod game-15 N1 timeline.

## Why

Production game 15 (2026-05-01) night 1:

```
11:05:01  mobilepeter  WOLF_KILL   john   → SUCCESS  (lock taken)
11:05:06  coco         WOLF_SELECT john2  → SUCCESS  (overwrote target)
11:05:07  coco         WOLF_SELECT ray    → SUCCESS  (overwrote target)
11:05:46  NIGHT_DEATH                     → ray dies, not john
```

`WerewolfHandler.killConfirmed` only blocked further `WOLF_KILL`. `WOLF_SELECT` from a teammate sailed past, and the unconditional `nightPhase.wolfTargetUserId = target` write at the bottom of `handle()` overwrote the locked-in target. The first wolf's confirmation became a lie — backend killed someone else.

## The fix

Single-branch addition in `WerewolfHandler.handle()`:

```kotlin
if (action.actionType == ActionType.WOLF_KILL) {
    if (killConfirmed.putIfAbsent(action.gameId, true) != null) {
        return GameActionResult.Rejected("Kill already confirmed by teammate")
    }
} else if (killConfirmed.containsKey(action.gameId)) {
    return GameActionResult.Rejected("Kill already confirmed by teammate")
}
```

The atomic `putIfAbsent` semantics for concurrent `WOLF_KILL` races are preserved. The lock still resets cleanly between nights via the existing `NightOrchestrator.initNightInternal` → `resetKillLock` call (covered by `wolf kill - lock resets for new night`).

## Test plan

- [x] `./gradlew test` — full backend suite green
- [x] New regression test `wolf select - rejected after teammate's WOLF_KILL is confirmed (game-15 regression)` — reproduces the prod timeline (wolf1 KILLs u3, wolf2 SELECTs u4, asserts the SELECT is rejected and `wolfTargetUserId` remains u3 with only one `repository.save`)
- [ ] CI green
- [ ] Optional: 3-bot smoke on prod after merge to confirm the live rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)