### PR TITLE
feat(sheriff): Variant B — sheriff election runs on Day 1 morning

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/config/GameTimingProperties.kt
+++ b/backend/src/main/kotlin/com/werewolf/config/GameTimingProperties.kt
@@ -26,6 +26,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *                               begins, so goes_dark + wolf_howl play fully.
  *   waitingDelayMs            — how long WAITING sub-phase idles for sheriff-
  *                               election games before the first real role.
+ *   sheriffResultAutoAdvanceMs — Variant B: how long the sheriff RESULT screen
+ *                               is shown before the game auto-advances back
+ *                               to DAY_DISCUSSION/RESULT_REVEALED. Defaults to
+ *                               60_000ms in production; tests/e2e shrink it.
  */
 @ConfigurationProperties(prefix = "werewolf.timing")
 data class GameTimingProperties(
@@ -35,6 +39,7 @@ data class GameTimingProperties(
     val interRoleGapMs: Long? = null,
     val nightInitAudioDelayMs: Long? = null,
     val waitingDelayMs: Long? = null,
+    val sheriffResultAutoAdvanceMs: Long? = null,
 ) {
     /**
      * Apply the configured overrides to the given role's default [RoleDelayConfig].

--- a/backend/src/main/kotlin/com/werewolf/game/night/NightOrchestrator.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/night/NightOrchestrator.kt
@@ -14,6 +14,7 @@ import com.werewolf.repository.EliminationHistoryRepository
 import com.werewolf.repository.GamePlayerRepository
 import com.werewolf.repository.GameRepository
 import com.werewolf.repository.NightPhaseRepository
+import com.werewolf.repository.SheriffElectionRepository
 import com.werewolf.service.GameContextLoader
 import com.werewolf.service.StompPublisher
 import kotlinx.coroutines.*
@@ -33,6 +34,7 @@ class NightOrchestrator(
     private val gameRepository: GameRepository,
     private val gamePlayerRepository: GamePlayerRepository,
     private val nightPhaseRepository: NightPhaseRepository,
+    private val sheriffElectionRepository: SheriffElectionRepository,
     private val eliminationHistoryRepository: EliminationHistoryRepository,
     private val winConditionChecker: WinConditionChecker,
     private val stompPublisher: StompPublisher,
@@ -243,7 +245,20 @@ class NightOrchestrator(
     }
 
     /**
-     * Resolve all night kills and transition to DAY_DISCUSSION (or GAME_OVER).
+     * End-of-night handler. Computes pending kills (wolf target unless saved
+     * by witch antidote or guard, plus witch poison) but does NOT apply them
+     * to `player.alive` yet — kills are deferred until the host clicks
+     * REVEAL_NIGHT_RESULT (via [GamePhasePipeline.revealNightResult] →
+     * [applyNightKills]).
+     *
+     * Why deferred: traditional 狼人杀 with sheriff requires the Day 1 sheriff
+     * election to run BEFORE the death announcement so N1 victims can still
+     * 上警 / use 挡刀 tactics. Decoupling the kill computation from the kill
+     * application lets the sheriff election see N1 victims as alive.
+     *
+     * Win check uses *projected* alive (current alive minus pending kills) so
+     * a wolf-parity-on-N1 short-circuit ends the game without spinning up a
+     * sheriff election that would never matter (Q1=a).
      */
     @Transactional
     fun resolveNightKills(context: GameContext, nightPhase: NightPhase) {
@@ -252,43 +267,27 @@ class NightOrchestrator(
             log.warn("[resolveNightKills] Night phase already COMPLETE for game $gameId, skipping double-resolution")
             return
         }
-        val kills = mutableListOf<String>()
 
-        val wolfTarget = nightPhase.wolfTargetUserId
-        if (wolfTarget != null) {
-            val antidoteSaved = nightPhase.witchAntidoteUsed
-            val guardSaved = nightPhase.guardTargetUserId == wolfTarget
-            if (!antidoteSaved && !guardSaved) {
-                kills.add(wolfTarget)
-            }
-        }
-
-        val poisonTarget = nightPhase.witchPoisonTargetUserId
-        if (poisonTarget != null) {
-            kills.add(poisonTarget)
-        }
-
-        for (killId in kills.distinct()) {
-            gamePlayerRepository.findByGameIdAndUserId(gameId, killId).ifPresent { player ->
-                player.alive = false
-                gamePlayerRepository.save(player)
-            }
-        }
-
-        actionLogService.recordNightDeaths(gameId, nightPhase.dayNumber, kills.distinct())
+        val pendingKills = computePendingKills(nightPhase)
 
         nightPhase.subPhase = NightSubPhase.COMPLETE
         nightPhaseRepository.save(nightPhase)
 
-        val updatedContext = contextLoader.load(gameId)
+        // Win check on PROJECTED alive (current alive minus pending kills).
+        // Important: we have NOT flipped player.alive yet, so we filter manually.
+        val projectedAlive = context.alivePlayers.filterNot { it.userId in pendingKills }
         val winner = winConditionChecker.check(
-            alivePlayers = updatedContext.alivePlayers,
-            mode = updatedContext.room.winCondition,
+            alivePlayers = projectedAlive,
+            mode = context.room.winCondition,
             trigger = WinCheckTrigger.POST_NIGHT,
-            counterplay = buildCounterplay(updatedContext),
+            counterplay = buildCounterplay(context),
         )
 
         if (winner != null) {
+            // Game over: apply kills now (deaths are real, no further sheriff
+            // election or reveal needed) and broadcast.
+            applyNightKills(gameId, pendingKills)
+            actionLogService.recordNightDeaths(gameId, nightPhase.dayNumber, pendingKills)
             context.game.apply {
                 this.winner = winner
                 phase = GamePhase.GAME_OVER
@@ -300,7 +299,7 @@ class NightOrchestrator(
                 TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
                     override fun afterCommit() {
                         try {
-                            stompPublisher.broadcastGame(gameId, DomainEvent.NightResult(gameId, kills.distinct()))
+                            stompPublisher.broadcastGame(gameId, DomainEvent.NightResult(gameId, pendingKills))
                         } catch (e: Exception) {
                             log.error("[resolveNightKills] Failed to broadcast NightResult for game $gameId", e)
                         }
@@ -317,11 +316,50 @@ class NightOrchestrator(
                     }
                 })
             } else {
-                stompPublisher.broadcastGame(gameId, DomainEvent.NightResult(gameId, kills.distinct()))
+                stompPublisher.broadcastGame(gameId, DomainEvent.NightResult(gameId, pendingKills))
                 stompPublisher.broadcastGame(gameId, DomainEvent.GameOver(gameId, winner))
             }
+        } else if (
+            context.game.dayNumber == 1 &&
+            context.room.hasSheriff &&
+            context.game.sheriffUserId == null &&
+            sheriffElectionRepository.findByGameId(gameId).isEmpty
+        ) {
+            // Day 1 + sheriff enabled + no sheriff yet: jump straight into
+            // SHERIFF_ELECTION. Kills remain deferred — N1 victims are still
+            // alive in DB and can sign up / speak / vote during the election.
+            context.game.phase = GamePhase.SHERIFF_ELECTION
+            context.game.subPhase = null
+            gameRepository.save(context.game)
+            sheriffElectionRepository.save(SheriffElection(gameId = gameId))
+
+            if (TransactionSynchronizationManager.isActualTransactionActive()) {
+                TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+                    override fun afterCommit() {
+                        try {
+                            stompPublisher.broadcastGame(
+                                gameId,
+                                DomainEvent.PhaseChanged(gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.SIGNUP.name),
+                            )
+                        } catch (e: Exception) {
+                            log.error("[resolveNightKills] Failed to broadcast SHERIFF_ELECTION/SIGNUP transition for game $gameId", e)
+                        }
+                    }
+                })
+            } else {
+                stompPublisher.broadcastGame(
+                    gameId,
+                    DomainEvent.PhaseChanged(gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.SIGNUP.name),
+                )
+            }
         } else {
-            val game = updatedContext.game
+            // No game-over, no sheriff election to open: transition to
+            // DAY_DISCUSSION/RESULT_HIDDEN. Kills remain deferred. The
+            // NightResult event + onDayEnter hooks are broadcast at host
+            // REVEAL_NIGHT_RESULT — broadcasting them now would leak the
+            // pending kill list to all browsers before the host has a chance
+            // to control the reveal moment.
+            val game = context.game
             game.phase = GamePhase.DAY_DISCUSSION
             game.subPhase = DaySubPhase.RESULT_HIDDEN.name
             gameRepository.save(game)
@@ -332,17 +370,12 @@ class NightOrchestrator(
                 newPhase = GamePhase.DAY_DISCUSSION,
                 oldSubPhase = null,
                 newSubPhase = DaySubPhase.RESULT_HIDDEN.name,
-                room = updatedContext.room,
+                room = context.room,
             )
 
             if (TransactionSynchronizationManager.isActualTransactionActive()) {
                 TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
                     override fun afterCommit() {
-                        try {
-                            stompPublisher.broadcastGame(gameId, DomainEvent.NightResult(gameId, kills.distinct()))
-                        } catch (e: Exception) {
-                            log.error("[resolveNightKills] Failed to broadcast NightResult for game $gameId", e)
-                        }
                         try {
                             stompPublisher.broadcastGame(
                                 gameId,
@@ -356,19 +389,7 @@ class NightOrchestrator(
                         } catch (e: Exception) {
                             log.error("[resolveNightKills] Failed to broadcast AudioSequence for game $gameId (non-critical)", e)
                         }
-                        try {
-                            val activeRoles = updatedContext.alivePlayers.map { it.role }.toSet()
-                            handlers.filter { it.role in activeRoles }.forEach { handler ->
-                                try {
-                                    val events = handler.onDayEnter(updatedContext)
-                                    events.forEach { stompPublisher.broadcastGame(gameId, it) }
-                                } catch (e: Exception) {
-                                    log.error("[resolveNightKills] Failed to execute onDayEnter for ${handler.role}, game $gameId", e)
-                                }
-                            }
-                        } catch (e: Exception) {
-                            log.error("[resolveNightKills] Failed to execute onDayEnter hooks for game $gameId (non-critical)", e)
-                        }
+                        fireDayEnterHooks(gameId, context)
                     }
                     override fun afterCompletion(status: Int) {
                         if (status != STATUS_COMMITTED) {
@@ -377,17 +398,79 @@ class NightOrchestrator(
                     }
                 })
             } else {
-                stompPublisher.broadcastGame(gameId, DomainEvent.NightResult(gameId, kills.distinct()))
                 stompPublisher.broadcastGame(
                     gameId,
                     DomainEvent.PhaseChanged(gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_HIDDEN.name)
                 )
                 stompPublisher.broadcastGame(gameId, DomainEvent.AudioSequence(gameId, audioSequence))
+                fireDayEnterHooks(gameId, context)
+            }
+        }
+    }
 
-                val activeRoles = updatedContext.alivePlayers.map { it.role }.toSet()
-                handlers.filter { it.role in activeRoles }.forEach { handler ->
-                    val events = handler.onDayEnter(updatedContext)
+    /**
+     * Broadcast onDayEnter events for handlers whose role is currently alive.
+     * With Variant B's deferred kills, "alive" here means alive at end-of-night
+     * BEFORE the host reveal applies pending kills — so a soon-to-be-dead
+     * player's role handler still fires onDayEnter. Default handler impl is
+     * empty, so this is mostly a no-op; custom impls that want to gate on
+     * accurate alive state should re-check via context.alivePlayerById.
+     */
+    private fun fireDayEnterHooks(gameId: Int, context: GameContext) {
+        try {
+            val activeRoles = context.alivePlayers.map { it.role }.toSet()
+            handlers.filter { it.role in activeRoles }.forEach { handler ->
+                try {
+                    val events = handler.onDayEnter(context)
                     events.forEach { stompPublisher.broadcastGame(gameId, it) }
+                } catch (e: Exception) {
+                    log.error("[resolveNightKills] Failed to execute onDayEnter for ${handler.role}, game $gameId", e)
+                }
+            }
+        } catch (e: Exception) {
+            log.error("[resolveNightKills] Failed to execute onDayEnter hooks for game $gameId (non-critical)", e)
+        }
+    }
+
+    /**
+     * Compute the set of pending kills from a NightPhase row. Pure function —
+     * does not touch DB. Public so [GamePhasePipeline.revealNightResult] can
+     * call it to figure out which players to flip alive=false on the reveal
+     * click.
+     *
+     * Wolf target dies unless witch antidote was used or guard protected the
+     * same target. Witch poison target dies unconditionally.
+     */
+    fun computePendingKills(nightPhase: NightPhase): List<String> {
+        val kills = mutableListOf<String>()
+        val wolfTarget = nightPhase.wolfTargetUserId
+        if (wolfTarget != null) {
+            val antidoteSaved = nightPhase.witchAntidoteUsed
+            val guardSaved = nightPhase.guardTargetUserId == wolfTarget
+            if (!antidoteSaved && !guardSaved) {
+                kills.add(wolfTarget)
+            }
+        }
+        val poisonTarget = nightPhase.witchPoisonTargetUserId
+        if (poisonTarget != null) {
+            kills.add(poisonTarget)
+        }
+        return kills.distinct()
+    }
+
+    /**
+     * Apply pending night kills to game_players (flip alive=false). Idempotent
+     * — already-dead targets are skipped. Called at host REVEAL_NIGHT_RESULT
+     * (and during [resolveNightKills]'s game-over branch when the win check
+     * fires immediately).
+     */
+    @Transactional
+    fun applyNightKills(gameId: Int, killIds: List<String>) {
+        for (killId in killIds.distinct()) {
+            gamePlayerRepository.findByGameIdAndUserId(gameId, killId).ifPresent { player ->
+                if (player.alive) {
+                    player.alive = false
+                    gamePlayerRepository.save(player)
                 }
             }
         }

--- a/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
@@ -23,11 +23,13 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 class GamePhasePipeline(
     private val gameRepository: GameRepository,
     private val gamePlayerRepository: GamePlayerRepository,
+    private val nightPhaseRepository: com.werewolf.repository.NightPhaseRepository,
     private val sheriffElectionRepository: SheriffElectionRepository,
     private val stompPublisher: StompPublisher,
     private val contextLoader: GameContextLoader,
     private val sheriffService: SheriffService,
     private val nightOrchestrator: NightOrchestrator,
+    private val actionLogService: com.werewolf.service.ActionLogService,
 ) {
     val log: Logger = LoggerFactory.getLogger(GamePhasePipeline::class.java)
     // ── Phase transition actions ───────────────────────────────────────────────
@@ -49,37 +51,36 @@ class GamePhasePipeline(
             return GameActionResult.Rejected("Result already revealed")
         }
 
+        // Variant B / correct ordering: kills were *computed* at end of night
+        // but NOT applied — apply them now. This is the moment the deceased
+        // become officially dead in DB; sheriff election (already over by
+        // this point on Day 1, or never opened on Day 2+) saw them as alive.
+        val nightPhase = nightPhaseRepository
+            .findByGameIdAndDayNumber(context.gameId, context.game.dayNumber)
+            .orElse(null)
+        val pendingKills = if (nightPhase != null) {
+            nightOrchestrator.computePendingKills(nightPhase)
+        } else emptyList()
+        if (pendingKills.isNotEmpty()) {
+            nightOrchestrator.applyNightKills(context.gameId, pendingKills)
+            actionLogService.recordNightDeaths(context.gameId, context.game.dayNumber, pendingKills)
+        }
+
         context.game.subPhase = DaySubPhase.RESULT_REVEALED.name
         gameRepository.save(context.game)
 
-        log.info("[revealNightResult] Successfully revealed night result")
+        log.info("[revealNightResult] Successfully revealed night result; applied kills=$pendingKills")
+        if (pendingKills.isNotEmpty()) {
+            stompPublisher.broadcastGameAfterCommit(
+                context.gameId,
+                DomainEvent.NightResult(context.gameId, pendingKills)
+            )
+        }
         stompPublisher.broadcastGameAfterCommit(
             context.gameId,
             DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_REVEALED.name)
         )
 
-        // Variant B sheriff election: on Day 1, after the N1 result is shown,
-        // automatically transition into SHERIFF_ELECTION/SIGNUP. Players have
-        // one night of context before the campaign begins.
-        // - Skipped if hasSheriff=false (CLASSIC-no-sheriff games go straight
-        //   to discussion → vote).
-        // - Skipped if a sheriff already exists (defensive — shouldn't happen
-        //   on Day 1, but keeps this idempotent).
-        // - Skipped on Day 2+ (sheriff election runs at most once per game).
-        if (context.room.hasSheriff
-            && context.game.dayNumber == 1
-            && context.game.sheriffUserId == null
-            && sheriffElectionRepository.findByGameId(context.gameId).isEmpty
-        ) {
-            context.game.phase = GamePhase.SHERIFF_ELECTION
-            context.game.subPhase = null
-            gameRepository.save(context.game)
-            sheriffElectionRepository.save(SheriffElection(gameId = context.gameId))
-            stompPublisher.broadcastGameAfterCommit(
-                context.gameId,
-                DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.SIGNUP.name)
-            )
-        }
         return GameActionResult.Success()
     }
 

--- a/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
@@ -51,12 +51,35 @@ class GamePhasePipeline(
 
         context.game.subPhase = DaySubPhase.RESULT_REVEALED.name
         gameRepository.save(context.game)
-        
+
         log.info("[revealNightResult] Successfully revealed night result")
         stompPublisher.broadcastGameAfterCommit(
             context.gameId,
             DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_REVEALED.name)
         )
+
+        // Variant B sheriff election: on Day 1, after the N1 result is shown,
+        // automatically transition into SHERIFF_ELECTION/SIGNUP. Players have
+        // one night of context before the campaign begins.
+        // - Skipped if hasSheriff=false (CLASSIC-no-sheriff games go straight
+        //   to discussion → vote).
+        // - Skipped if a sheriff already exists (defensive — shouldn't happen
+        //   on Day 1, but keeps this idempotent).
+        // - Skipped on Day 2+ (sheriff election runs at most once per game).
+        if (context.room.hasSheriff
+            && context.game.dayNumber == 1
+            && context.game.sheriffUserId == null
+            && sheriffElectionRepository.findByGameId(context.gameId).isEmpty
+        ) {
+            context.game.phase = GamePhase.SHERIFF_ELECTION
+            context.game.subPhase = null
+            gameRepository.save(context.game)
+            sheriffElectionRepository.save(SheriffElection(gameId = context.gameId))
+            stompPublisher.broadcastGameAfterCommit(
+                context.gameId,
+                DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.SIGNUP.name)
+            )
+        }
         return GameActionResult.Success()
     }
 
@@ -126,40 +149,23 @@ class GamePhasePipeline(
 
         stompPublisher.broadcastGameAfterCommit(context.gameId, DomainEvent.RoleConfirmed(context.gameId, request.actorUserId))
 
-        // Advance once everyone has confirmed
-        val allPlayers = gamePlayerRepository.findByGameId(context.gameId)
-        if (allPlayers.all { it.confirmedRole }) {
-            if (context.room.hasSheriff) {
-                context.game.phase = GamePhase.SHERIFF_ELECTION
-                gameRepository.save(context.game)
-                sheriffElectionRepository.save(SheriffElection(gameId = context.gameId))
-                stompPublisher.broadcastGameAfterCommit(
-                    context.gameId,
-                    DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.SIGNUP.name)
-                )
-            }
-            // When hasSheriff=false, stay in ROLE_REVEAL — host will explicitly call START_NIGHT
-        }
+        // After everyone has confirmed, the host always drives the next step
+        // by calling START_NIGHT. Sheriff election (when enabled) is now run
+        // on Day 1 morning after the N1 result is revealed — see
+        // [revealNightResult] for the auto-trigger.
         return GameActionResult.Success()
     }
 
-    /** Host: start night directly after role reveal when sheriff election is disabled. */
+    /** Host: start night after all roles have been confirmed. */
     @Transactional
     fun startNight(request: GameActionRequest, context: GameContext): GameActionResult {
         if (request.actorUserId != context.game.hostUserId)
             return GameActionResult.Rejected("Only the host can start the night")
-        val fromRoleReveal = context.game.phase == GamePhase.ROLE_REVEAL
-        val fromSheriffResult = context.game.phase == GamePhase.SHERIFF_ELECTION &&
-            context.election?.subPhase == ElectionSubPhase.RESULT
-        if (!fromRoleReveal && !fromSheriffResult)
+        if (context.game.phase != GamePhase.ROLE_REVEAL)
             return GameActionResult.Rejected("Cannot start night from current phase")
-        if (fromRoleReveal) {
-            if (context.room.hasSheriff)
-                return GameActionResult.Rejected("Sheriff election is enabled for this game")
-            val allPlayers = gamePlayerRepository.findByGameId(context.gameId)
-            if (!allPlayers.all { it.confirmedRole })
-                return GameActionResult.Rejected("Not all players have confirmed their role")
-        }
+        val allPlayers = gamePlayerRepository.findByGameId(context.gameId)
+        if (!allPlayers.all { it.confirmedRole })
+            return GameActionResult.Rejected("Not all players have confirmed their role")
         // Cancel any scheduled auto-advance jobs
         sheriffService.cancelScheduledJob(context.gameId)
         nightOrchestrator.initNight(context.gameId, context.game.dayNumber, withWaiting = true)

--- a/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
@@ -66,10 +66,35 @@ class GamePhasePipeline(
             actionLogService.recordNightDeaths(context.gameId, context.game.dayNumber, pendingKills)
         }
 
-        context.game.subPhase = DaySubPhase.RESULT_REVEALED.name
+        // Phase B: route through HUNTER_SHOOT and BADGE_HANDOVER if any
+        // killed player has the corresponding role/title. Order matters:
+        //  1. HUNTER_SHOOT first — the dying hunter gets to shoot before
+        //     the next sub-phase resolves. The hunter handler chains to
+        //     BADGE_HANDOVER itself if the shot target is the sheriff.
+        //  2. BADGE_HANDOVER if a sheriff was killed (and not already
+        //     routed by hunter handler). Triggers in BOTH CLASSIC and
+        //     HARD_MODE per the design decision (Q4=both modes).
+        //  3. Otherwise: RESULT_REVEALED (existing path).
+        //
+        // This mirrors the vote-out flow's ordering in VotingPipeline
+        // (HUNTER_SHOOT → BADGE_HANDOVER → continue).
+        val players = gamePlayerRepository.findByGameId(context.gameId).associateBy { it.userId }
+        val killedHunter = pendingKills.firstOrNull { players[it]?.role == PlayerRole.HUNTER }
+        val sheriffKilled = context.game.sheriffUserId != null &&
+            pendingKills.contains(context.game.sheriffUserId)
+
+        val (newSubPhase, transitionLog) = when {
+            killedHunter != null ->
+                DaySubPhase.HUNTER_SHOOT.name to "HUNTER_SHOOT (hunter=$killedHunter killed at night)"
+            sheriffKilled ->
+                DaySubPhase.BADGE_HANDOVER.name to "BADGE_HANDOVER (sheriff=${context.game.sheriffUserId} killed at night)"
+            else ->
+                DaySubPhase.RESULT_REVEALED.name to "RESULT_REVEALED (no special-role night kill)"
+        }
+        context.game.subPhase = newSubPhase
         gameRepository.save(context.game)
 
-        log.info("[revealNightResult] Successfully revealed night result; applied kills=$pendingKills")
+        log.info("[revealNightResult] Applied kills=$pendingKills; routing to $transitionLog")
         if (pendingKills.isNotEmpty()) {
             stompPublisher.broadcastGameAfterCommit(
                 context.gameId,
@@ -78,7 +103,7 @@ class GamePhasePipeline(
         }
         stompPublisher.broadcastGameAfterCommit(
             context.gameId,
-            DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_REVEALED.name)
+            DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_DISCUSSION, newSubPhase)
         )
 
         return GameActionResult.Success()

--- a/backend/src/main/kotlin/com/werewolf/game/voting/VotingPipeline.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/voting/VotingPipeline.kt
@@ -176,9 +176,16 @@ class VotingPipeline(
 
     @Transactional
     fun handleHunterShoot(request: GameActionRequest, context: GameContext): GameActionResult {
-        if (context.game.phase != GamePhase.DAY_VOTING)
-            return GameActionResult.Rejected("Not in voting phase")
-        if (context.game.subPhase != VotingSubPhase.HUNTER_SHOOT.name)
+        // Accept HUNTER_SHOOT under either parent phase:
+        //   - DAY_VOTING/HUNTER_SHOOT: hunter voted out (existing path).
+        //   - DAY_DISCUSSION/HUNTER_SHOOT: hunter killed at night (Phase B).
+        // The post-action routing differs between the two — see afterHunterAct
+        // and afterHunterActNightRoute.
+        val nightRoute = context.game.phase == GamePhase.DAY_DISCUSSION &&
+            context.game.subPhase == DaySubPhase.HUNTER_SHOOT.name
+        val voteRoute = context.game.phase == GamePhase.DAY_VOTING &&
+            context.game.subPhase == VotingSubPhase.HUNTER_SHOOT.name
+        if (!nightRoute && !voteRoute)
             return GameActionResult.Rejected("Not in HUNTER_SHOOT sub-phase")
 
         val actor = context.playerById(request.actorUserId)
@@ -217,31 +224,21 @@ class VotingPipeline(
 
                 // If hunted player was the sheriff, need badge handover
                 if (target == context.game.sheriffUserId) {
-                    context.game.subPhase = VotingSubPhase.BADGE_HANDOVER.name
-                    gameRepository.save(context.game)
-                    stompPublisher.broadcastGameAfterCommit(
-                        context.gameId,
-                        DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_VOTING, VotingSubPhase.BADGE_HANDOVER.name)
-                    )
+                    transitionToBadgeHandover(context, nightRoute)
                     return GameActionResult.Success()
                 }
 
-                // No badge handover needed — check win then go to night
-                afterHunterAct(context)
+                // No badge handover needed — check win then go to next phase
+                if (nightRoute) afterHunterActNightRoute(context) else afterHunterAct(context)
             }
 
             ActionType.HUNTER_PASS -> {
                 // Hunter chooses not to shoot; check if hunter was sheriff (badge handover needed)
                 if (actor.userId == context.game.sheriffUserId) {
-                    context.game.subPhase = VotingSubPhase.BADGE_HANDOVER.name
-                    gameRepository.save(context.game)
-                    stompPublisher.broadcastGameAfterCommit(
-                        context.gameId,
-                        DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_VOTING, VotingSubPhase.BADGE_HANDOVER.name)
-                    )
+                    transitionToBadgeHandover(context, nightRoute)
                     return GameActionResult.Success()
                 }
-                afterHunterAct(context)
+                if (nightRoute) afterHunterActNightRoute(context) else afterHunterAct(context)
             }
 
             else -> return GameActionResult.Rejected("Unknown action: ${request.actionType}")
@@ -251,15 +248,28 @@ class VotingPipeline(
 
     @Transactional
     fun handleBadge(request: GameActionRequest, context: GameContext): GameActionResult {
-        if (context.game.phase != GamePhase.DAY_VOTING)
-            return GameActionResult.Rejected("Not in voting phase")
-        if (context.game.subPhase != VotingSubPhase.BADGE_HANDOVER.name)
+        // Accept BADGE_HANDOVER under either parent phase:
+        //   - DAY_VOTING/BADGE_HANDOVER: sheriff voted out (existing path).
+        //   - DAY_DISCUSSION/BADGE_HANDOVER: sheriff killed at night (Phase B).
+        // After handover the post-resolution destination differs (VOTE_RESULT
+        // vs RESULT_REVEALED), so we capture which path we're on up front.
+        val nightRoute = context.game.phase == GamePhase.DAY_DISCUSSION &&
+            context.game.subPhase == DaySubPhase.BADGE_HANDOVER.name
+        val voteRoute = context.game.phase == GamePhase.DAY_VOTING &&
+            context.game.subPhase == VotingSubPhase.BADGE_HANDOVER.name
+        if (!nightRoute && !voteRoute)
             return GameActionResult.Rejected("Not in BADGE_HANDOVER sub-phase")
 
         val actor = context.playerById(request.actorUserId)
             ?: return GameActionResult.Rejected("Actor not found")
         if (actor.userId != context.game.sheriffUserId)
             return GameActionResult.Rejected("Only the current sheriff can hand over the badge")
+
+        val (postPhase, postSubPhase) = if (nightRoute) {
+            GamePhase.DAY_DISCUSSION to DaySubPhase.RESULT_REVEALED.name
+        } else {
+            GamePhase.DAY_VOTING to VotingSubPhase.VOTE_RESULT.name
+        }
 
         when (request.actionType) {
             ActionType.BADGE_PASS -> {
@@ -270,7 +280,8 @@ class VotingPipeline(
 
                 // Update sheriff
                 context.game.sheriffUserId = targetPlayer.userId
-                context.game.subPhase = VotingSubPhase.VOTE_RESULT.name
+                context.game.phase = postPhase
+                context.game.subPhase = postSubPhase
                 gameRepository.save(context.game)
 
                 // Update sheriff flags
@@ -286,14 +297,15 @@ class VotingPipeline(
                 )
                 stompPublisher.broadcastGameAfterCommit(
                     context.gameId,
-                    DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_VOTING, VotingSubPhase.VOTE_RESULT.name)
+                    DomainEvent.PhaseChanged(context.gameId, postPhase, postSubPhase)
                 )
             }
 
             ActionType.BADGE_DESTROY -> {
                 // Update sheriff
                 context.game.sheriffUserId = null
-                context.game.subPhase = VotingSubPhase.VOTE_RESULT.name
+                context.game.phase = postPhase
+                context.game.subPhase = postSubPhase
                 gameRepository.save(context.game)
                 gamePlayerRepository.findByGameIdAndUserId(context.gameId, actor.userId).ifPresent {
                     it.sheriff = false; gamePlayerRepository.save(it)
@@ -304,23 +316,74 @@ class VotingPipeline(
                 )
                 stompPublisher.broadcastGameAfterCommit(
                     context.gameId,
-                    DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_VOTING, VotingSubPhase.VOTE_RESULT.name)
+                    DomainEvent.PhaseChanged(context.gameId, postPhase, postSubPhase)
                 )
             }
 
             else -> return GameActionResult.Rejected("Unknown action: ${request.actionType}")
+        }
 
-            
+        // Post-action win check + downstream transition. Vote-out path runs
+        // afterElimination (existing behavior — stays in VOTE_RESULT for the
+        // host's continue-to-night click). Night-route path doesn't need
+        // afterElimination (kills already applied during revealNightResult);
+        // game just resumes on RESULT_REVEALED.
+        if (!nightRoute) {
+            afterElimination(context)
+        }
+        return GameActionResult.Success()
+    }
 
-                    }
+    /**
+     * Transition to BADGE_HANDOVER under the appropriate parent phase
+     * (DAY_DISCUSSION when invoked from the night-kill path, DAY_VOTING when
+     * invoked from the vote-out hunter-shoot path).
+     */
+    private fun transitionToBadgeHandover(context: GameContext, nightRoute: Boolean) {
+        val (parent, sub) = if (nightRoute) {
+            GamePhase.DAY_DISCUSSION to DaySubPhase.BADGE_HANDOVER.name
+        } else {
+            GamePhase.DAY_VOTING to VotingSubPhase.BADGE_HANDOVER.name
+        }
+        context.game.phase = parent
+        context.game.subPhase = sub
+        gameRepository.save(context.game)
+        stompPublisher.broadcastGameAfterCommit(
+            context.gameId,
+            DomainEvent.PhaseChanged(context.gameId, parent, sub),
+        )
+    }
 
-            
-
-                    afterElimination(context)
-
-                    return GameActionResult.Success()
-
-                }
+    /**
+     * After hunter shoots (or passes) under DAY_DISCUSSION/HUNTER_SHOOT (the
+     * Phase B night-kill path): check post-shot win condition; if no winner,
+     * transition to DAY_DISCUSSION/RESULT_REVEALED so the host can proceed
+     * with the day vote.
+     *
+     * (The DAY_VOTING/HUNTER_SHOOT path uses afterHunterAct, which goes
+     * straight to NIGHT — that's the vote-out flow's contract.)
+     */
+    private fun afterHunterActNightRoute(context: GameContext) {
+        val updatedContext = contextLoader.load(context.gameId)
+        val winner = winConditionChecker.check(
+            alivePlayers = updatedContext.alivePlayers,
+            mode = updatedContext.room.winCondition,
+            trigger = WinCheckTrigger.POST_NIGHT,
+            counterplay = buildCounterplay(updatedContext),
+        )
+        if (winner != null) {
+            endGame(updatedContext, winner)
+            return
+        }
+        val game = updatedContext.game
+        game.phase = GamePhase.DAY_DISCUSSION
+        game.subPhase = DaySubPhase.RESULT_REVEALED.name
+        gameRepository.save(game)
+        stompPublisher.broadcastGameAfterCommit(
+            context.gameId,
+            DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_REVEALED.name),
+        )
+    }
 
     /** Check win condition; if no winner, stay in VOTE_RESULT for host to proceed to night. */
     private fun afterElimination(context: GameContext) {

--- a/backend/src/main/kotlin/com/werewolf/model/Enums.kt
+++ b/backend/src/main/kotlin/com/werewolf/model/Enums.kt
@@ -27,7 +27,14 @@ enum class VoteContext { SHERIFF_ELECTION, ELIMINATION }
 
 enum class WinnerSide { WEREWOLF, VILLAGER }
 
-enum class DaySubPhase { RESULT_HIDDEN, RESULT_REVEALED }
+// Phase B: BADGE_HANDOVER and HUNTER_SHOOT also live in the DAY_DISCUSSION
+// flow when a sheriff/hunter dies at NIGHT (see GamePhasePipeline.revealNightResult).
+// These values are intentionally shared with VotingSubPhase — the DB CHECK
+// constraint on games.sub_phase already accepts them (no migration needed),
+// and the parent phase (DAY_DISCUSSION vs DAY_VOTING) disambiguates which
+// flow owns the sub-phase. Handlers live in VotingPipeline and accept either
+// parent phase.
+enum class DaySubPhase { RESULT_HIDDEN, RESULT_REVEALED, BADGE_HANDOVER, HUNTER_SHOOT }
 
 enum class VotingSubPhase { VOTING, RE_VOTING, VOTE_RESULT, HUNTER_SHOOT, BADGE_HANDOVER }
 

--- a/backend/src/main/kotlin/com/werewolf/service/GameService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/GameService.kt
@@ -299,6 +299,51 @@ class GameService(
                 "idiotRevealedNickname" to idiotRevealedUser?.nickname,
                 "idiotRevealedSeatIndex" to idiotRevealedPlayer?.seatIndex,
             )
+        } else if (
+            // Phase B: when sheriff/hunter is killed at night, the game routes
+            // through DAY_DISCUSSION/{HUNTER_SHOOT,BADGE_HANDOVER} sub-phases
+            // before landing on RESULT_REVEALED. Surface a votingPhase-shaped
+            // payload so the existing VotingPhase.vue UI can render the
+            // pass-or-destroy / shoot UI under DAY_DISCUSSION too.
+            game.phase == GamePhase.DAY_DISCUSSION &&
+            (game.subPhase == DaySubPhase.HUNTER_SHOOT.name ||
+                game.subPhase == DaySubPhase.BADGE_HANDOVER.name)
+        ) {
+            val playerMap = players.associateBy { it.userId }
+            val nightPhaseRow = nightPhaseRepository.findByGameIdAndDayNumber(gameId, game.dayNumber).orElse(null)
+            // Eliminated player = the dead role driving this sub-phase.
+            //   HUNTER_SHOOT: a now-dead hunter (alive=false + role=HUNTER).
+            //   BADGE_HANDOVER: the dead sheriff (game.sheriffUserId, who is
+            //   still set on the game even though they're dead — handler
+            //   clears sheriffUserId at end of handover).
+            val eliminatedId: String? = if (game.subPhase == DaySubPhase.HUNTER_SHOOT.name) {
+                players.firstOrNull { !it.alive && it.role == PlayerRole.HUNTER }?.userId
+            } else {
+                game.sheriffUserId
+            }
+            val eliminatedPlayer = eliminatedId?.let { playerMap[it] }
+            val eliminatedUser = eliminatedId?.let { userLookup[it] }
+            mapOf(
+                "subPhase" to game.subPhase,
+                "dayNumber" to game.dayNumber,
+                "phaseDeadline" to 0L,
+                "phaseStarted" to 0L,
+                "canVote" to false, // not in voting; field kept for shape compat
+                "tallyRevealed" to false,
+                "eliminatedPlayerId" to eliminatedId,
+                "eliminatedNickname" to eliminatedUser?.nickname,
+                "eliminatedSeatIndex" to eliminatedPlayer?.seatIndex,
+                "eliminatedRole" to eliminatedPlayer?.role?.name,
+                // Used by the night-route night-result banner (frontend reads
+                // this when the eliminated role is hunter, so the UI can show
+                // "wolves killed your hunter, you may shoot one player").
+                "nightKillIds" to nightPhaseRow?.let {
+                    listOfNotNull(
+                        it.wolfTargetUserId.takeIf { _ -> !it.witchAntidoteUsed && it.guardTargetUserId != it.wolfTargetUserId },
+                        it.witchPoisonTargetUserId,
+                    )
+                },
+            )
         } else null
 
         return mapOf(

--- a/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
@@ -4,6 +4,7 @@ import com.werewolf.game.DomainEvent
 import com.werewolf.game.GameContext
 import com.werewolf.game.action.GameActionRequest
 import com.werewolf.game.action.GameActionResult
+import com.werewolf.config.GameTimingProperties
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import kotlinx.coroutines.CoroutineScope
@@ -26,6 +27,7 @@ class SheriffService(
     private val userRepository: UserRepository,
     private val stompPublisher: StompPublisher,
     private val coroutineScope: CoroutineScope,
+    private val timingProperties: GameTimingProperties,
 ) {
     val log = LoggerFactory.getLogger(SheriffService::class.java)
     private val scheduledJobs = mutableMapOf<Int, Job>()
@@ -505,9 +507,10 @@ class SheriffService(
      * — we are NOT starting a new night.
      */
     private fun scheduleAutoAdvanceFromSheriffResult(gameId: Int): Job {
-        log.info("[SheriffService] Scheduling auto-advance to day discussion for game $gameId in 60 seconds")
+        val delayMs = timingProperties.sheriffResultAutoAdvanceMs ?: 60_000L
+        log.info("[SheriffService] Scheduling auto-advance to day discussion for game $gameId in ${delayMs}ms")
         return coroutineScope.launch {
-            delay(60_000) // 60 seconds for manual interaction
+            delay(delayMs)
             log.info("[SheriffService] Auto-advance to day discussion triggered for game $gameId")
             advanceToDayDiscussion(gameId)
         }.also { job ->

--- a/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
@@ -4,14 +4,12 @@ import com.werewolf.game.DomainEvent
 import com.werewolf.game.GameContext
 import com.werewolf.game.action.GameActionRequest
 import com.werewolf.game.action.GameActionResult
-import com.werewolf.game.night.NightOrchestrator
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -27,7 +25,6 @@ class SheriffService(
     private val voteRepository: VoteRepository,
     private val userRepository: UserRepository,
     private val stompPublisher: StompPublisher,
-    private val nightOrchestrator: NightOrchestrator,
     private val coroutineScope: CoroutineScope,
 ) {
     val log = LoggerFactory.getLogger(SheriffService::class.java)
@@ -191,7 +188,9 @@ class SheriffService(
             .filter { it.status == CandidateStatus.RUNNING }
 
         if (candidates.isEmpty()) {
-            nightOrchestrator.initNight(context.gameId, context.game.dayNumber, withWaiting = true)
+            // No one ran — sheriff election is over before it starts.
+            // Variant B: return to day discussion (we're already on Day 1).
+            advanceToDayDiscussion(context.gameId)
             return GameActionResult.Success()
         }
 
@@ -275,7 +274,7 @@ class SheriffService(
                 sheriffElectionRepository.save(election)
                 broadcastAfterCommit(context.gameId,
                     DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.RESULT.name))
-                scheduleAutoAdvanceToNight(context.gameId, context.game.dayNumber)
+                scheduleAutoAdvanceFromSheriffResult(context.gameId)
             }
             return GameActionResult.Success()
         }
@@ -288,8 +287,8 @@ class SheriffService(
             broadcastAfterCommit(context.gameId, DomainEvent.SheriffElected(context.gameId, winnerUserId))
             broadcastAfterCommit(context.gameId,
                 DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.RESULT.name))
-            // Schedule auto-advance to night in 30 seconds
-            scheduleAutoAdvanceToNight(context.gameId, context.game.dayNumber)
+            // Schedule auto-advance to day discussion (60s)
+            scheduleAutoAdvanceFromSheriffResult(context.gameId)
         } else {
             election.subPhase = ElectionSubPhase.TIED
             sheriffElectionRepository.save(election)
@@ -320,8 +319,8 @@ class SheriffService(
         broadcastAfterCommit(context.gameId, DomainEvent.SheriffElected(context.gameId, targetUserId))
         broadcastAfterCommit(context.gameId,
             DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.RESULT.name))
-        // Schedule auto-advance to night in 30 seconds
-        scheduleAutoAdvanceToNight(context.gameId, context.game.dayNumber)
+        // Schedule auto-advance to day discussion (60s)
+        scheduleAutoAdvanceFromSheriffResult(context.gameId)
         return GameActionResult.Success()
     }
 
@@ -357,7 +356,7 @@ class SheriffService(
             sheriffElectionRepository.save(election)
             broadcastAfterCommit(context.gameId,
                 DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.RESULT.name))
-            scheduleAutoAdvanceToNight(context.gameId, context.game.dayNumber)
+            scheduleAutoAdvanceFromSheriffResult(context.gameId)
             return GameActionResult.Success()
         }
 
@@ -499,15 +498,39 @@ class SheriffService(
         )
     }
 
-    private fun scheduleAutoAdvanceToNight(gameId: Int, dayNumber: Int): Job {
-        log.info("[SheriffService] Scheduling auto-advance to night for game $gameId in 60 seconds")
+    /**
+     * Variant B: after the sheriff RESULT is shown, auto-advance back to
+     * DAY_DISCUSSION/RESULT_REVEALED. The host then drives the regular day
+     * cadence (dayAdvance → DAY_VOTING). The game stays on the same Day 1
+     * — we are NOT starting a new night.
+     */
+    private fun scheduleAutoAdvanceFromSheriffResult(gameId: Int): Job {
+        log.info("[SheriffService] Scheduling auto-advance to day discussion for game $gameId in 60 seconds")
         return coroutineScope.launch {
             delay(60_000) // 60 seconds for manual interaction
-            log.info("[SheriffService] Auto-advance to night triggered for game $gameId")
-            nightOrchestrator.initNight(gameId, dayNumber, withWaiting = true)
+            log.info("[SheriffService] Auto-advance to day discussion triggered for game $gameId")
+            advanceToDayDiscussion(gameId)
         }.also { job ->
             scheduledJobs[gameId] = job
         }
+    }
+
+    /**
+     * Transition SHERIFF_ELECTION → DAY_DISCUSSION/RESULT_REVEALED. Idempotent:
+     * if the phase has already moved on (e.g. a fast host clicked a manual
+     * advance before the 60s timer fired) this is a no-op.
+     */
+    @Transactional
+    fun advanceToDayDiscussion(gameId: Int) {
+        val game = gameRepository.findById(gameId).orElse(null) ?: return
+        if (game.phase != GamePhase.SHERIFF_ELECTION) return
+        game.phase = GamePhase.DAY_DISCUSSION
+        game.subPhase = DaySubPhase.RESULT_REVEALED.name
+        gameRepository.save(game)
+        broadcastAfterCommit(
+            gameId,
+            DomainEvent.PhaseChanged(gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_REVEALED.name),
+        )
     }
 
     fun cancelScheduledJob(gameId: Int) {

--- a/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
@@ -519,20 +519,26 @@ class SheriffService(
     }
 
     /**
-     * Transition SHERIFF_ELECTION → DAY_DISCUSSION/RESULT_REVEALED. Idempotent:
+     * Transition SHERIFF_ELECTION → DAY_DISCUSSION/RESULT_HIDDEN. Idempotent:
      * if the phase has already moved on (e.g. a fast host clicked a manual
-     * advance before the 60s timer fired) this is a no-op.
+     * advance before the timer fired) this is a no-op.
+     *
+     * Note: lands on RESULT_HIDDEN, not RESULT_REVEALED. The host still needs
+     * to click REVEAL_NIGHT_RESULT to flip the deaths into RESULT_REVEALED
+     * (and to actually apply the deferred N1 kills). This preserves the
+     * traditional 狼人杀 cadence: sheriff election happens BEFORE death
+     * announcement, so N1 victims could 上警 and use 挡刀 / 撕牌 tactics.
      */
     @Transactional
     fun advanceToDayDiscussion(gameId: Int) {
         val game = gameRepository.findById(gameId).orElse(null) ?: return
         if (game.phase != GamePhase.SHERIFF_ELECTION) return
         game.phase = GamePhase.DAY_DISCUSSION
-        game.subPhase = DaySubPhase.RESULT_REVEALED.name
+        game.subPhase = DaySubPhase.RESULT_HIDDEN.name
         gameRepository.save(game)
         broadcastAfterCommit(
             gameId,
-            DomainEvent.PhaseChanged(gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_REVEALED.name),
+            DomainEvent.PhaseChanged(gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_HIDDEN.name),
         )
     }
 

--- a/backend/src/main/resources/application-e2e.yml
+++ b/backend/src/main/resources/application-e2e.yml
@@ -42,3 +42,4 @@ werewolf:
     inter-role-gap-ms: 500
     night-init-audio-delay-ms: 1000
     waiting-delay-ms: 500
+    sheriff-result-auto-advance-ms: 2000

--- a/backend/src/test/kotlin/com/werewolf/integration/GuardProtectionIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/GuardProtectionIntegrationTest.kt
@@ -57,6 +57,7 @@ class GuardProtectionIntegrationTest {
             gameRepository = gameRepository,
             gamePlayerRepository = gamePlayerRepository,
             nightPhaseRepository = nightPhaseRepository,
+            sheriffElectionRepository = mock(),
             eliminationHistoryRepository = eliminationHistoryRepository,
             winConditionChecker = winConditionChecker,
             stompPublisher = stompPublisher,
@@ -84,7 +85,10 @@ class GuardProtectionIntegrationTest {
         totalPlayers = 6,
         hasSeer = false,
         hasWitch = false,
-        hasGuard = true
+        hasGuard = true,
+        // Variant B: keep this test on the DAY_DISCUSSION end-of-night branch
+        // (sheriff election would intercept on Day 1 with hasSheriff=true).
+        hasSheriff = false,
     )
 
     private fun player(userId: String, seat: Int, role: PlayerRole = PlayerRole.VILLAGER, alive: Boolean = true) =
@@ -165,26 +169,22 @@ class GuardProtectionIntegrationTest {
         assertThat(guardResult).isInstanceOf(GameActionResult.Success::class.java)
         assertThat(np.guardTargetUserId).isEqualTo(victimId)
 
-        // Step 3: Resolve night kills
-        whenever(contextLoader.load(gameId))
-            .thenReturn(ctx(wolf, guard, victim))
+        // Step 3: Resolve night kills (Variant B: kills deferred; no
+        // contextLoader.load call needed by the new resolveNightKills.)
         whenever(winConditionChecker.check(any(), any(), any(), any())).thenReturn(null)
         mockAudioSequenceForDayTransition()
 
         nightOrchestrator.resolveNightKills(guardCtx, np)
 
-        // Verify victim survives
+        // Variant B: kills are deferred until host REVEAL_NIGHT_RESULT.
+        // Guard-saved victim has no pending kill regardless.
         assertThat(victim.alive).isTrue()
-
-        // Verify victim is not saved (no kill)
         verify(gamePlayerRepository, never()).save(victim)
+        assertThat(nightOrchestrator.computePendingKills(np)).isEmpty()
 
-        // Verify NightResult is broadcast with no kills
-        verify(stompPublisher).broadcastGame(eq(gameId), argThat { e ->
-            e is DomainEvent.NightResult && e.kills.isEmpty()
-        })
-
-        // Verify game transitions to DAY phase
+        // NightResult is no longer broadcast at end-of-night (it would leak
+        // pending kill list before host controls the reveal moment). Only
+        // PhaseChanged + AudioSequence fire here.
         verify(gameRepository).save(argThat<Game> { g -> g.phase == GamePhase.DAY_DISCUSSION })
     }
 
@@ -217,24 +217,18 @@ class GuardProtectionIntegrationTest {
         )
         guardHandler.handle(guardRequest, wolfCtx)
 
-        // Resolve night kills
-        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, victimId))
-            .thenReturn(Optional.of(victim))
-        whenever(contextLoader.load(gameId))
-            .thenReturn(ctx(wolf, guard, victim, otherPlayer))
+        // Resolve night kills (Variant B: kills deferred; no save/lookup yet.)
         whenever(winConditionChecker.check(any(), any(), any(), any())).thenReturn(null)
         mockAudioSequenceForDayTransition()
 
         nightOrchestrator.resolveNightKills(wolfCtx, np)
 
-        // Verify victim dies (not protected)
-        assertThat(victim.alive).isFalse()
-        verify(gamePlayerRepository).save(victim)
-
-        // Verify NightResult includes victim
-        verify(stompPublisher).broadcastGame(eq(gameId), argThat { e ->
-            e is DomainEvent.NightResult && e.kills.contains(victimId)
-        })
+        // Variant B: kill is computed but deferred. Pending kill list contains
+        // victim; alive flip happens later via applyNightKills (called from
+        // GamePhasePipeline.revealNightResult on host's reveal click).
+        assertThat(nightOrchestrator.computePendingKills(np)).contains(victimId)
+        assertThat(victim.alive).isTrue()
+        verify(gamePlayerRepository, never()).save(victim)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/werewolf/integration/NightPhaseDeadRoleIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/NightPhaseDeadRoleIntegrationTest.kt
@@ -226,7 +226,16 @@ class NightPhaseDeadRoleIntegrationTest {
         // Wait for night resolution (last role close eyes audio + resolveNightKills)
         Thread.sleep(5000)
 
-        // Verify seer and wolf2 are dead after night 1
+        // Variant B: kills are deferred until host reveals. Verify pending
+        // kills are computed correctly, then apply them manually so the rest
+        // of the test (which depends on actual deaths to drive N2's dead-
+        // role audio) works without driving REVEAL_NIGHT_RESULT.
+        val n1Phase = nightPhaseRepository.findByGameIdAndDayNumber(gameId, 1).orElseThrow()
+        val pendingN1 = nightOrchestrator.computePendingKills(n1Phase)
+        assertThat(pendingN1).contains(seerUserId, wolf2UserId)
+        nightOrchestrator.applyNightKills(gameId, pendingN1)
+
+        // Verify seer and wolf2 are dead after applying N1 kills
         val seerPlayer = gamePlayerRepository.findByGameIdAndUserId(gameId, seerUserId).orElseThrow()
         assertThat(seerPlayer.alive).isFalse()
         val wolf2Player = gamePlayerRepository.findByGameIdAndUserId(gameId, wolf2UserId).orElseThrow()
@@ -265,6 +274,11 @@ class NightPhaseDeadRoleIntegrationTest {
         val day2Game = gameRepository.findById(gameId).orElseThrow()
         assertThat(day2Game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
         assertThat(day2Game.dayNumber).isEqualTo(2)
+
+        // Variant B: apply N2 deferred kills so the post-N2 alive assertion
+        // matches reality (N2 kill is computed but not applied until reveal).
+        val n2Phase = nightPhaseRepository.findByGameIdAndDayNumber(gameId, 2).orElseThrow()
+        nightOrchestrator.applyNightKills(gameId, nightOrchestrator.computePendingKills(n2Phase))
 
         // Verify villager is dead
         val villagerPlayer = gamePlayerRepository.findByGameIdAndUserId(gameId, night2Target.userId).orElseThrow()
@@ -331,6 +345,16 @@ class NightPhaseDeadRoleIntegrationTest {
         // After night 1: 1W + Witch + Guard + 1V alive (seer + wolf2 dead)
         val dayGame = gameRepository.findById(gameId).orElseThrow()
         assertThat(dayGame.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+
+        // Variant B: kills are deferred until host reveals. Apply N1 kills
+        // manually so seer/wolf2 are actually dead before N2 starts (matches
+        // how the test simulates witch/guard deaths below).
+        gamePlayerRepository.findByGameIdAndUserId(gameId, seerUserId).ifPresent {
+            it.alive = false; gamePlayerRepository.save(it)
+        }
+        gamePlayerRepository.findByGameIdAndUserId(gameId, wolf2UserId).ifPresent {
+            it.alive = false; gamePlayerRepository.save(it)
+        }
 
         // ── Simulate prior rounds: mark witch and guard as dead ──
         // This lets us test the "all special roles dead" night scenario

--- a/backend/src/test/kotlin/com/werewolf/integration/SheriffElectionEdgeCaseIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/SheriffElectionEdgeCaseIntegrationTest.kt
@@ -10,8 +10,12 @@ import com.werewolf.integration.TestConstants.JOIN_ROOM_URL
 import com.werewolf.integration.TestConstants.LOGIN_URL
 import com.werewolf.model.ElectionSubPhase
 import com.werewolf.model.GamePhase
+import com.werewolf.model.NightPhase
+import com.werewolf.model.NightSubPhase
+import com.werewolf.model.SheriffElection
 import com.werewolf.repository.GamePlayerRepository
 import com.werewolf.repository.GameRepository
+import com.werewolf.repository.NightPhaseRepository
 import com.werewolf.repository.SheriffElectionRepository
 import com.werewolf.service.SheriffService
 import org.assertj.core.api.Assertions.assertThat
@@ -34,6 +38,7 @@ class SheriffElectionEdgeCaseIntegrationTest {
     @Autowired lateinit var gameRepository: GameRepository
     @Autowired lateinit var gamePlayerRepository: GamePlayerRepository
     @Autowired lateinit var sheriffElectionRepository: SheriffElectionRepository
+    @Autowired lateinit var nightPhaseRepository: NightPhaseRepository
     @Autowired lateinit var sheriffService: SheriffService
 
     companion object {
@@ -104,7 +109,13 @@ class SheriffElectionEdgeCaseIntegrationTest {
         return players to roomId
     }
 
-    private fun startGameAndConfirmRoles(players: List<TestPlayer>, roomId: Int): Int {
+    /**
+     * Variant B: arrange production-equivalent state for sheriff election
+     * (phase=SHERIFF_ELECTION/SIGNUP with a completed Day 1 NightPhase).
+     * Bypasses START_NIGHT + night actions + REVEAL_NIGHT_RESULT — the
+     * full night flow is not the focus of these tests.
+     */
+    private fun startGameAndOpenSheriffElection(players: List<TestPlayer>, roomId: Int): Int {
         val host = players[0]
         val startResp = restTemplate.postForEntity(
             START_URL, HttpEntity(mapOf("roomId" to roomId), headers(host.token)), Map::class.java
@@ -117,6 +128,15 @@ class SheriffElectionEdgeCaseIntegrationTest {
         players.forEach { player ->
             assertThat(action(player.token, gameId, "CONFIRM_ROLE").statusCode).isEqualTo(HttpStatus.OK)
         }
+
+        game.phase = GamePhase.SHERIFF_ELECTION
+        game.subPhase = null
+        game.dayNumber = 1
+        gameRepository.save(game)
+        nightPhaseRepository.save(NightPhase(gameId = gameId, dayNumber = 1).also {
+            it.subPhase = NightSubPhase.COMPLETE
+        })
+        sheriffElectionRepository.save(SheriffElection(gameId = gameId))
         return gameId
     }
 
@@ -138,7 +158,7 @@ class SheriffElectionEdgeCaseIntegrationTest {
         val (players, roomId) = setupSheriffRoom("EC1")
         val host = players[0]; val g1 = players[1]; val g2 = players[2]; val g3 = players[3]
         val g4 = players[4]; val g5 = players[5]
-        val gameId = startGameAndConfirmRoles(players, roomId)
+        val gameId = startGameAndOpenSheriffElection(players, roomId)
 
         // SIGNUP: g1, g2, g3 campaign; others pass
         assertThat(action(g1.token, gameId, "SHERIFF_CAMPAIGN").statusCode).isEqualTo(HttpStatus.OK)
@@ -197,7 +217,7 @@ class SheriffElectionEdgeCaseIntegrationTest {
         val (players, roomId) = setupSheriffRoom("EC1a")
         val host = players[0]; val g1 = players[1]; val g2 = players[2]; val g3 = players[3]
         val g4 = players[4]; val g5 = players[5]
-        val gameId = startGameAndConfirmRoles(players, roomId)
+        val gameId = startGameAndOpenSheriffElection(players, roomId)
 
         // SIGNUP: g1, g2, g3 campaign; others pass
         assertThat(action(g1.token, gameId, "SHERIFF_CAMPAIGN").statusCode).isEqualTo(HttpStatus.OK)
@@ -236,7 +256,7 @@ class SheriffElectionEdgeCaseIntegrationTest {
         val (players, roomId) = setupSheriffRoom("EC1b")
         val host = players[0]; val g1 = players[1]; val g2 = players[2]; val g3 = players[3]
         val g4 = players[4]; val g5 = players[5]
-        val gameId = startGameAndConfirmRoles(players, roomId)
+        val gameId = startGameAndOpenSheriffElection(players, roomId)
 
         // SIGNUP: g1, g2, g3 campaign; others pass
         assertThat(action(g1.token, gameId, "SHERIFF_CAMPAIGN").statusCode).isEqualTo(HttpStatus.OK)

--- a/backend/src/test/kotlin/com/werewolf/integration/SheriffElectionIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/SheriffElectionIntegrationTest.kt
@@ -277,7 +277,10 @@ class SheriffElectionIntegrationTest {
 
         val savedGame = gameRepository.findById(gameId).orElseThrow()
         assertThat(savedGame.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
-        assertThat(savedGame.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        // Variant B: post-sheriff auto-advance lands on RESULT_HIDDEN — host
+        // still needs to click REVEAL_NIGHT_RESULT to apply pending kills and
+        // flip to RESULT_REVEALED.
+        assertThat(savedGame.subPhase).isEqualTo(DaySubPhase.RESULT_HIDDEN.name)
         assertThat(savedGame.dayNumber).isEqualTo(1)
         // No sheriff was elected
         assertThat(savedGame.sheriffUserId).isNull()

--- a/backend/src/test/kotlin/com/werewolf/integration/SheriffElectionIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/SheriffElectionIntegrationTest.kt
@@ -1,6 +1,5 @@
 package com.werewolf.integration
 
-import com.werewolf.game.night.NightOrchestrator
 import com.werewolf.integration.TestConstants.CREATE_ROOM_URL
 import com.werewolf.integration.TestConstants.FIELD_CONFIG
 import com.werewolf.integration.TestConstants.FIELD_ROOM_CODE
@@ -9,9 +8,12 @@ import com.werewolf.integration.TestConstants.FIELD_TOKEN
 import com.werewolf.integration.TestConstants.FIELD_TOTAL_PLAYERS
 import com.werewolf.integration.TestConstants.JOIN_ROOM_URL
 import com.werewolf.integration.TestConstants.LOGIN_URL
+import com.werewolf.model.DaySubPhase
 import com.werewolf.model.ElectionSubPhase
 import com.werewolf.model.GamePhase
+import com.werewolf.model.NightPhase
 import com.werewolf.model.NightSubPhase
+import com.werewolf.model.SheriffElection
 import com.werewolf.repository.GamePlayerRepository
 import com.werewolf.repository.GameRepository
 import com.werewolf.repository.NightPhaseRepository
@@ -38,7 +40,6 @@ class SheriffElectionIntegrationTest {
     @Autowired lateinit var gamePlayerRepository: GamePlayerRepository
     @Autowired lateinit var sheriffElectionRepository: SheriffElectionRepository
     @Autowired lateinit var nightPhaseRepository: NightPhaseRepository
-    @Autowired lateinit var nightOrchestrator: NightOrchestrator
     @Autowired lateinit var sheriffService: SheriffService
 
     companion object {
@@ -123,8 +124,14 @@ class SheriffElectionIntegrationTest {
         assertThat(election.subPhase).isEqualTo(ElectionSubPhase.VOTING)
     }
 
-    /** Start game, confirm all roles. Returns gameId. Game is now in SHERIFF_ELECTION/SIGNUP. */
-    private fun startGameAndConfirmRoles(host: TestPlayer, players: List<TestPlayer>, roomId: Int): Int {
+    /**
+     * Start game, confirm all roles, and arrange production-equivalent state
+     * for sheriff election: phase=SHERIFF_ELECTION/SIGNUP with a completed
+     * Day 1 NightPhase. Production reaches this via START_NIGHT → night
+     * actions → REVEAL_NIGHT_RESULT, but we bypass the full night here since
+     * the night flow is not under test.
+     */
+    private fun startGameAndOpenSheriffElection(host: TestPlayer, players: List<TestPlayer>, roomId: Int): Int {
         val startResp = restTemplate.postForEntity(
             START_URL, HttpEntity(mapOf("roomId" to roomId), headers(host.token)), Map::class.java
         )
@@ -136,6 +143,15 @@ class SheriffElectionIntegrationTest {
         players.forEach { player ->
             assertThat(action(player.token, gameId, "CONFIRM_ROLE").statusCode).isEqualTo(HttpStatus.OK)
         }
+
+        game.phase = GamePhase.SHERIFF_ELECTION
+        game.subPhase = null
+        game.dayNumber = 1
+        gameRepository.save(game)
+        nightPhaseRepository.save(NightPhase(gameId = gameId, dayNumber = 1).also {
+            it.subPhase = NightSubPhase.COMPLETE
+        })
+        sheriffElectionRepository.save(SheriffElection(gameId = gameId))
         return gameId
     }
 
@@ -145,7 +161,7 @@ class SheriffElectionIntegrationTest {
     fun `sheriff election - single candidate wins, sheriffUserId and sheriff flag are set, game advances to NIGHT`() {
         val (host, g1, g2, g3, g4, g5, roomId) = setupSheriffRoom("SE1")
         val allPlayers = listOf(host, g1, g2, g3, g4, g5)
-        val gameId = startGameAndConfirmRoles(host, allPlayers, roomId)
+        val gameId = startGameAndOpenSheriffElection(host, allPlayers, roomId)
 
         // SIGNUP: g1 and g2 campaign; others pass
         assertThat(action(g1.token, gameId, "SHERIFF_CAMPAIGN").statusCode).isEqualTo(HttpStatus.OK)
@@ -191,7 +207,7 @@ class SheriffElectionIntegrationTest {
     fun `sheriff election - tied vote, host appoints, sheriffUserId is set`() {
         val (host, g1, g2, g3, g4, g5, roomId) = setupSheriffRoom("SE2")
         val allPlayers = listOf(host, g1, g2, g3, g4, g5)
-        val gameId = startGameAndConfirmRoles(host, allPlayers, roomId)
+        val gameId = startGameAndOpenSheriffElection(host, allPlayers, roomId)
 
         // SIGNUP: g1 and g2 both campaign
         assertThat(action(g1.token, gameId, "SHERIFF_CAMPAIGN").statusCode).isEqualTo(HttpStatus.OK)
@@ -241,10 +257,13 @@ class SheriffElectionIntegrationTest {
     // ── Test 3: No-candidate shortcut ─────────────────────────────────────────
 
     @Test
-    fun `sheriff election - no candidates, SHERIFF_START_SPEECH transitions directly to NIGHT`() {
+    fun `sheriff election - no candidates, SHERIFF_START_SPEECH returns to day discussion`() {
+        // Variant B: when no one runs, sheriff election ends immediately and
+        // the game returns to DAY_DISCUSSION/RESULT_REVEALED so the host can
+        // proceed with day voting (we are still on Day 1, NOT moving to N2).
         val (host, g1, g2, g3, g4, g5, roomId) = setupSheriffRoom("SE3")
         val allPlayers = listOf(host, g1, g2, g3, g4, g5)
-        val gameId = startGameAndConfirmRoles(host, allPlayers, roomId)
+        val gameId = startGameAndOpenSheriffElection(host, allPlayers, roomId)
 
         // SIGNUP: all players pass — no candidates
         assertThat(action(host.token, gameId, "SHERIFF_PASS").statusCode).isEqualTo(HttpStatus.OK)
@@ -254,18 +273,12 @@ class SheriffElectionIntegrationTest {
         assertThat(action(g4.token, gameId, "SHERIFF_PASS").statusCode).isEqualTo(HttpStatus.OK)
         assertThat(action(g5.token, gameId, "SHERIFF_PASS").statusCode).isEqualTo(HttpStatus.OK)
 
-        // No-candidate shortcut: SHERIFF_START_SPEECH calls initNight(withWaiting=true).
-        // Night starts immediately (WAITING sub-phase) without blocking — roles advance via player actions.
         assertThat(action(host.token, gameId, "SHERIFF_START_SPEECH").statusCode).isEqualTo(HttpStatus.OK)
 
-        // Game has transitioned from SHERIFF_ELECTION to NIGHT
         val savedGame = gameRepository.findById(gameId).orElseThrow()
-        assertThat(savedGame.phase).isEqualTo(GamePhase.NIGHT)
-
-        // Night phase record was created in WAITING sub-phase (ready for first role to act)
-        val nightPhase = nightPhaseRepository.findByGameIdAndDayNumber(gameId, savedGame.dayNumber).orElseThrow()
-        assertThat(nightPhase.subPhase).isEqualTo(NightSubPhase.WAITING)
-
+        assertThat(savedGame.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(savedGame.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        assertThat(savedGame.dayNumber).isEqualTo(1)
         // No sheriff was elected
         assertThat(savedGame.sheriffUserId).isNull()
     }

--- a/backend/src/test/kotlin/com/werewolf/unit/role/HookInvocationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/role/HookInvocationTest.kt
@@ -48,7 +48,10 @@ class HookInvocationTest {
             it.dayNumber = 1
         }
 
-    private fun room() = Room(roomCode = "ABCD", hostUserId = hostId, totalPlayers = 6)
+    // hasSheriff=false keeps resolveNightKills on the DAY_DISCUSSION/RESULT_HIDDEN
+    // branch where onDayEnter fires. Sheriff election (Day 1 + hasSheriff=true)
+    // takes a separate code path tested elsewhere.
+    private fun room() = Room(roomCode = "ABCD", hostUserId = hostId, totalPlayers = 6, hasSheriff = false)
 
     private fun player(userId: String, seat: Int, role: PlayerRole = PlayerRole.VILLAGER, alive: Boolean = true) =
         GamePlayer(gameId = gameId, userId = userId, seatIndex = seat, role = role).also { it.alive = alive }
@@ -90,6 +93,7 @@ class HookInvocationTest {
         gameRepository = gameRepository,
         gamePlayerRepository = gamePlayerRepository,
         nightPhaseRepository = nightPhaseRepository,
+        sheriffElectionRepository = mock(),
         eliminationHistoryRepository = eliminationHistoryRepository,
         winConditionChecker = winConditionChecker,
         stompPublisher = stompPublisher,
@@ -126,7 +130,6 @@ class HookInvocationTest {
         val villagerHandler = dayEnterHandler(PlayerRole.VILLAGER)
         val orchestrator = makeOrchestrator(listOf(wolfHandler, villagerHandler))
 
-        whenever(contextLoader.load(gameId)).thenReturn(initialCtx)
         whenever(winConditionChecker.check(any(), any(), any(), any())).thenReturn(null)
         whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
 
@@ -169,9 +172,9 @@ class HookInvocationTest {
         val wolfHandler = dayEnterHandler(PlayerRole.WEREWOLF)
         val orchestrator = makeOrchestrator(listOf(wolfHandler))
 
-        whenever(contextLoader.load(gameId)).thenReturn(initialCtx)
         whenever(winConditionChecker.check(any(), any(), any(), any())).thenReturn(WinnerSide.WEREWOLF)
         whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+        whenever(nightPhaseRepository.save(any<NightPhase>())).thenAnswer { it.arguments[0] }
 
         orchestrator.resolveNightKills(initialCtx, np)
 

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GamePhasePipelineDayTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GamePhasePipelineDayTest.kt
@@ -8,7 +8,9 @@ import com.werewolf.game.phase.GamePhasePipeline
 import com.werewolf.model.*
 import com.werewolf.repository.GamePlayerRepository
 import com.werewolf.repository.GameRepository
+import com.werewolf.repository.NightPhaseRepository
 import com.werewolf.repository.SheriffElectionRepository
+import com.werewolf.service.ActionLogService
 import com.werewolf.service.GameContextLoader
 import com.werewolf.service.SheriffService
 import com.werewolf.service.StompPublisher
@@ -28,11 +30,13 @@ class GamePhasePipelineDayTest {
 
     @Mock lateinit var gameRepository: GameRepository
     @Mock lateinit var gamePlayerRepository: GamePlayerRepository
+    @Mock lateinit var nightPhaseRepository: NightPhaseRepository
     @Mock lateinit var sheriffElectionRepository: SheriffElectionRepository
     @Mock lateinit var stompPublisher: StompPublisher
     @Mock lateinit var contextLoader: GameContextLoader
     @Mock lateinit var sheriffService: SheriffService
     @Mock lateinit var nightOrchestrator: NightOrchestrator
+    @Mock lateinit var actionLogService: ActionLogService
     @InjectMocks lateinit var pipeline: GamePhasePipeline
 
     private val gameId = 10

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
@@ -243,4 +243,124 @@ class GamePipelineSheriffTest {
         verifyNoInteractions(sheriffElectionRepository)
         assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
     }
+
+    // ── Phase B: night-kill HUNTER_SHOOT and BADGE_HANDOVER routing ───────────
+
+    @Test
+    fun `revealNightResult routes to HUNTER_SHOOT when killed player is HUNTER (Phase B)`() {
+        // Wolf killed player u3 who happens to be a hunter. Hunter should get
+        // a chance to shoot before the night result is fully revealed.
+        val np = NightPhase(gameId = gameId, dayNumber = 1).also {
+            it.subPhase = NightSubPhase.COMPLETE
+            it.wolfTargetUserId = "u3"
+        }
+        whenever(nightPhaseRepository.findByGameIdAndDayNumber(gameId, 1)).thenReturn(Optional.of(np))
+        whenever(nightOrchestrator.computePendingKills(np)).thenReturn(listOf("u3"))
+
+        val hunter = GamePlayer(gameId = gameId, userId = "u3", seatIndex = 3, role = PlayerRole.HUNTER)
+        val villager = GamePlayer(gameId = gameId, userId = "u4", seatIndex = 4, role = PlayerRole.VILLAGER)
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(listOf(hunter, villager))
+
+        val ctx = GameContext(
+            game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name),
+            room(hasSheriff = false),
+            emptyList(),
+        )
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        val result = pipeline.revealNightResult(req, ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        verify(nightOrchestrator).applyNightKills(gameId, listOf("u3"))
+        // Routes to HUNTER_SHOOT, not RESULT_REVEALED.
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.HUNTER_SHOOT.name)
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+    }
+
+    @Test
+    fun `revealNightResult routes to BADGE_HANDOVER when killed player is sheriff (Phase B)`() {
+        // Wolf killed the sheriff. Sheriff should choose pass-or-destroy
+        // before the day continues.
+        val sheriffId = "sheriff:001"
+        val np = NightPhase(gameId = gameId, dayNumber = 2).also {
+            it.subPhase = NightSubPhase.COMPLETE
+            it.wolfTargetUserId = sheriffId
+        }
+        whenever(nightPhaseRepository.findByGameIdAndDayNumber(gameId, 2)).thenReturn(Optional.of(np))
+        whenever(nightOrchestrator.computePendingKills(np)).thenReturn(listOf(sheriffId))
+
+        val sheriff = GamePlayer(gameId = gameId, userId = sheriffId, seatIndex = 5, role = PlayerRole.VILLAGER)
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(listOf(sheriff))
+
+        val gameWithSheriff = game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 2, subPhase = DaySubPhase.RESULT_HIDDEN.name)
+            .also { it.sheriffUserId = sheriffId }
+        val ctx = GameContext(gameWithSheriff, room(hasSheriff = true), emptyList())
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        val result = pipeline.revealNightResult(req, ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        verify(nightOrchestrator).applyNightKills(gameId, listOf(sheriffId))
+        // Routes to BADGE_HANDOVER under DAY_DISCUSSION.
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.BADGE_HANDOVER.name)
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+    }
+
+    @Test
+    fun `revealNightResult prioritises HUNTER_SHOOT when both hunter and sheriff are killed`() {
+        // Wolf killed hunter, witch poisoned sheriff. HUNTER_SHOOT fires first;
+        // the hunter handler chains to BADGE_HANDOVER if its shot target
+        // happens to be the (now-also-dead) sheriff. Otherwise badge handover
+        // can be triggered by the test logic afterwards. This test only
+        // asserts the immediate routing decision: HUNTER_SHOOT first.
+        val sheriffId = "sheriff:002"
+        val hunterId = "hunter:001"
+        val np = NightPhase(gameId = gameId, dayNumber = 3).also {
+            it.subPhase = NightSubPhase.COMPLETE
+            it.wolfTargetUserId = hunterId
+            it.witchPoisonTargetUserId = sheriffId
+        }
+        whenever(nightPhaseRepository.findByGameIdAndDayNumber(gameId, 3)).thenReturn(Optional.of(np))
+        whenever(nightOrchestrator.computePendingKills(np)).thenReturn(listOf(hunterId, sheriffId))
+
+        val hunter = GamePlayer(gameId = gameId, userId = hunterId, seatIndex = 1, role = PlayerRole.HUNTER)
+        val sheriff = GamePlayer(gameId = gameId, userId = sheriffId, seatIndex = 2, role = PlayerRole.VILLAGER)
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(listOf(hunter, sheriff))
+
+        val gameWithSheriff = game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 3, subPhase = DaySubPhase.RESULT_HIDDEN.name)
+            .also { it.sheriffUserId = sheriffId }
+        val ctx = GameContext(gameWithSheriff, room(hasSheriff = true), emptyList())
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        pipeline.revealNightResult(req, ctx)
+
+        // Hunter shoots first; badge handover follows in the hunter handler
+        // (DAY_DISCUSSION/HUNTER_SHOOT → … → BADGE_HANDOVER if applicable).
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.HUNTER_SHOOT.name)
+    }
+
+    @Test
+    fun `revealNightResult routes to RESULT_REVEALED when no special role killed`() {
+        val np = NightPhase(gameId = gameId, dayNumber = 1).also {
+            it.subPhase = NightSubPhase.COMPLETE
+            it.wolfTargetUserId = "u3"
+        }
+        whenever(nightPhaseRepository.findByGameIdAndDayNumber(gameId, 1)).thenReturn(Optional.of(np))
+        whenever(nightOrchestrator.computePendingKills(np)).thenReturn(listOf("u3"))
+
+        // Killed player is just a villager (no special role).
+        val villager = GamePlayer(gameId = gameId, userId = "u3", seatIndex = 3, role = PlayerRole.VILLAGER)
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(listOf(villager))
+
+        val ctx = GameContext(
+            game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name),
+            room(hasSheriff = true),
+            emptyList(),
+        )
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        pipeline.revealNightResult(req, ctx)
+
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+    }
 }

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
@@ -19,6 +19,12 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
 import java.util.*
 
+/**
+ * Tests for the Variant B sheriff-election flow:
+ *  - ROLE_REVEAL → host calls START_NIGHT → NIGHT 1 (regardless of hasSheriff)
+ *  - NIGHT 1 result revealed on Day 1 → if hasSheriff, auto-trigger
+ *    SHERIFF_ELECTION/SIGNUP. Otherwise stay in DAY_DISCUSSION/RESULT_REVEALED.
+ */
 @ExtendWith(MockitoExtension::class)
 class GamePipelineSheriffTest {
 
@@ -35,10 +41,13 @@ class GamePipelineSheriffTest {
     private val hostId = "host:001"
     private val guestId = "guest:001"
 
-    private fun game() = Game(roomId = 1, hostUserId = hostId).also {
-        val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
-        it.phase = GamePhase.ROLE_REVEAL
-    }
+    private fun game(phase: GamePhase = GamePhase.ROLE_REVEAL, dayNumber: Int = 1, subPhase: String? = null) =
+        Game(roomId = 1, hostUserId = hostId).also {
+            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
+            it.phase = phase
+            it.dayNumber = dayNumber
+            it.subPhase = subPhase
+        }
 
     private fun room(hasSheriff: Boolean = true) = Room(
         roomCode = "ABCD", hostUserId = hostId, totalPlayers = 4, hasSheriff = hasSheriff
@@ -48,40 +57,16 @@ class GamePipelineSheriffTest {
         gameId = gameId, userId = userId, seatIndex = seat, role = PlayerRole.VILLAGER
     ).also { it.confirmedRole = true }
 
-    private fun context(hasSheriff: Boolean = true): GameContext {
-        val game = game()
-        return GameContext(game, room(hasSheriff), emptyList())
-    }
-
-    // ── confirmRole with hasSheriff=false ──────────────────────────────────────
+    // ── confirmRole always stays in ROLE_REVEAL ───────────────────────────────
 
     @Test
-    fun `confirmRole with hasSheriff=false-stays in ROLE_REVEAL when not all confirmed`() {
-        val ctx = context(hasSheriff = false)
+    fun `confirmRole always stays in ROLE_REVEAL (hasSheriff=true)`() {
+        // Variant B: confirmRole only updates the player's confirmedRole flag.
+        // It never creates a SheriffElection or transitions the game phase —
+        // the host drives the next step (START_NIGHT).
+        val ctx = GameContext(game(), room(hasSheriff = true), emptyList())
         val player = GamePlayer(gameId = gameId, userId = guestId, seatIndex = 1, role = PlayerRole.VILLAGER)
         whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, guestId)).thenReturn(Optional.of(player))
-        val allPlayers = listOf(
-            confirmedPlayer(hostId, 0),
-            player, // guestId not yet confirmed
-        )
-        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(allPlayers)
-
-        val req = GameActionRequest(gameId, guestId, ActionType.CONFIRM_ROLE)
-        val result = pipeline.confirmRole(req, ctx)
-
-        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
-        verifyNoInteractions(sheriffElectionRepository)
-        verifyNoInteractions(nightOrchestrator)
-    }
-
-    @Test
-    fun `confirmRole with hasSheriff=false-does NOT create SheriffElection when all confirmed`() {
-        val ctx = context(hasSheriff = false)
-        val player = GamePlayer(gameId = gameId, userId = guestId, seatIndex = 1, role = PlayerRole.VILLAGER)
-        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, guestId)).thenReturn(Optional.of(player))
-        val allPlayers = listOf(confirmedPlayer(hostId, 0), confirmedPlayer(guestId, 1))
-        // After save, player is confirmed-simulate all confirmed
-        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(allPlayers)
 
         val req = GameActionRequest(gameId, guestId, ActionType.CONFIRM_ROLE)
         val result = pipeline.confirmRole(req, ctx)
@@ -90,57 +75,55 @@ class GamePipelineSheriffTest {
         verifyNoInteractions(sheriffElectionRepository)
         verifyNoInteractions(nightOrchestrator)
         verifyNoInteractions(gameRepository)
-        verify(stompPublisher).broadcastGameAfterCommit(eq(gameId), any())
     }
 
     @Test
-    fun `confirmRole with hasSheriff=true-creates SheriffElection when all confirmed`() {
-        val ctx = context(hasSheriff = true)
+    fun `confirmRole always stays in ROLE_REVEAL (hasSheriff=false)`() {
+        val ctx = GameContext(game(), room(hasSheriff = false), emptyList())
         val player = GamePlayer(gameId = gameId, userId = guestId, seatIndex = 1, role = PlayerRole.VILLAGER)
         whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, guestId)).thenReturn(Optional.of(player))
-        val allPlayers = listOf(confirmedPlayer(hostId, 0), confirmedPlayer(guestId, 1))
-        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(allPlayers)
-        whenever(sheriffElectionRepository.save(any<SheriffElection>())).thenAnswer { it.arguments[0] }
 
         val req = GameActionRequest(gameId, guestId, ActionType.CONFIRM_ROLE)
         val result = pipeline.confirmRole(req, ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
-        verify(sheriffElectionRepository).save(any<SheriffElection>())
+        verifyNoInteractions(sheriffElectionRepository)
         verifyNoInteractions(nightOrchestrator)
+        verifyNoInteractions(gameRepository)
     }
 
-    // ── startNight ─────────────────────────────────────────────────────────────
+    // ── startNight is allowed regardless of hasSheriff ─────────────────────────
 
     @Test
-    fun `startNight-transitions to NIGHT when all confirmed and hasSheriff=false`() {
-        val ctx = context(hasSheriff = false)
+    fun `startNight transitions to NIGHT when all confirmed and hasSheriff=false`() {
+        val ctx = GameContext(game(), room(hasSheriff = false), emptyList())
         val allConfirmed = listOf(confirmedPlayer(hostId, 0), confirmedPlayer(guestId, 1))
         whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(allConfirmed)
 
-        val req = GameActionRequest(gameId, hostId, ActionType.START_NIGHT)
-        val result = pipeline.startNight(req, ctx)
+        val result = pipeline.startNight(GameActionRequest(gameId, hostId, ActionType.START_NIGHT), ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
         verify(nightOrchestrator).initNight(gameId, 1, null, true)
     }
 
     @Test
-    fun `startNight-rejected if hasSheriff=true`() {
-        val ctx = context(hasSheriff = true)
-        val req = GameActionRequest(gameId, hostId, ActionType.START_NIGHT)
-        val result = pipeline.startNight(req, ctx)
+    fun `startNight transitions to NIGHT when all confirmed and hasSheriff=true (Variant B)`() {
+        // Variant B: sheriff election no longer gates start-of-night. Host
+        // starts Night 1, then sheriff election runs on Day 1 morning.
+        val ctx = GameContext(game(), room(hasSheriff = true), emptyList())
+        val allConfirmed = listOf(confirmedPlayer(hostId, 0), confirmedPlayer(guestId, 1))
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(allConfirmed)
 
-        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
-        assertThat((result as GameActionResult.Rejected).reason).contains("Sheriff election is enabled")
-        verifyNoInteractions(nightOrchestrator)
+        val result = pipeline.startNight(GameActionRequest(gameId, hostId, ActionType.START_NIGHT), ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        verify(nightOrchestrator).initNight(gameId, 1, null, true)
     }
 
     @Test
-    fun `startNight-rejected if actor is not host`() {
-        val ctx = context(hasSheriff = false)
-        val req = GameActionRequest(gameId, guestId, ActionType.START_NIGHT)
-        val result = pipeline.startNight(req, ctx)
+    fun `startNight rejected if actor is not host`() {
+        val ctx = GameContext(game(), room(hasSheriff = false), emptyList())
+        val result = pipeline.startNight(GameActionRequest(gameId, guestId, ActionType.START_NIGHT), ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
         assertThat((result as GameActionResult.Rejected).reason).contains("host")
@@ -148,56 +131,96 @@ class GamePipelineSheriffTest {
     }
 
     @Test
-    fun `startNight-rejected if not all players have confirmed`() {
-        val ctx = context(hasSheriff = false)
-        val notAllConfirmed = listOf(
+    fun `startNight rejected if not all players have confirmed`() {
+        val ctx = GameContext(game(), room(hasSheriff = false), emptyList())
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(listOf(
             confirmedPlayer(hostId, 0),
             GamePlayer(gameId = gameId, userId = guestId, seatIndex = 1, role = PlayerRole.VILLAGER),
-        )
-        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(notAllConfirmed)
+        ))
 
-        val req = GameActionRequest(gameId, hostId, ActionType.START_NIGHT)
-        val result = pipeline.startNight(req, ctx)
+        val result = pipeline.startNight(GameActionRequest(gameId, hostId, ActionType.START_NIGHT), ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
         assertThat((result as GameActionResult.Rejected).reason).contains("confirmed")
         verifyNoInteractions(nightOrchestrator)
     }
 
-    // ── startNight from SHERIFF_ELECTION RESULT ────────────────────────────────
-
     @Test
-    fun `startNight - succeeds from SHERIFF_ELECTION when sub-phase is RESULT`() {
-        // New path: after sheriff is elected, host clicks "Start Night" from the RESULT screen.
-        // The game phase is SHERIFF_ELECTION and election.subPhase is RESULT.
-        val sheriffGame = Game(roomId = 1, hostUserId = hostId).also {
-            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
-            it.phase = GamePhase.SHERIFF_ELECTION
-        }
-        val resultElection = SheriffElection(gameId = gameId, subPhase = ElectionSubPhase.RESULT)
-        val ctx = GameContext(sheriffGame, room(hasSheriff = true), emptyList(), election = resultElection)
-
-        val req = GameActionRequest(gameId, hostId, ActionType.START_NIGHT)
-        val result = pipeline.startNight(req, ctx)
-
-        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
-        verify(nightOrchestrator).initNight(gameId, 1, null, true)
-    }
-
-    @Test
-    fun `startNight - rejected from SHERIFF_ELECTION when sub-phase is not RESULT`() {
-        // Guard: startNight must not be callable in mid-election (e.g., VOTING sub-phase).
-        val sheriffGame = Game(roomId = 1, hostUserId = hostId).also {
-            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
-            it.phase = GamePhase.SHERIFF_ELECTION
-        }
-        val votingElection = SheriffElection(gameId = gameId, subPhase = ElectionSubPhase.VOTING)
-        val ctx = GameContext(sheriffGame, room(hasSheriff = true), emptyList(), election = votingElection)
-
-        val req = GameActionRequest(gameId, hostId, ActionType.START_NIGHT)
-        val result = pipeline.startNight(req, ctx)
+    fun `startNight rejected if not in ROLE_REVEAL phase`() {
+        val ctx = GameContext(game(phase = GamePhase.NIGHT), room(hasSheriff = true), emptyList())
+        val result = pipeline.startNight(GameActionRequest(gameId, hostId, ActionType.START_NIGHT), ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
         verifyNoInteractions(nightOrchestrator)
+    }
+
+    // ── revealNightResult auto-triggers SHERIFF_ELECTION on Day 1 ──────────────
+
+    @Test
+    fun `revealNightResult on Day 1 with hasSheriff=true creates SheriffElection and transitions to SHERIFF_ELECTION`() {
+        val ctx = GameContext(
+            game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name),
+            room(hasSheriff = true),
+            emptyList(),
+        )
+        whenever(sheriffElectionRepository.findByGameId(gameId)).thenReturn(Optional.empty())
+        whenever(sheriffElectionRepository.save(any<SheriffElection>())).thenAnswer { it.arguments[0] }
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        val result = pipeline.revealNightResult(req, ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.SHERIFF_ELECTION)
+        verify(sheriffElectionRepository).save(any<SheriffElection>())
+    }
+
+    @Test
+    fun `revealNightResult on Day 1 with hasSheriff=false stays in DAY_DISCUSSION`() {
+        val ctx = GameContext(
+            game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name),
+            room(hasSheriff = false),
+            emptyList(),
+        )
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        val result = pipeline.revealNightResult(req, ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        verifyNoInteractions(sheriffElectionRepository)
+    }
+
+    @Test
+    fun `revealNightResult on Day 2 with hasSheriff=true does NOT create another SheriffElection`() {
+        // Sheriff election runs at most once per game (Day 1 only).
+        val ctx = GameContext(
+            game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 2, subPhase = DaySubPhase.RESULT_HIDDEN.name),
+            room(hasSheriff = true),
+            emptyList(),
+        )
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        val result = pipeline.revealNightResult(req, ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        verifyNoInteractions(sheriffElectionRepository)
+    }
+
+    @Test
+    fun `revealNightResult on Day 1 with sheriff already elected does NOT recreate SheriffElection`() {
+        // Defensive: should not happen on Day 1, but ensure idempotence.
+        val gameWithSheriff = game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name)
+            .also { it.sheriffUserId = guestId }
+        val ctx = GameContext(gameWithSheriff, room(hasSheriff = true), emptyList())
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        val result = pipeline.revealNightResult(req, ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        verifyNoInteractions(sheriffElectionRepository)
     }
 }

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
@@ -7,6 +7,7 @@ import com.werewolf.game.night.NightOrchestrator
 import com.werewolf.game.phase.GamePhasePipeline
 import com.werewolf.model.*
 import com.werewolf.repository.*
+import com.werewolf.service.ActionLogService
 import com.werewolf.service.GameContextLoader
 import com.werewolf.service.SheriffService
 import com.werewolf.service.StompPublisher
@@ -20,21 +21,29 @@ import org.mockito.kotlin.*
 import java.util.*
 
 /**
- * Tests for the Variant B sheriff-election flow:
+ * Tests for the GamePhasePipeline contract under the corrected Variant B
+ * sheriff-election ordering:
+ *
  *  - ROLE_REVEAL → host calls START_NIGHT → NIGHT 1 (regardless of hasSheriff)
- *  - NIGHT 1 result revealed on Day 1 → if hasSheriff, auto-trigger
- *    SHERIFF_ELECTION/SIGNUP. Otherwise stay in DAY_DISCUSSION/RESULT_REVEALED.
+ *  - End of night → SHERIFF_ELECTION (Day 1 + hasSheriff) auto-opens, kills
+ *    are NOT applied yet (NightOrchestrator.resolveNightKills's job).
+ *  - revealNightResult is the moment kills are *applied* (alive=false flipped)
+ *    and the NightResult event is broadcast — it no longer triggers the
+ *    sheriff election (that already opened at end of night, hours of
+ *    gameplay ago).
  */
 @ExtendWith(MockitoExtension::class)
 class GamePipelineSheriffTest {
 
     @Mock lateinit var gameRepository: GameRepository
     @Mock lateinit var gamePlayerRepository: GamePlayerRepository
+    @Mock lateinit var nightPhaseRepository: NightPhaseRepository
     @Mock lateinit var sheriffElectionRepository: SheriffElectionRepository
     @Mock lateinit var stompPublisher: StompPublisher
     @Mock lateinit var contextLoader: GameContextLoader
     @Mock lateinit var sheriffService: SheriffService
     @Mock lateinit var nightOrchestrator: NightOrchestrator
+    @Mock lateinit var actionLogService: ActionLogService
     @InjectMocks lateinit var pipeline: GamePhasePipeline
 
     private val gameId = 10
@@ -57,13 +66,18 @@ class GamePipelineSheriffTest {
         gameId = gameId, userId = userId, seatIndex = seat, role = PlayerRole.VILLAGER
     ).also { it.confirmedRole = true }
 
+    private fun nightPhase(dayNumber: Int = 1) = NightPhase(gameId = gameId, dayNumber = dayNumber).also {
+        it.subPhase = NightSubPhase.COMPLETE
+    }
+
     // ── confirmRole always stays in ROLE_REVEAL ───────────────────────────────
 
     @Test
     fun `confirmRole always stays in ROLE_REVEAL (hasSheriff=true)`() {
         // Variant B: confirmRole only updates the player's confirmedRole flag.
         // It never creates a SheriffElection or transitions the game phase —
-        // the host drives the next step (START_NIGHT).
+        // the host drives the next step (START_NIGHT). The actual sheriff
+        // election triggers from end-of-night.
         val ctx = GameContext(game(), room(hasSheriff = true), emptyList())
         val player = GamePlayer(gameId = gameId, userId = guestId, seatIndex = 1, role = PlayerRole.VILLAGER)
         whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, guestId)).thenReturn(Optional.of(player))
@@ -109,7 +123,8 @@ class GamePipelineSheriffTest {
     @Test
     fun `startNight transitions to NIGHT when all confirmed and hasSheriff=true (Variant B)`() {
         // Variant B: sheriff election no longer gates start-of-night. Host
-        // starts Night 1, then sheriff election runs on Day 1 morning.
+        // starts Night 1, then sheriff election runs on Day 1 morning (after
+        // end-of-night, before death announcement).
         val ctx = GameContext(game(), room(hasSheriff = true), emptyList())
         val allConfirmed = listOf(confirmedPlayer(hostId, 0), confirmedPlayer(guestId, 1))
         whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(allConfirmed)
@@ -154,28 +169,42 @@ class GamePipelineSheriffTest {
         verifyNoInteractions(nightOrchestrator)
     }
 
-    // ── revealNightResult auto-triggers SHERIFF_ELECTION on Day 1 ──────────────
+    // ── revealNightResult applies deferred kills ──────────────────────────────
 
     @Test
-    fun `revealNightResult on Day 1 with hasSheriff=true creates SheriffElection and transitions to SHERIFF_ELECTION`() {
+    fun `revealNightResult applies pending wolf-kill via NightOrchestrator and broadcasts NightResult`() {
+        // The deferred kill is wolf_target without antidote/guard save —
+        // computePendingKills returns ['victim'].
+        val np = NightPhase(gameId = gameId, dayNumber = 1).also {
+            it.subPhase = NightSubPhase.COMPLETE
+            it.wolfTargetUserId = "victim"
+        }
+        whenever(nightPhaseRepository.findByGameIdAndDayNumber(gameId, 1)).thenReturn(Optional.of(np))
+        whenever(nightOrchestrator.computePendingKills(np)).thenReturn(listOf("victim"))
+
         val ctx = GameContext(
             game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name),
             room(hasSheriff = true),
             emptyList(),
         )
-        whenever(sheriffElectionRepository.findByGameId(gameId)).thenReturn(Optional.empty())
-        whenever(sheriffElectionRepository.save(any<SheriffElection>())).thenAnswer { it.arguments[0] }
 
         val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
         val result = pipeline.revealNightResult(req, ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
-        assertThat(ctx.game.phase).isEqualTo(GamePhase.SHERIFF_ELECTION)
-        verify(sheriffElectionRepository).save(any<SheriffElection>())
+        // Kills applied via the orchestrator helper (pure function for testing).
+        verify(nightOrchestrator).applyNightKills(gameId, listOf("victim"))
+        verify(actionLogService).recordNightDeaths(gameId, 1, listOf("victim"))
+        // Transitions to RESULT_REVEALED.
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
     }
 
     @Test
-    fun `revealNightResult on Day 1 with hasSheriff=false stays in DAY_DISCUSSION`() {
+    fun `revealNightResult with no pending kills does NOT call applyNightKills`() {
+        val np = NightPhase(gameId = gameId, dayNumber = 1).also { it.subPhase = NightSubPhase.COMPLETE }
+        whenever(nightPhaseRepository.findByGameIdAndDayNumber(gameId, 1)).thenReturn(Optional.of(np))
+        whenever(nightOrchestrator.computePendingKills(np)).thenReturn(emptyList())
+
         val ctx = GameContext(
             game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name),
             room(hasSheriff = false),
@@ -186,41 +215,32 @@ class GamePipelineSheriffTest {
         val result = pipeline.revealNightResult(req, ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
-        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        verify(nightOrchestrator, never()).applyNightKills(any(), any())
+        verifyNoInteractions(actionLogService)
         assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
-        verifyNoInteractions(sheriffElectionRepository)
     }
 
     @Test
-    fun `revealNightResult on Day 2 with hasSheriff=true does NOT create another SheriffElection`() {
-        // Sheriff election runs at most once per game (Day 1 only).
+    fun `revealNightResult does NOT trigger sheriff election (that happens at end of night now)`() {
+        // The old Variant-B-incorrect implementation triggered SHERIFF_ELECTION
+        // from revealNightResult on Day 1. The corrected flow opens the
+        // election at end-of-night via NightOrchestrator.resolveNightKills,
+        // so by the time revealNightResult runs the sheriff election is
+        // already over.
+        val np = NightPhase(gameId = gameId, dayNumber = 1).also { it.subPhase = NightSubPhase.COMPLETE }
+        whenever(nightPhaseRepository.findByGameIdAndDayNumber(gameId, 1)).thenReturn(Optional.of(np))
+        whenever(nightOrchestrator.computePendingKills(np)).thenReturn(emptyList())
+
         val ctx = GameContext(
-            game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 2, subPhase = DaySubPhase.RESULT_HIDDEN.name),
+            game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name),
             room(hasSheriff = true),
             emptyList(),
         )
 
         val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
-        val result = pipeline.revealNightResult(req, ctx)
+        pipeline.revealNightResult(req, ctx)
 
-        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
-        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
-        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
         verifyNoInteractions(sheriffElectionRepository)
-    }
-
-    @Test
-    fun `revealNightResult on Day 1 with sheriff already elected does NOT recreate SheriffElection`() {
-        // Defensive: should not happen on Day 1, but ensure idempotence.
-        val gameWithSheriff = game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 1, subPhase = DaySubPhase.RESULT_HIDDEN.name)
-            .also { it.sheriffUserId = guestId }
-        val ctx = GameContext(gameWithSheriff, room(hasSheriff = true), emptyList())
-
-        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
-        val result = pipeline.revealNightResult(req, ctx)
-
-        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
         assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
-        verifyNoInteractions(sheriffElectionRepository)
     }
 }

--- a/backend/src/test/kotlin/com/werewolf/unit/service/NightOrchestratorTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/NightOrchestratorTest.kt
@@ -70,6 +70,7 @@ class NightOrchestratorTest {
         gameRepository = gameRepository,
         gamePlayerRepository = gamePlayerRepository,
         nightPhaseRepository = nightPhaseRepository,
+        sheriffElectionRepository = mock(),
         eliminationHistoryRepository = eliminationHistoryRepository,
         winConditionChecker = winConditionChecker,
         stompPublisher = stompPublisher,
@@ -144,8 +145,24 @@ class NightOrchestratorTest {
         it.dayNumber = 1
     }
 
-    private fun room(hasSeer: Boolean = false, hasWitch: Boolean = false, hasGuard: Boolean = false) =
-        Room(roomCode = "ABCD", hostUserId = hostId, totalPlayers = 6, hasSeer = hasSeer, hasWitch = hasWitch, hasGuard = hasGuard)
+    // hasSheriff defaults to FALSE in tests so resolveNightKills lands on the
+    // DAY_DISCUSSION/RESULT_HIDDEN branch (the simpler one most assertions
+    // were written against). Tests that exercise the SHERIFF_ELECTION
+    // auto-trigger (Variant B) pass hasSheriff = true explicitly.
+    private fun room(
+        hasSeer: Boolean = false,
+        hasWitch: Boolean = false,
+        hasGuard: Boolean = false,
+        hasSheriff: Boolean = false,
+    ) = Room(
+        roomCode = "ABCD",
+        hostUserId = hostId,
+        totalPlayers = 6,
+        hasSeer = hasSeer,
+        hasWitch = hasWitch,
+        hasGuard = hasGuard,
+        hasSheriff = hasSheriff,
+    )
 
     private fun player(userId: String, seat: Int, role: PlayerRole = PlayerRole.VILLAGER, alive: Boolean = true) =
         GamePlayer(gameId = gameId, userId = userId, seatIndex = seat, role = role).also { it.alive = alive }
@@ -284,15 +301,20 @@ class NightOrchestratorTest {
         val r = room()
         val initialCtx = ctx(wolf, victim, roomOverride = r)
 
-        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, "u2")).thenReturn(Optional.of(victim))
-        whenever(contextLoader.load(gameId)).thenReturn(ctx(wolf, victim.also { it.alive = false }, roomOverride = r))
         whenever(winConditionChecker.check(any(), any(), any(), any())).thenReturn(null)
         mockAudioServiceForDayTransition(r)
 
         nightOrchestrator.resolveNightKills(initialCtx, np)
 
-        assertThat(victim.alive).isFalse()
-        verify(gamePlayerRepository).save(victim)
+        // Variant B: kills are deferred until host clicks REVEAL_NIGHT_RESULT.
+        // resolveNightKills only computes the pending kill list; victim stays
+        // alive in DB until applyNightKills is called separately.
+        assertThat(victim.alive).isTrue()
+        verify(gamePlayerRepository, never()).save(victim)
+        // The pending kill IS surfaced via computePendingKills for callers
+        // (e.g. GamePhasePipeline.revealNightResult) to apply on the host's
+        // reveal click.
+        assertThat(nightOrchestrator.computePendingKills(np)).containsExactly("u2")
     }
 
     @Test
@@ -710,7 +732,14 @@ class NightOrchestratorTest {
     // ── Action log recording ─────────────────────────────────────────────────
 
     @Test
-    fun `resolveNightKills - records NIGHT_DEATH events for each killed player`() {
+    fun `resolveNightKills - records NIGHT_DEATH events when game ends on N1 parity`() {
+        // Variant B: actionLogService.recordNightDeaths is now called only in
+        // the GAME_OVER branch (kills are applied immediately when the game
+        // ends). For the no-game-over path, recordNightDeaths fires later from
+        // GamePhasePipeline.revealNightResult — see GamePipelineSheriffTest.
+        //
+        // To exercise the recordNightDeaths call, this test sets up a
+        // wolf-parity scenario where the wolf kill ends the game on N1.
         val wolf = GamePlayer(gameId = gameId, userId = "wolf1", seatIndex = 1, role = PlayerRole.WEREWOLF)
         val villager = GamePlayer(gameId = gameId, userId = "vil1", seatIndex = 2, role = PlayerRole.VILLAGER)
         val game = Game(roomId = 1, hostUserId = hostId).also {
@@ -718,7 +747,7 @@ class NightOrchestratorTest {
             it.phase = GamePhase.NIGHT
             it.dayNumber = 1
         }
-        val room = Room(roomCode = "ABCD", hostUserId = hostId, totalPlayers = 6)
+        val room = Room(roomCode = "ABCD", hostUserId = hostId, totalPlayers = 6, hasSheriff = false)
         // Use GUARD_PICK (not COMPLETE) — resolveNightKills is called on an in-progress phase
         val nightPhase = NightPhase(gameId = gameId, dayNumber = 1, subPhase = NightSubPhase.GUARD_PICK).also {
             it.wolfTargetUserId = "vil1"
@@ -730,10 +759,12 @@ class NightOrchestratorTest {
             .thenReturn(Optional.of(villager))
         whenever(gamePlayerRepository.save(any<GamePlayer>())).thenAnswer { it.arguments[0] }
         whenever(contextLoader.load(gameId)).thenReturn(updatedCtx)
-        whenever(winConditionChecker.check(any(), any(), any(), any())).thenReturn(null)
+        // Force GAME_OVER branch so actionLogService.recordNightDeaths runs
+        // immediately. (No-game-over path defers it to revealNightResult,
+        // covered by GamePipelineSheriffTest.)
+        whenever(winConditionChecker.check(any(), any(), any(), any())).thenReturn(WinnerSide.WEREWOLF)
         whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
         whenever(nightPhaseRepository.save(any<NightPhase>())).thenAnswer { it.arguments[0] }
-        mockAudioServiceForDayTransition(room)
 
         nightOrchestrator.resolveNightKills(ctx, nightPhase)
 
@@ -955,6 +986,11 @@ class NightOrchestratorTest {
         val r = Room(
             roomCode = "ABCD", hostUserId = hostId, totalPlayers = 12,
             hasSeer = true, hasWitch = true, hasGuard = true,
+            // Variant B: hasSheriff=false keeps these tests on the
+            // DAY_DISCUSSION/RESULT_HIDDEN end-of-night branch so the day-
+            // transition audio assertions still apply. Sheriff election
+            // path (Day 1 + hasSheriff=true) is covered separately.
+            hasSheriff = false,
         ).also {
             it.config = GameConfig(mapOf(
                 PlayerRole.WEREWOLF to shortCfg, PlayerRole.SEER to shortCfg,

--- a/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
@@ -4,7 +4,6 @@ import com.werewolf.game.DomainEvent
 import com.werewolf.game.GameContext
 import com.werewolf.game.action.GameActionRequest
 import com.werewolf.game.action.GameActionResult
-import com.werewolf.game.night.NightOrchestrator
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.SheriffService
@@ -31,7 +30,6 @@ class SheriffServiceTest {
     @Mock lateinit var voteRepository: VoteRepository
     @Mock lateinit var userRepository: UserRepository
     @Mock lateinit var stompPublisher: StompPublisher
-    @Mock lateinit var nightOrchestrator: NightOrchestrator
     private lateinit var sheriffService: SheriffService
 
     @BeforeEach
@@ -39,7 +37,7 @@ class SheriffServiceTest {
         sheriffService = SheriffService(
             gameRepository, gamePlayerRepository, sheriffElectionRepository,
             sheriffCandidateRepository, voteRepository, userRepository,
-            stompPublisher, nightOrchestrator, CoroutineScope(Dispatchers.Default),
+            stompPublisher, CoroutineScope(Dispatchers.Default),
         )
     }
 
@@ -366,7 +364,6 @@ class SheriffServiceTest {
         val event = eventCaptor.firstValue as DomainEvent.PhaseChanged
         assertThat(event.subPhase).isEqualTo(ElectionSubPhase.SPEECH.name)
 
-        verifyNoInteractions(nightOrchestrator)
     }
 
     @Test
@@ -397,7 +394,6 @@ class SheriffServiceTest {
         verify(stompPublisher).broadcastGame(eq(gameId), captor.capture())
         assertThat((captor.firstValue as DomainEvent.PhaseChanged).subPhase).isEqualTo(ElectionSubPhase.RESULT.name)
         // Should NOT call startNightPhase directly — auto-advance is scheduled
-        verify(nightOrchestrator, never()).startNightPhase(any(), any(), anyOrNull(), any())
     }
 
     // ── Group 4: revealResult() empty votes / all-abstain ────────────────────────
@@ -433,7 +429,6 @@ class SheriffServiceTest {
         val captor = argumentCaptor<DomainEvent>()
         verify(stompPublisher).broadcastGame(eq(gameId), captor.capture())
         assertThat((captor.firstValue as DomainEvent.PhaseChanged).subPhase).isEqualTo(ElectionSubPhase.TIED.name)
-        verify(nightOrchestrator, never()).startNightPhase(any(), any(), anyOrNull(), any())
     }
 
     @Test
@@ -459,7 +454,6 @@ class SheriffServiceTest {
         verify(stompPublisher).broadcastGame(eq(gameId), captor.capture())
         assertThat((captor.firstValue as DomainEvent.PhaseChanged).subPhase).isEqualTo(ElectionSubPhase.RESULT.name)
         // Should NOT call startNightPhase directly — auto-advance is scheduled asynchronously
-        verify(nightOrchestrator, never()).startNightPhase(any(), any(), anyOrNull(), any())
     }
 
     @Test
@@ -485,7 +479,6 @@ class SheriffServiceTest {
         val captor = argumentCaptor<DomainEvent>()
         verify(stompPublisher).broadcastGame(eq(gameId), captor.capture())
         assertThat((captor.firstValue as DomainEvent.PhaseChanged).subPhase).isEqualTo(ElectionSubPhase.TIED.name)
-        verify(nightOrchestrator, never()).startNightPhase(any(), any(), anyOrNull(), any())
     }
 
     // ── Group 5: vote() — self-vote and other vote validations ────────────────
@@ -737,7 +730,6 @@ class SheriffServiceTest {
         verify(stompPublisher, times(2)).broadcastGame(eq(gameId), captor.capture())
         assertThat(captor.allValues).anyMatch { it is DomainEvent.SheriffElected && it.sheriffUserId == winnerId }
         assertThat(captor.allValues).anyMatch { it is DomainEvent.PhaseChanged && it.subPhase == ElectionSubPhase.RESULT.name }
-        verify(nightOrchestrator, never()).startNightPhase(any(), any(), anyOrNull(), any())
     }
 
     @Test
@@ -767,7 +759,6 @@ class SheriffServiceTest {
         val captor = argumentCaptor<DomainEvent>()
         verify(stompPublisher).broadcastGame(eq(gameId), captor.capture())
         assertThat((captor.firstValue as DomainEvent.PhaseChanged).subPhase).isEqualTo(ElectionSubPhase.TIED.name)
-        verify(nightOrchestrator, never()).startNightPhase(any(), any(), anyOrNull(), any())
     }
 
     // ── Group 9: appoint() action ─────────────────────────────────────────────

--- a/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
@@ -3,6 +3,7 @@ package com.werewolf.unit.service
 import com.werewolf.game.DomainEvent
 import com.werewolf.game.GameContext
 import com.werewolf.game.action.GameActionRequest
+import com.werewolf.config.GameTimingProperties
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.model.*
 import com.werewolf.repository.*
@@ -38,6 +39,7 @@ class SheriffServiceTest {
             gameRepository, gamePlayerRepository, sheriffElectionRepository,
             sheriffCandidateRepository, voteRepository, userRepository,
             stompPublisher, CoroutineScope(Dispatchers.Default),
+            GameTimingProperties(),
         )
     }
 

--- a/backend/src/test/kotlin/com/werewolf/unit/service/VotingPipelineTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/VotingPipelineTest.kt
@@ -341,6 +341,176 @@ class VotingPipelineTest {
         assertThat(gameCaptor.firstValue.subPhase).isEqualTo(VotingSubPhase.VOTE_RESULT.name)
     }
 
+    // ── Phase B: BADGE_HANDOVER + HUNTER_SHOOT under DAY_DISCUSSION ──────────
+
+    /**
+     * Build a Game in DAY_DISCUSSION/BADGE_HANDOVER (Phase B night-kill route)
+     * for a sheriff. The handler's exit transition must land on
+     * DAY_DISCUSSION/RESULT_REVEALED — NOT DAY_VOTING/VOTE_RESULT.
+     */
+    private fun nightRouteGame(subPhase: String = DaySubPhase.BADGE_HANDOVER.name, sheriff: String? = null) =
+        Game(roomId = 1, hostUserId = hostId).also {
+            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
+            it.phase = GamePhase.DAY_DISCUSSION
+            it.subPhase = subPhase
+            it.dayNumber = 1
+            it.sheriffUserId = sheriff
+        }
+
+    @Test
+    fun `handleBadge - night-route BADGE_PASS transitions to DAY_DISCUSSION RESULT_REVEALED (Phase B)`() {
+        val sheriff = player(hostId, 0)
+        val newSheriff = player("u2", 2)
+        val context = GameContext(
+            nightRouteGame(sheriff = hostId), room(), listOf(sheriff, newSheriff),
+        )
+
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, hostId)).thenReturn(Optional.of(sheriff))
+        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, "u2")).thenReturn(Optional.of(newSheriff))
+
+        val result = votingPipeline.handleBadge(req(hostId, ActionType.BADGE_PASS, "u2"), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        val gameCaptor = argumentCaptor<Game>()
+        verify(gameRepository).save(gameCaptor.capture())
+        assertThat(gameCaptor.firstValue.sheriffUserId).isEqualTo("u2")
+        assertThat(gameCaptor.firstValue.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(gameCaptor.firstValue.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        // Night-route does NOT call afterElimination → contextLoader.load not invoked
+        verifyNoInteractions(contextLoader)
+    }
+
+    @Test
+    fun `handleBadge - night-route BADGE_DESTROY transitions to DAY_DISCUSSION RESULT_REVEALED (Phase B)`() {
+        val sheriff = player(hostId, 0)
+        val context = GameContext(nightRouteGame(sheriff = hostId), room(), listOf(sheriff))
+
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, hostId)).thenReturn(Optional.of(sheriff))
+
+        val result = votingPipeline.handleBadge(req(hostId, ActionType.BADGE_DESTROY), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        val gameCaptor = argumentCaptor<Game>()
+        verify(gameRepository).save(gameCaptor.capture())
+        assertThat(gameCaptor.firstValue.sheriffUserId).isNull()
+        assertThat(gameCaptor.firstValue.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(gameCaptor.firstValue.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        verifyNoInteractions(contextLoader)
+    }
+
+    @Test
+    fun `handleBadge - rejected when phase is DAY_DISCUSSION but subPhase is wrong (Phase B guard)`() {
+        val sheriff = player(hostId, 0)
+        val context = GameContext(
+            nightRouteGame(subPhase = DaySubPhase.RESULT_HIDDEN.name, sheriff = hostId),
+            room(), listOf(sheriff),
+        )
+
+        val result = votingPipeline.handleBadge(req(hostId, ActionType.BADGE_PASS, "u2"), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+        assertThat((result as GameActionResult.Rejected).reason).contains("BADGE_HANDOVER")
+    }
+
+    @Test
+    fun `handleHunterShoot - night-route hunter shoots non-sheriff, transitions to RESULT_REVEALED (Phase B)`() {
+        val hunter = player(hostId, 0, PlayerRole.HUNTER)
+        val target = player("u2", 2)
+        val game = Game(roomId = 1, hostUserId = hostId).also {
+            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
+            it.phase = GamePhase.DAY_DISCUSSION
+            it.subPhase = DaySubPhase.HUNTER_SHOOT.name
+            it.dayNumber = 1
+        }
+        val context = GameContext(game, room(), listOf(hunter, target))
+
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, "u2")).thenReturn(Optional.of(target))
+        stubLoader(hunter, target)
+        whenever(winConditionChecker.check(any(), any(), any(), any())).thenReturn(null)
+
+        val result = votingPipeline.handleHunterShoot(req(hostId, ActionType.HUNTER_SHOOT, "u2"), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(target.alive).isFalse()
+        // Night-route exit: DAY_DISCUSSION/RESULT_REVEALED, NOT goToNight
+        val savedGames = argumentCaptor<Game>()
+        verify(gameRepository, atLeastOnce()).save(savedGames.capture())
+        val final = savedGames.allValues.last()
+        assertThat(final.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(final.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        // Critical: night-route does NOT trigger initNight (that would be the
+        // vote-out path's afterHunterAct → goToNight).
+        verifyNoInteractions(nightOrchestrator)
+    }
+
+    @Test
+    fun `handleHunterShoot - night-route hunter shoots sheriff, transitions to BADGE_HANDOVER (Phase B)`() {
+        val hunter = player(hostId, 0, PlayerRole.HUNTER)
+        val sheriff = player("u2", 2)
+        val game = Game(roomId = 1, hostUserId = hostId).also {
+            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
+            it.phase = GamePhase.DAY_DISCUSSION
+            it.subPhase = DaySubPhase.HUNTER_SHOOT.name
+            it.dayNumber = 1
+            it.sheriffUserId = "u2"
+        }
+        val context = GameContext(game, room(), listOf(hunter, sheriff))
+
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, "u2")).thenReturn(Optional.of(sheriff))
+
+        votingPipeline.handleHunterShoot(req(hostId, ActionType.HUNTER_SHOOT, "u2"), context)
+
+        // Hunter killed sheriff at night → cascade into BADGE_HANDOVER under
+        // DAY_DISCUSSION (NOT DAY_VOTING — that's the vote-out path).
+        val gameCaptor = argumentCaptor<Game>()
+        verify(gameRepository, atLeastOnce()).save(gameCaptor.capture())
+        val final = gameCaptor.allValues.last()
+        assertThat(final.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(final.subPhase).isEqualTo(DaySubPhase.BADGE_HANDOVER.name)
+    }
+
+    @Test
+    fun `handleHunterShoot - night-route HUNTER_PASS hunter is sheriff, transitions to BADGE_HANDOVER (Phase B)`() {
+        val hunter = player(hostId, 0, PlayerRole.HUNTER)
+        val game = Game(roomId = 1, hostUserId = hostId).also {
+            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
+            it.phase = GamePhase.DAY_DISCUSSION
+            it.subPhase = DaySubPhase.HUNTER_SHOOT.name
+            it.dayNumber = 1
+            it.sheriffUserId = hostId  // hunter is also the sheriff
+        }
+        val context = GameContext(game, room(), listOf(hunter))
+
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+
+        votingPipeline.handleHunterShoot(req(hostId, ActionType.HUNTER_PASS), context)
+
+        val gameCaptor = argumentCaptor<Game>()
+        verify(gameRepository).save(gameCaptor.capture())
+        assertThat(gameCaptor.firstValue.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(gameCaptor.firstValue.subPhase).isEqualTo(DaySubPhase.BADGE_HANDOVER.name)
+    }
+
+    @Test
+    fun `handleHunterShoot - rejected when phase is DAY_DISCUSSION but subPhase is RESULT_HIDDEN`() {
+        val hunter = player(hostId, 0, PlayerRole.HUNTER)
+        val game = Game(roomId = 1, hostUserId = hostId).also {
+            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
+            it.phase = GamePhase.DAY_DISCUSSION
+            it.subPhase = DaySubPhase.RESULT_HIDDEN.name
+        }
+        val context = GameContext(game, room(), listOf(hunter))
+
+        val result = votingPipeline.handleHunterShoot(req(hostId, ActionType.HUNTER_PASS), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+        assertThat((result as GameActionResult.Rejected).reason).contains("HUNTER_SHOOT")
+    }
+
     @Test
     fun `handleBadge - sheriff destroys badge, sheriffUserId becomes null and transitions to VOTE_RESULT`() {
         val sheriff = player(hostId, 0)

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -53,3 +53,4 @@ werewolf:
     inter-role-gap-ms: 300
     night-init-audio-delay-ms: 500
     waiting-delay-ms: 200
+    sheriff-result-auto-advance-ms: 1000

--- a/frontend/e2e/real/flow-12p-sheriff.spec.ts
+++ b/frontend/e2e/real/flow-12p-sheriff.spec.ts
@@ -18,7 +18,6 @@ import {type GameContext, setupGame} from './helpers/multi-browser'
 import {act, actName, type RoleName, sheriff} from './helpers/shell-runner'
 import {
   driveMinimalNight1ViaDom,
-  revealNightResultAndOpenSheriffElection,
   waitForDayDiscussionAfterSheriff,
 } from './helpers/night-driver'
 import {verifyAllBrowsersPhase} from './helpers/assertions'
@@ -811,20 +810,23 @@ test.describe('12p sheriff — CLASSIC villager win', () => {
     const wolfTargetSeatN1 = villagerSeats[0]
     const guardTargetSeatN1 = villagerSeats[1]
 
+    // Variant B (correct): driveMinimalNight1ViaDom drives N1 actions and
+    // waits for the auto-transition into SHERIFF_ELECTION/SIGNUP (Day 1 +
+    // hasSheriff). Kills are still deferred at this point — N1 victims
+    // are alive in DB and could 上警 if the test wanted them to.
     await driveMinimalNight1ViaDom(ctx, {
       wolfTargetSeat: wolfTargetSeatN1,
       guardTargetSeat: guardTargetSeatN1,
     })
-    await captureSnapshot(ctx.pages, testInfo, 'classic-02-night-1-done')
-
-    await revealNightResultAndOpenSheriffElection(ctx)
-    await captureSnapshot(ctx.pages, testInfo, 'classic-03-sheriff-election-opened')
+    await captureSnapshot(ctx.pages, testInfo, 'classic-02-night-1-done-sheriff-opened')
 
     await runSheriffElection(ctx, candidates)
-    await captureSnapshot(ctx.pages, testInfo, 'classic-04-sheriff-elected')
+    await captureSnapshot(ctx.pages, testInfo, 'classic-03-sheriff-elected')
 
+    // After sheriff RESULT, backend auto-advances to DAY_DISCUSSION/RESULT_HIDDEN
+    // (kills still deferred; host clicks reveal in completeDay below).
     await waitForDayDiscussionAfterSheriff(ctx)
-    await captureSnapshot(ctx.pages, testInfo, 'classic-05-day-discussion-after-sheriff')
+    await captureSnapshot(ctx.pages, testInfo, 'classic-04-day-result-hidden')
 
     // Wolves will be voted out every day. No village player dies at night if
     // we can avoid it — wolves hit a villager target we'll vote no-one for.
@@ -979,22 +981,26 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
       'HARD_MODE kit needs at least one wolf so guard can protect a non-target seat',
     ).toBeDefined()
 
+    // Variant B: drives N1 then waits for end-of-night auto-transition into
+    // SHERIFF_ELECTION/SIGNUP. Guard is the wolf-target but kills are
+    // deferred — guard is still alive in DB during sheriff election (and
+    // could 上警 if the test wanted them to).
     await driveMinimalNight1ViaDom(ctx, {
       wolfTargetSeat: guard.seat,
       seerCheckSeat: wolfBots[0]?.seat ?? guard.seat,
       guardTargetSeat: wolfSeatForGuardProtect!,
     })
-    await captureSnapshot(ctx.pages, testInfo, 'hard-02-night-1-done')
-
-    await revealNightResultAndOpenSheriffElection(ctx)
-    await captureSnapshot(ctx.pages, testInfo, 'hard-03-sheriff-election-opened')
+    await captureSnapshot(ctx.pages, testInfo, 'hard-02-night-1-done-sheriff-opened')
 
     // Sheriff election — only the seer campaigns. After speeches + votes
     // the seer holds the badge.
     await runSheriffElection(ctx, [seer.nick])
-    await captureSnapshot(ctx.pages, testInfo, 'hard-04-sheriff-elected-is-seer')
+    await captureSnapshot(ctx.pages, testInfo, 'hard-03-sheriff-elected-is-seer')
 
+    // After sheriff RESULT, backend auto-advances to DAY_DISCUSSION/RESULT_HIDDEN.
+    // Host clicks reveal in completeDay below to apply the deferred guard kill.
     await waitForDayDiscussionAfterSheriff(ctx)
+    await captureSnapshot(ctx.pages, testInfo, 'hard-04-day-result-hidden')
 
     // D1: village votes out the seer (sheriff). Backend transitions to
     // BADGE_HANDOVER — only the seer's browser page sees the pass-badge

--- a/frontend/e2e/real/flow-12p-sheriff.spec.ts
+++ b/frontend/e2e/real/flow-12p-sheriff.spec.ts
@@ -16,6 +16,11 @@
 import {expect, type Page, test} from '@playwright/test'
 import {type GameContext, setupGame} from './helpers/multi-browser'
 import {act, actName, type RoleName, sheriff} from './helpers/shell-runner'
+import {
+  driveMinimalNight1ViaDom,
+  revealNightResultAndOpenSheriffElection,
+  waitForDayDiscussionAfterSheriff,
+} from './helpers/night-driver'
 import {verifyAllBrowsersPhase} from './helpers/assertions'
 import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
 import {
@@ -782,8 +787,8 @@ test.describe('12p sheriff — CLASSIC villager win', () => {
   // diagnostics (browser sentinels, backend log scan, invariants, action
   // observability, sub-phase gating) should make this both bearable on the
   // shared backend AND debuggable when it fails.
-  test('phase: role-reveal + sheriff election + village votes out wolves', async ({}, testInfo) => {
-    await captureSnapshot(ctx.pages, testInfo, 'classic-01-role-reveal-or-election-start')
+  test('phase: role-reveal + N1 + sheriff election + village votes out wolves', async ({}, testInfo) => {
+    await captureSnapshot(ctx.pages, testInfo, 'classic-01-role-reveal')
 
     const wolfBots = ctx.roleMap.WEREWOLF ?? []
     const seerBots = ctx.roleMap.SEER ?? []
@@ -792,19 +797,34 @@ test.describe('12p sheriff — CLASSIC villager win', () => {
       .filter((b): b is NonNullable<typeof b> => !!b && b.nick !== 'Host')
       .map((b) => b.nick)
 
-    await runSheriffElection(ctx, candidates)
-    await captureSnapshot(ctx.pages, testInfo, 'classic-02-sheriff-elected')
+    // Variant B Day 1: drive Night 1 (DOM-clicks) → reveal night result →
+    // sheriff election. The wolf must avoid the seer (so the seer can run
+    // and win Test 1's election). Guard must NOT protect the wolf-target
+    // seat (UI has no skip — guard always protects someone; protecting
+    // the kill target would block the kill and stall the planned outcome).
+    const villagerBots = ctx.roleMap.VILLAGER ?? []
+    const villagerSeats = villagerBots.filter((b) => b.nick !== 'Host').map((b) => b.seat)
+    expect(
+      villagerSeats.length,
+      'classic kit must include at least 2 non-host VILLAGER seats so wolf and guard can target distinct seats',
+    ).toBeGreaterThanOrEqual(2)
+    const wolfTargetSeatN1 = villagerSeats[0]
+    const guardTargetSeatN1 = villagerSeats[1]
 
-    // Start night
-    const startBtn = ctx.hostPage.getByTestId('start-night')
-    if (await startBtn.isVisible({ timeout: 10_000 }).catch(() => false)) {
-      await startBtn.click()
-    } else {
-      // sheriff flow sometimes auto-transitions; try scripted fallback
-      tryAct('START_NIGHT', 'Host', { room: ctx.roomCode })
-    }
-    await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 20_000)
-    await captureSnapshot(ctx.pages, testInfo, 'classic-03-night-1-entered')
+    await driveMinimalNight1ViaDom(ctx, {
+      wolfTargetSeat: wolfTargetSeatN1,
+      guardTargetSeat: guardTargetSeatN1,
+    })
+    await captureSnapshot(ctx.pages, testInfo, 'classic-02-night-1-done')
+
+    await revealNightResultAndOpenSheriffElection(ctx)
+    await captureSnapshot(ctx.pages, testInfo, 'classic-03-sheriff-election-opened')
+
+    await runSheriffElection(ctx, candidates)
+    await captureSnapshot(ctx.pages, testInfo, 'classic-04-sheriff-elected')
+
+    await waitForDayDiscussionAfterSheriff(ctx)
+    await captureSnapshot(ctx.pages, testInfo, 'classic-05-day-discussion-after-sheriff')
 
     // Wolves will be voted out every day. No village player dies at night if
     // we can avoid it — wolves hit a villager target we'll vote no-one for.
@@ -819,34 +839,28 @@ test.describe('12p sheriff — CLASSIC villager win', () => {
     const wolvesToEliminate = (ctx.roleMap.WEREWOLF ?? []).map((b) => ({
       nick: b.nick,
       userId: b.userId,
-      // Host's seat in roleMap comes from the shell state file's seat=0
-      // (initialized in setupGame and never updated post seat-claim).
-      // Substitute the live API seat. Other bots' seats from the state
-      // file are correct.
       seat: b.nick === 'Host' && hostSeat != null ? hostSeat : b.seat,
     }))
-
-    const villagerBots = ctx.roleMap.VILLAGER ?? []
-    // Do NOT target the host even if the host's role is VILLAGER — the spec
-    // needs the host alive to keep driving UI clicks. Also exclude the
-    // elected sheriff if they're on the village team so the badge stays put
-    // for as long as possible (simplifies reasoning in evidence screenshots).
-    const villagerSeats = villagerBots.filter((b) => b.nick !== 'Host').map((b) => b.seat)
 
     let round = 0
     const maxRounds = 6
     while (round < maxRounds && wolvesToEliminate.length > 0) {
-      // Night: wolves kill a villager; seer checks a wolf (for evidence)
-      const killSeat = villagerSeats[round % villagerSeats.length] ?? 1
-      const checkSeat = wolvesToEliminate[0]?.seat ?? 1
-      await completeNight(ctx, killSeat, checkSeat)
-      await ctx.hostPage.waitForTimeout(3_000)
-      if (ctx.hostPage.url().includes('/result/')) break
-      await captureSnapshot(ctx.pages, testInfo, `classic-04-night-${round + 1}-actions`)
+      // Skip night on round 0 — Night 1 was already driven before sheriff
+      // election. Subsequent rounds drive Night N>=2 via the existing
+      // completeNight helper (which handles dead actors + seerCheckSeat
+      // logic for nights with prior eliminations).
+      if (round > 0) {
+        const killSeat = villagerSeats[round % villagerSeats.length] ?? 1
+        const checkSeat = wolvesToEliminate[0]?.seat ?? 1
+        await completeNight(ctx, killSeat, checkSeat)
+        await ctx.hostPage.waitForTimeout(3_000)
+        if (ctx.hostPage.url().includes('/result/')) break
+        await captureSnapshot(ctx.pages, testInfo, `classic-06-night-${round + 1}-actions`)
+      }
 
       // Day: vote out the front wolf
       const targetWolfSeat = wolvesToEliminate[0].seat
-      await completeDay(ctx, testInfo, targetWolfSeat, `classic-04-day-${round + 1}`)
+      await completeDay(ctx, testInfo, targetWolfSeat, `classic-07-day-${round + 1}`)
       await ctx.hostPage.waitForTimeout(2_500)
       if (ctx.hostPage.url().includes('/result/')) break
 
@@ -918,7 +932,7 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     // eslint-disable-next-line no-console
     console.warn(`[hard-mode test] starting with hostRole=${ctx.hostRole}`)
 
-    await captureSnapshot(ctx.pages, testInfo, 'hard-01-role-reveal-or-election-start')
+    await captureSnapshot(ctx.pages, testInfo, 'hard-01-role-reveal')
 
     // For each special role: resolve to bot OR host (host takes the role on
     // ~25% of rolls in this 12p kit). Read the host's actual seat from the
@@ -948,29 +962,39 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
       `D2 vote-out plan needs at least one non-host non-wolf villager seat`,
     ).toBeGreaterThanOrEqual(1)
 
+    // Variant B Day 1: drive Night 1 first (DOM-clicks on every special
+    // role browser), then reveal night result → sheriff election.
+    //
+    // N1 plan: wolves kill the GUARD. Witch passes on the antidote (per
+    // helper default), so the kill stands. Seer checks a wolf so the
+    // SEER_RESULT sub-phase has a real check to render. Guard MUST NOT
+    // protect themselves (the UI has no skip; if the guard protects
+    // guard.seat, the wolf kill is blocked and the test plan fails).
+    // Park the guard's protect on a wolf — wolves don't kill each other,
+    // so the protection is wasted but doesn't block the planned death.
+    const wolfBots = ctx.roleMap.WEREWOLF ?? []
+    const wolfSeatForGuardProtect = wolfBots.find((b) => b.nick !== 'Host')?.seat ?? wolfBots[0]?.seat
+    expect(
+      wolfSeatForGuardProtect,
+      'HARD_MODE kit needs at least one wolf so guard can protect a non-target seat',
+    ).toBeDefined()
+
+    await driveMinimalNight1ViaDom(ctx, {
+      wolfTargetSeat: guard.seat,
+      seerCheckSeat: wolfBots[0]?.seat ?? guard.seat,
+      guardTargetSeat: wolfSeatForGuardProtect!,
+    })
+    await captureSnapshot(ctx.pages, testInfo, 'hard-02-night-1-done')
+
+    await revealNightResultAndOpenSheriffElection(ctx)
+    await captureSnapshot(ctx.pages, testInfo, 'hard-03-sheriff-election-opened')
+
     // Sheriff election — only the seer campaigns. After speeches + votes
     // the seer holds the badge.
     await runSheriffElection(ctx, [seer.nick])
-    await captureSnapshot(ctx.pages, testInfo, 'hard-02-sheriff-elected-is-seer')
+    await captureSnapshot(ctx.pages, testInfo, 'hard-04-sheriff-elected-is-seer')
 
-    // Start night 1
-    const startBtn = ctx.hostPage.getByTestId('start-night')
-    if (await startBtn.isVisible({ timeout: 10_000 }).catch(() => false)) {
-      await startBtn.click()
-    } else {
-      tryAct('START_NIGHT', 'Host', { room: ctx.roomCode })
-    }
-    await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 20_000)
-    await captureSnapshot(ctx.pages, testInfo, 'hard-03-night-1-entered')
-
-    // N1: wolves kill the GUARD. Witch's `useAntidote: false` (set inside
-    // completeNight) leaves the kill standing. Seer checks a wolf so the
-    // SEER_PICK sub-phase advances. After: 11 alive (4W/1S/1Wi/0G/5V),
-    // counterplay still has the witch, post-night logical win is skipped.
-    const wolfBots = ctx.roleMap.WEREWOLF ?? []
-    await completeNight(ctx, guard.seat, wolfBots[0]?.seat ?? guard.seat)
-    await ctx.hostPage.waitForTimeout(2_500)
-    await captureSnapshot(ctx.pages, testInfo, 'hard-04-night-1-done')
+    await waitForDayDiscussionAfterSheriff(ctx)
 
     // D1: village votes out the seer (sheriff). Backend transitions to
     // BADGE_HANDOVER — only the seer's browser page sees the pass-badge

--- a/frontend/e2e/real/helpers/night-driver.ts
+++ b/frontend/e2e/real/helpers/night-driver.ts
@@ -103,55 +103,48 @@ export async function driveMinimalNight1ViaDom(
   await guardSlot.click()
   await guardPage.getByTestId('guard-confirm-protect').click()
 
-  // ── Wait for Day 1 morning state ─────────────────────────────────────
-  // Backend transitions NIGHT → DAY_DISCUSSION/RESULT_HIDDEN once the
-  // night phase completes. Caller will then click `day-reveal-result`.
-  await waitForCondition(
-    async () => {
-      const state = await fetchPhaseAndSubPhase(hostPage, gameId)
-      return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_HIDDEN'
-    },
-    'game to reach DAY_DISCUSSION/RESULT_HIDDEN after Night 1 completes',
-    30_000,
-  )
+  // ── Wait for end-of-night transition ─────────────────────────────────
+  // Variant B (correct ordering): the backend automatically opens
+  // SHERIFF_ELECTION at end-of-night when Day 1 + hasSheriff + no sheriff
+  // yet. Otherwise it transitions to DAY_DISCUSSION/RESULT_HIDDEN. Either
+  // way, we just wait for whichever phase the game settles into.
+  await waitForSheriffOrDayDiscussion(ctx)
 }
 
 /**
- * Click `day-reveal-result` on the host browser and (when hasSheriff &&
- * dayNumber==1) wait for the auto-trigger into SHERIFF_ELECTION/SIGNUP.
- *
- * For non-sheriff games or Day 2+, callers should use the regular reveal
- * flow inline; this helper is specifically for the Variant B Day 1 trigger.
+ * Wait for the end-of-night transition to land in either:
+ *  - SHERIFF_ELECTION/SIGNUP   (Day 1 + hasSheriff: kills are still deferred,
+ *                               N1 victims are alive in DB and can 上警)
+ *  - DAY_DISCUSSION/RESULT_HIDDEN  (anything else: kills deferred until host
+ *                                   reveals)
  */
-export async function revealNightResultAndOpenSheriffElection(ctx: GameContext): Promise<void> {
-  const hostPage = ctx.hostPage
-  const gameId = ctx.gameId
-
-  const revealBtn = hostPage.getByTestId('day-reveal-result')
-  await expect(revealBtn).toBeVisible({ timeout: 15_000 })
-  await expect(revealBtn).toBeEnabled({ timeout: 10_000 })
-  await revealBtn.click()
-
-  // Backend transitions DAY_DISCUSSION/RESULT_REVEALED → SHERIFF_ELECTION
-  // immediately on Day 1 with hasSheriff. Wait for the SIGNUP sub-phase to
-  // appear in the SheriffElection state.
+export async function waitForSheriffOrDayDiscussion(
+  ctx: GameContext,
+  timeoutMs = 30_000,
+): Promise<void> {
   await waitForCondition(
     async () => {
-      const state = await fetchGameState(hostPage, gameId)
-      return (
-        state?.phase === 'SHERIFF_ELECTION' && state?.sheriffElection?.subPhase === 'SIGNUP'
-      )
+      const state = await fetchGameState(ctx.hostPage, ctx.gameId)
+      if (state?.phase === 'SHERIFF_ELECTION' && state?.sheriffElection?.subPhase === 'SIGNUP')
+        return true
+      if (state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_HIDDEN') return true
+      return false
     },
-    'game to reach SHERIFF_ELECTION/SIGNUP after revealNightResult on Day 1',
-    15_000,
+    'end-of-night transition to SHERIFF_ELECTION/SIGNUP (Day 1 + hasSheriff) or DAY_DISCUSSION/RESULT_HIDDEN',
+    timeoutMs,
   )
 }
 
 /**
- * Wait for the configurable post-sheriff auto-advance to land the game in
- * DAY_DISCUSSION/RESULT_REVEALED. Backed by
- * `werewolf.timing.sheriff-result-auto-advance-ms` — application-e2e.yml
- * sets it to 2_000ms; default production value is 60_000ms.
+ * Wait until the SHERIFF_ELECTION sub-game wraps and the backend auto-
+ * advances to DAY_DISCUSSION/RESULT_HIDDEN.
+ *
+ * Variant B: kills are still deferred at this point — the host must click
+ * REVEAL_NIGHT_RESULT next to apply them and flip RESULT_HIDDEN →
+ * RESULT_REVEALED. Use [waitForResultRevealed] after the host reveal click.
+ *
+ * Backed by `werewolf.timing.sheriff-result-auto-advance-ms` —
+ * application-e2e.yml sets it to 2_000ms; default production value is 60_000ms.
  */
 export async function waitForDayDiscussionAfterSheriff(
   ctx: GameContext,
@@ -160,9 +153,9 @@ export async function waitForDayDiscussionAfterSheriff(
   await waitForCondition(
     async () => {
       const state = await fetchGameState(ctx.hostPage, ctx.gameId)
-      return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_REVEALED'
+      return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_HIDDEN'
     },
-    'auto-advance from SHERIFF_ELECTION/RESULT to DAY_DISCUSSION/RESULT_REVEALED',
+    'auto-advance from SHERIFF_ELECTION/RESULT to DAY_DISCUSSION/RESULT_HIDDEN',
     timeoutMs,
   )
 }

--- a/frontend/e2e/real/helpers/night-driver.ts
+++ b/frontend/e2e/real/helpers/night-driver.ts
@@ -1,6 +1,6 @@
 import { expect, type Page } from '@playwright/test'
 import type { GameContext } from './multi-browser'
-import { waitForCondition, waitForNightSubPhase } from './state-polling'
+import { waitForCondition, waitForNightSubPhase, waitForPhase } from './state-polling'
 
 /**
  * Drive a Night 1 to completion via DOM clicks on each special-role browser.
@@ -32,6 +32,16 @@ export async function driveMinimalNight1ViaDom(
   await expect(startBtn).toBeVisible({ timeout: 15_000 })
   await expect(startBtn).toBeEnabled({ timeout: 10_000 })
   await startBtn.click()
+
+  // After clicking start-night, the backend transitions ROLE_REVEAL → NIGHT.
+  // waitForNightSubPhase has an early-exit guard that returns false if
+  // game.phase is anything other than NIGHT — gate on phase=NIGHT first
+  // to avoid racing that guard while the transition is still in-flight.
+  // (Flake observed in PR #89 CI run 73954244714: the helper was called
+  // mid-transition while phase still showed ROLE_REVEAL.)
+  if (!(await waitForPhase(hostPage, gameId, 'NIGHT', 15_000))) {
+    throw new Error('driveMinimalNight1ViaDom: NIGHT phase not reached after start-night click')
+  }
 
   // ── Wolf kill ────────────────────────────────────────────────────────
   const reachedWolfPick = await waitForNightSubPhase(hostPage, gameId, 'WEREWOLF_PICK', 25_000)

--- a/frontend/e2e/real/helpers/night-driver.ts
+++ b/frontend/e2e/real/helpers/night-driver.ts
@@ -1,0 +1,206 @@
+import { expect, type Page } from '@playwright/test'
+import type { GameContext } from './multi-browser'
+import { waitForCondition, waitForNightSubPhase } from './state-polling'
+
+/**
+ * Drive a Night 1 to completion via DOM clicks on each special-role browser.
+ *
+ * Wolf, seer, witch, and guard each take their action through their own
+ * browser context — never through act.sh. This keeps the test honest about
+ * what real users do (per the e2e-six-design-principles memory: "Special-role
+ * browsers + the host browser fire each gameplay action via Playwright clicks
+ * on real testids, not via act.sh"). It catches button-render bugs, click-
+ * handler wiring, target-grid filters, and reactive watchers — the very
+ * regressions that prompted Variant B in the first place.
+ *
+ * Preconditions:
+ *  - ctx.game in ROLE_REVEAL with all roles confirmed.
+ *  - ctx.pages has entries for WEREWOLF, SEER, WITCH, GUARD.
+ *
+ * Postcondition: backend state is DAY_DISCUSSION/RESULT_HIDDEN, ready for
+ * the host to click `day-reveal-result`.
+ */
+export async function driveMinimalNight1ViaDom(
+  ctx: GameContext,
+  opts: { wolfTargetSeat: number; seerCheckSeat?: number; guardTargetSeat?: number },
+): Promise<void> {
+  const hostPage = ctx.hostPage
+  const gameId = ctx.gameId
+
+  // ── Host starts night ────────────────────────────────────────────────
+  const startBtn = hostPage.getByTestId('start-night')
+  await expect(startBtn).toBeVisible({ timeout: 15_000 })
+  await expect(startBtn).toBeEnabled({ timeout: 10_000 })
+  await startBtn.click()
+
+  // ── Wolf kill ────────────────────────────────────────────────────────
+  const reachedWolfPick = await waitForNightSubPhase(hostPage, gameId, 'WEREWOLF_PICK', 25_000)
+  if (!reachedWolfPick) {
+    throw new Error('driveMinimalNight1ViaDom: WEREWOLF_PICK sub-phase not reached')
+  }
+  const wolfPage = pageOrThrow(ctx, 'WEREWOLF')
+  const wolfSlot = wolfPage.locator(`.player-grid [data-seat="${opts.wolfTargetSeat}"]`)
+  await expect(wolfSlot, `wolf target seat ${opts.wolfTargetSeat} must render`).toBeVisible({
+    timeout: 10_000,
+  })
+  await wolfSlot.click()
+  await wolfPage.getByTestId('wolf-confirm-kill').click()
+
+  // ── Seer check + acknowledge result ──────────────────────────────────
+  const reachedSeerPick = await waitForNightSubPhase(hostPage, gameId, 'SEER_PICK', 15_000)
+  if (!reachedSeerPick) {
+    throw new Error('driveMinimalNight1ViaDom: SEER_PICK sub-phase not reached')
+  }
+  const seerPage = pageOrThrow(ctx, 'SEER')
+  const checkSeat = opts.seerCheckSeat ?? 1
+  const seerSlot = seerPage.locator(`.player-grid [data-seat="${checkSeat}"]`)
+  await expect(seerSlot, `seer check seat ${checkSeat} must render`).toBeVisible({ timeout: 10_000 })
+  await seerSlot.click()
+  await seerPage.getByTestId('seer-check').click()
+
+  await waitForNightSubPhase(hostPage, gameId, 'SEER_RESULT', 10_000)
+  await expect(seerPage.getByTestId('seer-result-card')).toBeVisible({ timeout: 10_000 })
+  await seerPage.getByTestId('seer-done').click()
+
+  // ── Witch passes on antidote + poison ────────────────────────────────
+  const reachedWitchAct = await waitForNightSubPhase(hostPage, gameId, 'WITCH_ACT', 15_000)
+  if (!reachedWitchAct) {
+    throw new Error('driveMinimalNight1ViaDom: WITCH_ACT sub-phase not reached')
+  }
+  const witchPage = pageOrThrow(ctx, 'WITCH')
+  // The witch UI shows: (a) antidote section if hasAntidote, (b) poison
+  // section if hasPoison, (c) skip button only when neither item is
+  // available. For a fresh Day 1 witch both items are available — pass on
+  // each in turn. Use isVisible-with-short-timeout rather than asserting
+  // visibility: a particular sub-section only renders if the condition is
+  // met (e.g. switch-pass-poison is gated on a wolf having killed someone).
+  const passAntidote = witchPage.getByTestId('switch-pass-antidote')
+  if (await passAntidote.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await passAntidote.click()
+  }
+  const passPoison = witchPage.getByTestId('switch-pass-poison')
+  if (await passPoison.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await passPoison.click()
+  }
+  // If the witch happens to have no items, the skip button replaces the
+  // sections above and is the only path forward.
+  const witchSkip = witchPage.getByTestId('witch-skip')
+  if (await witchSkip.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await witchSkip.click()
+  }
+
+  // ── Guard protects (UI has no skip — must pick a target) ─────────────
+  const reachedGuardPick = await waitForNightSubPhase(hostPage, gameId, 'GUARD_PICK', 15_000)
+  if (!reachedGuardPick) {
+    throw new Error('driveMinimalNight1ViaDom: GUARD_PICK sub-phase not reached')
+  }
+  const guardPage = pageOrThrow(ctx, 'GUARD')
+  const protectSeat = opts.guardTargetSeat ?? 1
+  const guardSlot = guardPage.locator(`.player-grid [data-seat="${protectSeat}"]`)
+  await expect(guardSlot, `guard protect seat ${protectSeat} must render`).toBeVisible({
+    timeout: 10_000,
+  })
+  await guardSlot.click()
+  await guardPage.getByTestId('guard-confirm-protect').click()
+
+  // ── Wait for Day 1 morning state ─────────────────────────────────────
+  // Backend transitions NIGHT → DAY_DISCUSSION/RESULT_HIDDEN once the
+  // night phase completes. Caller will then click `day-reveal-result`.
+  await waitForCondition(
+    async () => {
+      const state = await fetchPhaseAndSubPhase(hostPage, gameId)
+      return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_HIDDEN'
+    },
+    'game to reach DAY_DISCUSSION/RESULT_HIDDEN after Night 1 completes',
+    30_000,
+  )
+}
+
+/**
+ * Click `day-reveal-result` on the host browser and (when hasSheriff &&
+ * dayNumber==1) wait for the auto-trigger into SHERIFF_ELECTION/SIGNUP.
+ *
+ * For non-sheriff games or Day 2+, callers should use the regular reveal
+ * flow inline; this helper is specifically for the Variant B Day 1 trigger.
+ */
+export async function revealNightResultAndOpenSheriffElection(ctx: GameContext): Promise<void> {
+  const hostPage = ctx.hostPage
+  const gameId = ctx.gameId
+
+  const revealBtn = hostPage.getByTestId('day-reveal-result')
+  await expect(revealBtn).toBeVisible({ timeout: 15_000 })
+  await expect(revealBtn).toBeEnabled({ timeout: 10_000 })
+  await revealBtn.click()
+
+  // Backend transitions DAY_DISCUSSION/RESULT_REVEALED → SHERIFF_ELECTION
+  // immediately on Day 1 with hasSheriff. Wait for the SIGNUP sub-phase to
+  // appear in the SheriffElection state.
+  await waitForCondition(
+    async () => {
+      const state = await fetchGameState(hostPage, gameId)
+      return (
+        state?.phase === 'SHERIFF_ELECTION' && state?.sheriffElection?.subPhase === 'SIGNUP'
+      )
+    },
+    'game to reach SHERIFF_ELECTION/SIGNUP after revealNightResult on Day 1',
+    15_000,
+  )
+}
+
+/**
+ * Wait for the configurable post-sheriff auto-advance to land the game in
+ * DAY_DISCUSSION/RESULT_REVEALED. Backed by
+ * `werewolf.timing.sheriff-result-auto-advance-ms` — application-e2e.yml
+ * sets it to 2_000ms; default production value is 60_000ms.
+ */
+export async function waitForDayDiscussionAfterSheriff(
+  ctx: GameContext,
+  timeoutMs = 20_000,
+): Promise<void> {
+  await waitForCondition(
+    async () => {
+      const state = await fetchGameState(ctx.hostPage, ctx.gameId)
+      return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_REVEALED'
+    },
+    'auto-advance from SHERIFF_ELECTION/RESULT to DAY_DISCUSSION/RESULT_REVEALED',
+    timeoutMs,
+  )
+}
+
+// ── internal helpers ───────────────────────────────────────────────────
+
+function pageOrThrow(ctx: GameContext, role: string): Page {
+  const page = ctx.pages.get(role)
+  if (!page) {
+    throw new Error(
+      `ctx.pages missing browser for role=${role}. Pass browserRoles including '${role}' to setupGame.`,
+    )
+  }
+  return page
+}
+
+interface PhaseSnapshot {
+  phase?: string
+  subPhase?: string | null
+  sheriffElection?: { subPhase?: string | null } | null
+}
+
+async function fetchGameState(page: Page, gameId: string): Promise<PhaseSnapshot | null> {
+  return page.evaluate(async (id: string) => {
+    const token = localStorage.getItem('jwt')
+    if (!token) return null
+    const res = await fetch(`/api/game/${id}/state`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    return res.ok ? await res.json() : null
+  }, gameId)
+}
+
+async function fetchPhaseAndSubPhase(
+  page: Page,
+  gameId: string,
+): Promise<{ phase?: string; subPhase?: string | null } | null> {
+  const state = await fetchGameState(page, gameId)
+  if (!state) return null
+  return { phase: state.phase, subPhase: state.subPhase ?? null }
+}

--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -303,8 +303,9 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
       20_000,
     )
 
-    // All browsers transition to DAY_DISCUSSION.
-    await verifyAllBrowsersPhase(ctx.pages, 'DAY_DISCUSSION', 15_000)
+    // All browsers transition to DAY (PHASE_DATA_VALUES maps "DAY" to
+    // {DAY_PENDING, DAY_DISCUSSION} on the data-phase attribute).
+    await verifyAllBrowsersPhase(ctx.pages, 'DAY', 15_000)
 
     await captureSnapshot(ctx.pages, testInfo, 'sheriff-05-day-discussion')
   })

--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -23,8 +23,13 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
       totalPlayers: 9,
       hasSheriff: true,
       // Variant B: each role's Night 1 action is DOM-driven from its own
-      // browser context. WITCH and GUARD now need browsers (they were API-
-      // only before).
+      // browser context. driveMinimalNight1ViaDom drives WEREWOLF_PICK →
+      // SEER_PICK → SEER_RESULT → WITCH_ACT → GUARD_PICK in order, so the
+      // kit MUST include all four special roles; otherwise the missing
+      // role's sub-phase never fires and the wait times out. Explicit
+      // roles also bypass the default 9p kit which doesn't guarantee
+      // GUARD presence.
+      roles: ['WEREWOLF', 'VILLAGER', 'SEER', 'WITCH', 'GUARD'] as RoleName[],
       browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'GUARD', 'VILLAGER'] as RoleName[],
     })
   })

--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -10,7 +10,7 @@ import {actName, type RoleName, sheriff} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase,} from './helpers/assertions'
 import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
 import {waitForCondition} from './helpers/state-polling'
-import {driveMinimalNight1ViaDom, revealNightResultAndOpenSheriffElection} from './helpers/night-driver'
+import {driveMinimalNight1ViaDom} from './helpers/night-driver'
 
 let ctx: GameContext
 
@@ -46,15 +46,17 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
 
   // ── Test 1: N1 + reveal → SHERIFF_ELECTION ────────────────────────────
 
-  test('1. Day 1 morning — sheriff election opens after revealNightResult', async ({}, testInfo) => {
-    // Variant B: setup leaves us in ROLE_REVEAL. Drive Night 1 via DOM
-    // clicks on each role's browser, then host reveals the night result —
-    // the backend auto-transitions into SHERIFF_ELECTION/SIGNUP because
-    // hasSheriff && dayNumber == 1.
-
-    // Wolves must NOT kill the seer — Test 4 votes the seer in as sheriff,
-    // which requires the seer to be alive (and a candidate signs up in
-    // Test 2 from the seer browser). Pick a non-host VILLAGER seat.
+  test('1. Day 1 morning — sheriff election opens at end-of-night (deferred kills)', async ({}, testInfo) => {
+    // Variant B (correct order): setup leaves us in ROLE_REVEAL. Drive
+    // Night 1 via DOM clicks on each role's browser. The backend
+    // automatically opens SHERIFF_ELECTION at end-of-night when Day 1 +
+    // hasSheriff + no sheriff yet — host does NOT click reveal yet
+    // (kills are deferred until after the sheriff election so N1 victims
+    // can still 上警 / use 挡刀 tactics).
+    //
+    // Wolves can target any non-host villager — even the seer's would-be
+    // running mate works, because deferred kills mean no one is dead in
+    // DB yet during sheriff signup.
     const villagerSeats = (ctx.roleMap.VILLAGER ?? [])
       .filter((b) => b.nick !== 'Host')
       .map((b) => b.seat)
@@ -64,10 +66,12 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
       'kit must include at least one non-host VILLAGER for the wolf to target',
     ).toBeDefined()
 
+    // driveMinimalNight1ViaDom drives the 4 night sub-phases via DOM and
+    // then waits for either SHERIFF_ELECTION/SIGNUP (Day 1 + hasSheriff)
+    // or DAY_DISCUSSION/RESULT_HIDDEN (other days). Here we expect SHERIFF.
     await driveMinimalNight1ViaDom(ctx, { wolfTargetSeat: wolfTargetSeat! })
-    await revealNightResultAndOpenSheriffElection(ctx)
 
-    // After the auto-trigger, all browsers must be in SHERIFF_ELECTION.
+    // After the auto-transition, all browsers must be in SHERIFF_ELECTION.
     await verifyAllBrowsersPhase(ctx.pages, 'SHERIFF_ELECTION', 20_000)
 
     // Verify the signup sub-phase UI is shown on every browser.
@@ -274,12 +278,14 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
     await captureSnapshot(ctx.pages, testInfo, 'sheriff-04-result')
   })
 
-  // ── Test 5: Sheriff result → DAY_DISCUSSION auto-advance ───────────────
+  // ── Test 5: Sheriff result → DAY_DISCUSSION/RESULT_HIDDEN auto-advance ──
 
-  test('5. Sheriff result → DAY_DISCUSSION auto-advance', async ({}, testInfo) => {
-    // Variant B: after sheriff RESULT the backend auto-advances to
-    // DAY_DISCUSSION/RESULT_REVEALED via SheriffService.scheduleAutoAdvance-
-    // FromSheriffResult. The delay is configurable via
+  test('5. Sheriff result → DAY_DISCUSSION/RESULT_HIDDEN auto-advance', async ({}, testInfo) => {
+    // Variant B (correct order): after sheriff RESULT the backend auto-
+    // advances to DAY_DISCUSSION/RESULT_HIDDEN via
+    // SheriffService.scheduleAutoAdvanceFromSheriffResult. The host then
+    // clicks REVEAL_NIGHT_RESULT separately to apply pending kills and
+    // flip to RESULT_REVEALED. The delay is configurable via
     // werewolf.timing.sheriff-result-auto-advance-ms — application-e2e.yml
     // sets it to 2_000ms so this test doesn't hang for 60s.
     await waitForCondition(
@@ -291,9 +297,9 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
           })
           return res.ok ? await res.json() : null
         }, ctx.gameId)
-        return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_REVEALED'
+        return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_HIDDEN'
       },
-      'auto-advance from SHERIFF_ELECTION/RESULT to DAY_DISCUSSION/RESULT_REVEALED',
+      'auto-advance from SHERIFF_ELECTION/RESULT to DAY_DISCUSSION/RESULT_HIDDEN',
       20_000,
     )
 

--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -10,6 +10,7 @@ import {actName, type RoleName, sheriff} from './helpers/shell-runner'
 import {verifyAllBrowsersPhase,} from './helpers/assertions'
 import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
 import {waitForCondition} from './helpers/state-polling'
+import {driveMinimalNight1ViaDom, revealNightResultAndOpenSheriffElection} from './helpers/night-driver'
 
 let ctx: GameContext
 
@@ -21,7 +22,10 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
     ctx = await setupGame(browser, {
       totalPlayers: 9,
       hasSheriff: true,
-      browserRoles: ['WEREWOLF', 'SEER', 'VILLAGER'] as RoleName[],
+      // Variant B: each role's Night 1 action is DOM-driven from its own
+      // browser context. WITCH and GUARD now need browsers (they were API-
+      // only before).
+      browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'GUARD', 'VILLAGER'] as RoleName[],
     })
   })
 
@@ -35,15 +39,34 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
     }
   })
 
-  // ── Test 1: Sheriff signup ─────────────────────────────────────────────
+  // ── Test 1: N1 + reveal → SHERIFF_ELECTION ────────────────────────────
 
-  test('1. Sheriff signup — all browsers show SHERIFF_ELECTION phase', async ({}, testInfo) => {
-    // After role reveal with hasSheriff=true, phase should go to SHERIFF_ELECTION
-    // The host may need to wait for automatic transition, or the election starts automatically
+  test('1. Day 1 morning — sheriff election opens after revealNightResult', async ({}, testInfo) => {
+    // Variant B: setup leaves us in ROLE_REVEAL. Drive Night 1 via DOM
+    // clicks on each role's browser, then host reveals the night result —
+    // the backend auto-transitions into SHERIFF_ELECTION/SIGNUP because
+    // hasSheriff && dayNumber == 1.
+
+    // Wolves must NOT kill the seer — Test 4 votes the seer in as sheriff,
+    // which requires the seer to be alive (and a candidate signs up in
+    // Test 2 from the seer browser). Pick a non-host VILLAGER seat.
+    const villagerSeats = (ctx.roleMap.VILLAGER ?? [])
+      .filter((b) => b.nick !== 'Host')
+      .map((b) => b.seat)
+    const wolfTargetSeat = villagerSeats[0]
+    expect(
+      wolfTargetSeat,
+      'kit must include at least one non-host VILLAGER for the wolf to target',
+    ).toBeDefined()
+
+    await driveMinimalNight1ViaDom(ctx, { wolfTargetSeat: wolfTargetSeat! })
+    await revealNightResultAndOpenSheriffElection(ctx)
+
+    // After the auto-trigger, all browsers must be in SHERIFF_ELECTION.
     await verifyAllBrowsersPhase(ctx.pages, 'SHERIFF_ELECTION', 20_000)
 
-    // Verify the signup sub-phase UI is shown
-    for (const [role, page] of Array.from(ctx.pages.entries())) {
+    // Verify the signup sub-phase UI is shown on every browser.
+    for (const [, page] of Array.from(ctx.pages.entries())) {
       await expect(page.locator('.sheriff-wrap')).toBeVisible({ timeout: 10_000 })
     }
 
@@ -246,20 +269,32 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
     await captureSnapshot(ctx.pages, testInfo, 'sheriff-04-result')
   })
 
-  // ── Test 5: Sheriff → Night transition ─────────────────────────────────
+  // ── Test 5: Sheriff result → DAY_DISCUSSION auto-advance ───────────────
 
-  test('5. Sheriff result → Night transition', async ({}, testInfo) => {
-    // After sheriff RESULT, the host has a "start-night" button on the
-    // result screen. The button is the contract — fail loudly if it
-    // doesn't render in 10s rather than silently fall back to a script
-    // that may also fail.
-    const startNightBtn = ctx.hostPage.getByTestId('start-night')
-    await startNightBtn.waitFor({ state: 'visible', timeout: 10_000 })
-    await startNightBtn.click()
+  test('5. Sheriff result → DAY_DISCUSSION auto-advance', async ({}, testInfo) => {
+    // Variant B: after sheriff RESULT the backend auto-advances to
+    // DAY_DISCUSSION/RESULT_REVEALED via SheriffService.scheduleAutoAdvance-
+    // FromSheriffResult. The delay is configurable via
+    // werewolf.timing.sheriff-result-auto-advance-ms — application-e2e.yml
+    // sets it to 2_000ms so this test doesn't hang for 60s.
+    await waitForCondition(
+      async () => {
+        const state = await ctx.hostPage.evaluate(async (id: string) => {
+          const token = localStorage.getItem('jwt')
+          const res = await fetch(`/api/game/${id}/state`, {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          return res.ok ? await res.json() : null
+        }, ctx.gameId)
+        return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'RESULT_REVEALED'
+      },
+      'auto-advance from SHERIFF_ELECTION/RESULT to DAY_DISCUSSION/RESULT_REVEALED',
+      20_000,
+    )
 
-    // All browsers transition to NIGHT.
-    await verifyAllBrowsersPhase(ctx.pages, 'NIGHT', 15_000)
+    // All browsers transition to DAY_DISCUSSION.
+    await verifyAllBrowsersPhase(ctx.pages, 'DAY_DISCUSSION', 15_000)
 
-    await captureSnapshot(ctx.pages, testInfo, 'sheriff-05-night-transition')
+    await captureSnapshot(ctx.pages, testInfo, 'sheriff-05-day-discussion')
   })
 })

--- a/frontend/src/__tests__/phaseBVotingPhaseGate.test.ts
+++ b/frontend/src/__tests__/phaseBVotingPhaseGate.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Phase B contract test: GameView.vue must mount VotingPhase under DAY_DISCUSSION
+ * when the sub-phase is HUNTER_SHOOT or BADGE_HANDOVER (the new night-kill
+ * routing path).
+ *
+ * Without this gate, the existing BADGE_HANDOVER / HUNTER_SHOOT UI in
+ * VotingPhase.vue stays hidden when a sheriff/hunter dies at night, and the
+ * eliminated player has no way to pass the badge or fire the shot.
+ *
+ * The full mount path is exercised by the Playwright real-backend run; this
+ * unit test catches the case where someone removes or simplifies the gate
+ * (e.g. "this looks redundant, just check DAY_VOTING").
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const template = readFileSync(join(__dirname, '..', 'views', 'GameView.vue'), 'utf-8')
+
+describe('Phase B — VotingPhase gate under DAY_DISCUSSION', () => {
+  it('GameView.vue mounts VotingPhase when DAY_DISCUSSION + dayPhase.subPhase is HUNTER_SHOOT', () => {
+    // The gate must include a clause that triggers VotingPhase render when
+    // dayPhase.subPhase === 'HUNTER_SHOOT'. We grep for the literal so a
+    // refactor that drops/renames the clause fails this test.
+    expect(template).toMatch(/dayPhase\?\.subPhase\s*===\s*'HUNTER_SHOOT'/)
+  })
+
+  it('GameView.vue mounts VotingPhase when DAY_DISCUSSION + dayPhase.subPhase is BADGE_HANDOVER', () => {
+    expect(template).toMatch(/dayPhase\?\.subPhase\s*===\s*'BADGE_HANDOVER'/)
+  })
+
+  it('the gate still includes the original DAY_VOTING + votingPhase clause', () => {
+    // Sanity: Phase B added an OR branch — the original DAY_VOTING gate
+    // must still be there or the vote-out BADGE_HANDOVER UI breaks.
+    expect(template).toMatch(/phase\s*===\s*'DAY_VOTING'\s*&&\s*gameStore\.state\?\.votingPhase/)
+  })
+})

--- a/frontend/src/components/SheriffElection.vue
+++ b/frontend/src/components/SheriffElection.vue
@@ -471,20 +471,13 @@
           </div>
         </div>
       </div>
-      <template v-if="isHost">
-        <div class="spacer" />
-        <div class="action-footer">
-          <button
-            class="btn btn-primary"
-            :class="{ 'is-loading': actionPending }"
-            :disabled="actionPending"
-            data-testid="start-night"
-            @click="emit('startNight')"
-          >
-            开始夜晚 / Start Night
-          </button>
-        </div>
-      </template>
+      <!--
+        Variant B: no manual "Start Night" button on the sheriff RESULT
+        screen. After the result is shown, the backend auto-advances to
+        DAY_DISCUSSION/RESULT_REVEALED via
+        SheriffService.scheduleAutoAdvanceFromSheriffResult — the host's
+        next manual action is "start vote" on the day-discussion screen.
+      -->
     </template>
   </div>
 </template>
@@ -511,7 +504,6 @@ const emit = defineEmits<{
   advanceSpeech: []
   revealResult: []
   appoint: [userId: string]
-  startNight: []
 }>()
 
 const iAmCandidate = computed(() =>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -228,7 +228,11 @@ export interface SheriffElectionState {
 
 // ── Day Phase ─────────────────────────────────────────────────────────────────
 
-export type DaySubPhase = 'RESULT_HIDDEN' | 'RESULT_REVEALED'
+// Phase B: BADGE_HANDOVER and HUNTER_SHOOT also live in DAY_DISCUSSION when
+// a sheriff/hunter is killed at night (see GamePhasePipeline.revealNightResult
+// on the backend). They share names with VotingSubPhase but are scoped to
+// the DAY_DISCUSSION parent.
+export type DaySubPhase = 'RESULT_HIDDEN' | 'RESULT_REVEALED' | 'BADGE_HANDOVER' | 'HUNTER_SHOOT'
 
 export interface KilledPlayer {
   killedPlayerId: string

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -47,7 +47,6 @@
         <button
           v-if="
             isHost &&
-            gameStore.state.hasSheriff === false &&
             gameStore.state.roleReveal?.confirmedCount === gameStore.state.roleReveal?.totalCount
           "
           class="btn btn-primary"
@@ -82,7 +81,6 @@
         @advance-speech="handleSheriffAdvanceSpeech"
         @reveal-result="handleSheriffRevealResult"
         @appoint="handleSheriffAppoint"
-        @start-night="handleSheriffStartNight"
       />
     </template>
 
@@ -670,10 +668,6 @@ async function handleSheriffRevealResult() {
 async function handleSheriffAppoint(userId: string) {
   await action({ actionType: 'SHERIFF_APPOINT', targetId: userId })
 }
-async function handleSheriffStartNight() {
-  await action({ actionType: 'START_NIGHT' })
-}
-
 async function handleRevealResult() {
   await action({ actionType: 'REVEAL_NIGHT_RESULT' })
 }

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -104,10 +104,24 @@
     </template>
 
     <!-- Voting phase -->
-    <template v-else-if="gameStore.state?.phase === 'DAY_VOTING' && gameStore.state?.votingPhase">
+    <template
+      v-else-if="
+        (gameStore.state?.phase === 'DAY_VOTING' && gameStore.state?.votingPhase) ||
+        (gameStore.state?.phase === 'DAY_DISCUSSION' &&
+          gameStore.state?.votingPhase &&
+          (gameStore.state?.dayPhase?.subPhase === 'HUNTER_SHOOT' ||
+            gameStore.state?.dayPhase?.subPhase === 'BADGE_HANDOVER'))
+      "
+    >
+      <!--
+        Phase B: VotingPhase also renders under DAY_DISCUSSION when the
+        sub-phase is HUNTER_SHOOT or BADGE_HANDOVER (sheriff/hunter killed
+        at night). The backend populates `votingPhase` with the same shape
+        in this case so the existing UI works without changes.
+      -->
       <VotingPhase
-        :key="`voting-${gameStore.state.votingPhase.subPhase}-${gameStore.state.dayNumber}`"
-        :voting-phase="gameStore.state.votingPhase"
+        :key="`voting-${gameStore.state.votingPhase!.subPhase}-${gameStore.state.dayNumber}`"
+        :voting-phase="gameStore.state.votingPhase!"
         :players="gameStore.state.players"
         :my-user-id="userStore.userId ?? ''"
         :is-host="isHost"


### PR DESCRIPTION
## Summary

Reorder the sheriff election so it runs on **Day 1 morning, after the Night 1 result is revealed**, instead of before Night 1. Players now have one night of context before the campaign — speeches stop being cold-open self-intros.

## Flow change

**Before:**
\`\`\`
ROLE_REVEAL → SHERIFF_ELECTION → NIGHT 1 → DAY 1 → ...
\`\`\`

**After (Variant B):**
\`\`\`
ROLE_REVEAL
  → host startNight → NIGHT 1
  → DAY 1: RESULT_HIDDEN → host revealNightResult → RESULT_REVEALED
  → (auto, if hasSheriff && Day 1 && no sheriff yet) SHERIFF_ELECTION/SIGNUP
       SIGNUP → SPEECH → VOTING → RESULT
       → (60s auto-advance) DAY_DISCUSSION/RESULT_REVEALED
  → host dayAdvance → DAY_VOTING
  → NIGHT 2 → ...
\`\`\`

Sheriff election is **opt-in** (\`Room.hasSheriff\`) and **one-shot** — runs on Day 1 only, never re-opens on subsequent days.

## Design choices (confirmed before implementing)

| | Choice |
|---|---|
| **Trigger** | Auto on \`revealNightResult\` (no extra host click) |
| **After result** | Back to \`DAY_DISCUSSION/RESULT_REVEALED\` (host clicks dayAdvance to start vote) |
| **Game start (hasSheriff=true)** | Stay in \`ROLE_REVEAL\` until host clicks startNight (uniform with hasSheriff=false) |
| **Re-run frequency** | Day 1 only |

## Backend changes

- \`GamePhasePipeline.confirmRole\` — drop the all-confirmed → \`SHERIFF_ELECTION\` transition.
- \`GamePhasePipeline.startNight\` — drop the \`hasSheriff\` rejection. Always allowed from \`ROLE_REVEAL\` when all confirmed.
- \`GamePhasePipeline.revealNightResult\` — auto-trigger \`SHERIFF_ELECTION/SIGNUP\` on Day 1 with hasSheriff and no existing sheriff.
- \`SheriffService\` — replace \`scheduleAutoAdvanceToNight\` with \`scheduleAutoAdvanceFromSheriffResult\` + new idempotent \`advanceToDayDiscussion\`. Drop unused \`NightOrchestrator\` dep.
- All four sheriff-result paths (\`revealResult\`, \`appoint\`, \`quitCampaign-all-quit\`, \`startSpeech-no-candidates\`) now land on \`DAY_DISCUSSION/RESULT_REVEALED\` instead of \`NIGHT\`.

## Test status

| Suite | Status |
|---|---|
| Backend unit tests | ✅ Passing (\`GamePipelineSheriffTest\` rewritten; \`SheriffServiceTest\` updated) |
| Backend integration tests | ✅ Passing (\`SheriffElectionIntegrationTest\` + EdgeCase: new helper bypasses START_NIGHT/N1 to arrange production-equivalent state, no-candidates assertion changed from \"transitions to NIGHT\" to \"returns to DAY_DISCUSSION/RESULT_REVEALED\") |
| Backend full \`./gradlew test\` | ✅ Green (538 tests) |
| Frontend \`npx vitest run\` | ✅ 244/244 green |
| Frontend \`npx vue-tsc --noEmit\` | ✅ Clean |
| Frontend E2E real-backend specs (\`sheriff-flow\`, \`flow-12p-sheriff\`) | ⏳ **TODO follow-up commit** — these specs assume the old order (sheriff before N1) and need restructuring to drive a full N1 before sheriff election. The non-sheriff specs (game-flow, idiot-flow, etc., all \`hasSheriff: false\`) are unaffected. |

## Test plan

- [x] Backend unit + integration tests
- [x] Frontend unit + tsc
- [ ] CI green (will fail on sheriff E2E specs until follow-up commit)
- [ ] Frontend E2E specs updated (sheriff-flow.spec.ts + flow-12p-sheriff.spec.ts) — separate commit on this branch
- [ ] Manual smoke on dev backend after E2E updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)