### PR TITLE
fix(game): return players in seat order from getGameState

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/service/GameService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/GameService.kt
@@ -316,7 +316,7 @@ class GameService(
             "dayPhase" to dayPhase,
             "votingPhase" to votingPhase,
             "nightPhase" to nightPhase,
-            "players" to players.map { p ->
+            "players" to players.sortedBy { it.seatIndex }.map { p ->
                 mapOf(
                     "userId"        to p.userId,
                     "nickname"      to (userLookup[p.userId]?.nickname ?: p.userId),

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceNightPhaseTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceNightPhaseTest.kt
@@ -118,6 +118,27 @@ class GameServiceNightPhaseTest {
     }
 
     @Test
+    fun `getGameState - players list is sorted by seatIndex regardless of repository order`() {
+        // Repository can return rows in heap order (post-UPDATE), not seat order.
+        // The dashboard renders players directly from this array, so the API must sort.
+        val players = listOf(
+            player("u3", 3, PlayerRole.VILLAGER),
+            player("u1", 1, PlayerRole.VILLAGER),
+            player("u4", 4, PlayerRole.VILLAGER),
+            player("u2", 2, PlayerRole.WEREWOLF),
+        )
+        val users = listOf(user("u1", "A"), user("u2", "B"), user("u3", "C"), user("u4", "D"))
+        val game = game(phase = GamePhase.DAY_DISCUSSION).also { it.dayNumber = 1 }
+        setupGameAndPlayers(game, players, users)
+
+        val result = gameService.getGameState(gameId, "u1")
+
+        @Suppress("UNCHECKED_CAST")
+        val playerList = result["players"] as List<Map<String, Any?>>
+        assertThat(playerList.map { it["seatIndex"] }).containsExactly(1, 2, 3, 4)
+    }
+
+    @Test
     fun `getGameState - WEREWOLF gets teammate list formatted as seat-dot-nick`() {
         val wolf1 = player("u1", 1, PlayerRole.WEREWOLF)
         val wolf2 = player("u2", 2, PlayerRole.WEREWOLF)

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceNightPhaseTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceNightPhaseTest.kt
@@ -10,6 +10,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
@@ -117,10 +119,16 @@ class GameServiceNightPhaseTest {
         assertThat(bob["nickname"]).isEqualTo("Bob")
     }
 
-    @Test
-    fun `getGameState - players list is sorted by seatIndex regardless of repository order`() {
-        // Repository can return rows in heap order (post-UPDATE), not seat order.
-        // The dashboard renders players directly from this array, so the API must sort.
+    // The dashboard renders gameStore.state.players via v-for without any
+    // client-side sort, so the contract is: getGameState must always return
+    // players[] in ascending seatIndex order. Postgres returns rows in heap
+    // order (which can shift after UPDATEs on GamePlayer.alive / .sheriff /
+    // .confirmedRole), so the API has to sort. This test runs across EVERY
+    // GamePhase to also catch a future refactor that branches the players-
+    // list construction by phase and forgets to sort in some path.
+    @ParameterizedTest
+    @EnumSource(GamePhase::class)
+    fun `getGameState - players list is always sorted by seatIndex regardless of phase`(phase: GamePhase) {
         val players = listOf(
             player("u3", 3, PlayerRole.VILLAGER),
             player("u1", 1, PlayerRole.VILLAGER),
@@ -128,14 +136,16 @@ class GameServiceNightPhaseTest {
             player("u2", 2, PlayerRole.WEREWOLF),
         )
         val users = listOf(user("u1", "A"), user("u2", "B"), user("u3", "C"), user("u4", "D"))
-        val game = game(phase = GamePhase.DAY_DISCUSSION).also { it.dayNumber = 1 }
+        val game = game(phase = phase).also { it.dayNumber = 1 }
         setupGameAndPlayers(game, players, users)
 
         val result = gameService.getGameState(gameId, "u1")
 
         @Suppress("UNCHECKED_CAST")
         val playerList = result["players"] as List<Map<String, Any?>>
-        assertThat(playerList.map { it["seatIndex"] }).containsExactly(1, 2, 3, 4)
+        assertThat(playerList.map { it["seatIndex"] })
+            .`as`("players[] must be in seat order during phase=$phase")
+            .containsExactly(1, 2, 3, 4)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- **Bug:** in-game player dashboard occasionally renders seats out of order (1, 3, 2, 5, 4 …) after phase transitions
- **Cause:** `GameService.getGameState()` built the `players[]` array from `gamePlayerRepository.findByGameId()`, which has no `ORDER BY`. Postgres returns rows in heap order, which can shift after `UPDATE`s on `GamePlayer` rows (e.g., when `alive`, `sheriff`, or `confirmedRole` flips). The frontend dashboard renders that array directly via `v-for`.
- **Fix:** add `.sortedBy { it.seatIndex }` at the serialization boundary in `GameService.kt:319`. STOMP broadcasts only emit domain events (no `players[]` payload) — the frontend re-fetches `getGameState` after each event — so this single fix covers every dashboard refresh path.

## Test plan
- [x] Added regression test `GameServiceNightPhaseTest > "players list is sorted by seatIndex regardless of repository order"` — feeds the repository mock `[seat 3, 1, 4, 2]` and asserts the API response is `[1, 2, 3, 4]`. Would have failed before this commit.
- [x] All 16 tests in `GameServiceNightPhaseTest` pass locally
- [ ] Manual: open a 12-player game, walk through ROLE_REVEAL → NIGHT → DAY → VOTE; confirm the dashboard always renders seats 1..12 in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)