### PR TITLE
fix(voting): only eliminated sheriff sees "you are eliminated" badge banner

### DIFF
--- a/frontend/src/__tests__/nightPhase.test.ts
+++ b/frontend/src/__tests__/nightPhase.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import NightPhase from '@/components/NightPhase.vue'
+import type { GamePlayer, NightPhaseState, PlayerRole } from '@/types'
+
+// Contract under test: ONLY dead players see "你已经出局 / You are eliminated"
+// during NIGHT. The user's edge case: a guard who was wolf-attacked on night 1
+// is still alive=true in DB during their own GUARD_PICK turn (kills are
+// deferred until host reveal at dawn — see NightOrchestrator.applyNightKills),
+// so the eliminated banner must NOT show. On the NEXT night, the guard's
+// alive=false and the banner SHOULD show.
+
+describe('NightPhase - eliminated banner gating', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  const mkPlayer = (overrides: Partial<GamePlayer> = {}): GamePlayer => ({
+    userId: 'u1',
+    nickname: 'Alice',
+    seatIndex: 1,
+    isAlive: true,
+    isSheriff: false,
+    ...overrides,
+  })
+
+  const mkNight = (overrides: Partial<NightPhaseState> = {}): NightPhaseState => ({
+    subPhase: 'WEREWOLF_PICK',
+    dayNumber: 1,
+    ...overrides,
+  })
+
+  const mountNight = (props: {
+    nightPhase: NightPhaseState
+    players: GamePlayer[]
+    myUserId: string
+    myRole?: PlayerRole
+  }) => mount(NightPhase, { props })
+
+  it('guard wolf-attacked on N1 still sees their action UI on N1 (alive=true in DB until reveal)', () => {
+    // The wolf has already chosen to kill the guard, but kills are deferred
+    // until host REVEAL_NIGHT_RESULT. During GUARD_PICK on this same night,
+    // the guard's alive=true, so they should see the protect UI, NOT the
+    // eliminated banner.
+    const guard = mkPlayer({ userId: 'g1', nickname: 'Guard', seatIndex: 4, isAlive: true })
+    const wolf = mkPlayer({ userId: 'w1', nickname: 'Wolf', seatIndex: 2 })
+    const others = [mkPlayer({ userId: 'v1', nickname: 'V1', seatIndex: 3 })]
+
+    const wrapper = mountNight({
+      nightPhase: mkNight({ subPhase: 'GUARD_PICK', dayNumber: 1 }),
+      players: [guard, wolf, ...others],
+      myUserId: 'g1',
+      myRole: 'GUARD',
+    })
+
+    expect(wrapper.html()).not.toContain('你已经出局')
+    expect(wrapper.html()).not.toContain('You are eliminated')
+    expect(wrapper.find('[data-testid="guard-confirm-protect"]').exists()).toBe(true)
+  })
+
+  it('dead guard on N2 sees the eliminated banner (alive=false after host revealed N1 kills)', () => {
+    // After day 1 reveal, the wolf-attacked guard is now alive=false. On
+    // the next night their dashboard must show "你已经出局 / You are eliminated"
+    // and NOT show the protect UI.
+    const guard = mkPlayer({ userId: 'g1', nickname: 'Guard', seatIndex: 4, isAlive: false })
+    const wolf = mkPlayer({ userId: 'w1', nickname: 'Wolf', seatIndex: 2 })
+
+    const wrapper = mountNight({
+      nightPhase: mkNight({ subPhase: 'GUARD_PICK', dayNumber: 2 }),
+      players: [guard, wolf],
+      myUserId: 'g1',
+      myRole: 'GUARD',
+    })
+
+    expect(wrapper.html()).toContain('你已经出局')
+    expect(wrapper.html()).toContain('You are eliminated')
+    expect(wrapper.find('[data-testid="guard-confirm-protect"]').exists()).toBe(false)
+  })
+
+  it('alive non-actor (villager during WEREWOLF_PICK) does NOT see the eliminated banner', () => {
+    const villager = mkPlayer({ userId: 'v1', isAlive: true })
+    const wolf = mkPlayer({ userId: 'w1', seatIndex: 2 })
+
+    const wrapper = mountNight({
+      nightPhase: mkNight({ subPhase: 'WEREWOLF_PICK', dayNumber: 1 }),
+      players: [villager, wolf],
+      myUserId: 'v1',
+      myRole: 'VILLAGER',
+    })
+
+    expect(wrapper.html()).not.toContain('你已经出局')
+    expect(wrapper.html()).not.toContain('You are eliminated')
+  })
+
+  it('alive actor on their own turn does NOT see the eliminated banner (regression guard for werewolf)', () => {
+    const wolf = mkPlayer({ userId: 'w1', isAlive: true, role: 'WEREWOLF' })
+    const target = mkPlayer({ userId: 'v1', seatIndex: 2 })
+
+    const wrapper = mountNight({
+      nightPhase: mkNight({ subPhase: 'WEREWOLF_PICK', dayNumber: 1, teammates: [] }),
+      players: [wolf, target],
+      myUserId: 'w1',
+      myRole: 'WEREWOLF',
+    })
+
+    expect(wrapper.html()).not.toContain('你已经出局')
+  })
+
+  it('dead actor sees the eliminated banner across all sub-phases', () => {
+    const subPhases: NightPhaseState['subPhase'][] = [
+      'WAITING',
+      'WEREWOLF_PICK',
+      'SEER_PICK',
+      'WITCH_ACT',
+      'GUARD_PICK',
+    ]
+    for (const subPhase of subPhases) {
+      const me = mkPlayer({ userId: 'me', isAlive: false })
+      const wrapper = mountNight({
+        nightPhase: mkNight({ subPhase, dayNumber: 2 }),
+        players: [me, mkPlayer({ userId: 'a1', seatIndex: 2 })],
+        myUserId: 'me',
+        myRole: 'VILLAGER',
+      })
+      expect(wrapper.html(), `subPhase=${subPhase}`).toContain('你已经出局')
+    }
+  })
+})

--- a/frontend/src/__tests__/votingPhase.test.ts
+++ b/frontend/src/__tests__/votingPhase.test.ts
@@ -282,6 +282,74 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
     expect(buttonLabels).not.toContain('销毁')
   })
 
+  // The "你已出局 · Eliminated · 选择警徽继承人" banner is addressed to "you"
+  // and only the dying sheriff is in fact eliminated. It must not show to
+  // alive viewers — they already see the footer hint "等待警长移交警徽".
+  it('alive non-sheriff does NOT see "you are eliminated" banner during BADGE_HANDOVER', async () => {
+    const sheriffUserId = 'sheriff-1'
+    const aliveOtherId = 'player-2'
+    const votingPhase = createVotingPhase('BADGE_HANDOVER', sheriffUserId)
+    const players = createPlayers(sheriffUserId)
+
+    const wrapper = mount(VotingPhase, {
+      global: { plugins: [pinia, router] },
+      props: {
+        votingPhase,
+        players,
+        myUserId: aliveOtherId,
+        isHost: false,
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.html()).not.toContain('你已出局')
+    expect(wrapper.html()).not.toContain('You are eliminated')
+    expect(wrapper.html()).toContain('等待警长移交警徽')
+  })
+
+  it('alive host does NOT see "you are eliminated" banner during BADGE_HANDOVER', async () => {
+    const sheriffUserId = 'sheriff-1'
+    const hostId = 'player-2'
+    const votingPhase = createVotingPhase('BADGE_HANDOVER', sheriffUserId)
+    const players = createPlayers(sheriffUserId)
+
+    const wrapper = mount(VotingPhase, {
+      global: { plugins: [pinia, router] },
+      props: {
+        votingPhase,
+        players,
+        myUserId: hostId,
+        isHost: true,
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.html()).not.toContain('你已出局')
+  })
+
+  it('eliminated sheriff DOES see "you are eliminated · choose heir" banner during BADGE_HANDOVER', async () => {
+    const sheriffUserId = 'sheriff-1'
+    const votingPhase = createVotingPhase('BADGE_HANDOVER', sheriffUserId)
+    const players = createPlayers(sheriffUserId)
+
+    const wrapper = mount(VotingPhase, {
+      global: { plugins: [pinia, router] },
+      props: {
+        votingPhase,
+        players,
+        myUserId: sheriffUserId,
+        isHost: false,
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.html()).toContain('你已出局')
+    expect(wrapper.html()).toContain('选择警徽继承人')
+  })
+
   it('host can continue to night when eliminated player is not sheriff', async () => {
     // Bug fix: when a non-sheriff player is eliminated, badgeDone should be true
     // so the host can continue to night

--- a/frontend/src/components/VotingPhase.vue
+++ b/frontend/src/components/VotingPhase.vue
@@ -441,7 +441,7 @@
             </div>
           </div>
         </div>
-        <div v-else class="banner banner-gold">
+        <div v-else-if="isEliminatedSheriff" class="banner banner-gold">
           <span class="banner-avatar">⭐</span>
           <div>
             <div class="banner-title">你已出局 · Eliminated</div>


### PR DESCRIPTION
## Summary
- BADGE_HANDOVER's fall-through banner (`VotingPhase.vue:444`) showed **"你已出局 · Eliminated · 选择警徽继承人"** to *every* viewer of the screen — including alive non-sheriff players — during the window the dying sheriff was deciding to pass or destroy the badge.
- Fix: gate that banner on `isEliminatedSheriff` (one-line change, `v-else` → `v-else-if="isEliminatedSheriff"`). Alive viewers continue to see the existing footer hint "等待警长移交警徽 · Waiting for sheriff to pass badge…", which already conveys what's happening.
- Adds 3 BADGE_HANDOVER tests + 5 NightPhase contract tests that lock in the rule "only dead players see _You are eliminated_". The NightPhase tests also document the user's edge case: a guard wolf-attacked on N1 still sees their `GUARD_PICK` action on N1 (because `applyNightKills` at `NightOrchestrator.kt:472` defers `alive=false` until host `REVEAL_NIGHT_RESULT`), then sees the eliminated banner on N2.

## Test plan
- [x] `vitest run src/__tests__/votingPhase.test.ts` → 11/11 pass (8 existing + 3 new)
- [x] `vitest run src/__tests__/nightPhase.test.ts` → 5/5 pass (new)
- [x] Full frontend suite: 24 files / 263 tests, all green
- [x] ESLint clean on changed files
- [x] Verified failing-without-fix: the 2 alive-viewer tests in `votingPhase.test.ts` fail before the `v-else-if` change with HTML containing `你已出局`
- [ ] Manual smoke: 12-player game, vote out the elected sheriff on Day 1, observe BADGE_HANDOVER on a non-sheriff alive page → no eliminated banner; on the eliminated sheriff's page → banner still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)