### PR TITLE
fix(e2e): three race fixes for flow-12p-sheriff + sheriff-flow setup

### DIFF
--- a/frontend/e2e/real/flow-12p-sheriff.spec.ts
+++ b/frontend/e2e/real/flow-12p-sheriff.spec.ts
@@ -985,9 +985,16 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     // SHERIFF_ELECTION/SIGNUP. Guard is the wolf-target but kills are
     // deferred — guard is still alive in DB during sheriff election (and
     // could 上警 if the test wanted them to).
+    //
+    // seerCheckSeat: prefer a non-host wolf so we exercise the seer's
+    // cross-browser action against a bot — and guard against a stale
+    // host seat (the placeholder seat=0 in the state file is now updated
+    // post-game-start, but staying explicit keeps test intent clear).
+    const seerCheckWolfSeat =
+      wolfBots.find((b) => b.nick !== 'Host')?.seat ?? wolfBots[0]?.seat ?? guard.seat
     await driveMinimalNight1ViaDom(ctx, {
       wolfTargetSeat: guard.seat,
-      seerCheckSeat: wolfBots[0]?.seat ?? guard.seat,
+      seerCheckSeat: seerCheckWolfSeat,
       guardTargetSeat: wolfSeatForGuardProtect!,
     })
     await captureSnapshot(ctx.pages, testInfo, 'hard-02-night-1-done-sheriff-opened')

--- a/frontend/e2e/real/helpers/multi-browser.ts
+++ b/frontend/e2e/real/helpers/multi-browser.ts
@@ -222,13 +222,23 @@ export async function setupGame(
     throw new Error(`Invalid room code: ${roomCode}`)
   }
 
+  // Read host JWT/userId NOW, while the room view is freshly stable. Doing
+  // this AFTER joinBots used to race the STOMP-driven re-render storm that
+  // bot-joining triggers — page.evaluate intermittently saw "Execution
+  // context was destroyed, most likely because of a navigation" because
+  // a re-render happened mid-CDP-call. Capturing here, before joinBots,
+  // moves the read to a quiescent window. (Reproduced locally on this
+  // branch: flow-12p-sheriff.spec.ts CLASSIC failed at multi-browser.ts:230
+  // before any sheriff code path was reached.)
+  const hostJwt = await hostPage.evaluate(() => localStorage.getItem('jwt'))
+  const hostUserId = await hostPage.evaluate(() => localStorage.getItem('userId'))
+
   // ── Step 2: Bots join + ready ──────────────────────────────────────────
 
   joinBots(roomCode, totalPlayers - 1, true)
 
-  // Inject host into state file so scripts (roles.sh) and getRoles() can discover the host's role
-  const hostJwt = await hostPage.evaluate(() => localStorage.getItem('jwt'))
-  const hostUserId = await hostPage.evaluate(() => localStorage.getItem('userId'))
+  // Inject host into state file so scripts (roles.sh) and getRoles() can discover the host's role.
+  // Uses the JWT/userId captured BEFORE joinBots — see comment above.
   if (hostJwt) {
     const stateFilePath = path.join('/tmp', `werewolf-${roomCode.toUpperCase()}.json`)
     const stateData = JSON.parse(readFileSync(stateFilePath, 'utf-8'))
@@ -240,7 +250,7 @@ export async function setupGame(
     stateData.users.push({
       nick: 'Host',
       token: hostJwt,
-      seat: 0, // will be updated after seat claim
+      seat: 0, // placeholder; updated below after game starts
       userId: hostUserId,
     })
     writeFileSync(stateFilePath, JSON.stringify(stateData, null, 2))
@@ -295,6 +305,54 @@ export async function setupGame(
   }
 
   act('CONFIRM_ROLE', undefined, { room: roomCode })
+
+  // ── Step 5.5: Update host's seat in state file from backend ─────────────
+  //
+  // The earlier injection at Step 2 wrote seat=0 as a placeholder because
+  // the host hadn't claimed a slot yet. The backend now has the host's
+  // actual seat — fetch it once so roles.sh emits the right seat for the
+  // host (used by ctx.roleMap, which downstream tests use to drive role
+  // actions on the correct DOM player tile).
+  //
+  // No retry: act('CONFIRM_ROLE') just succeeded for every bot, which is
+  // only possible if every player row (including host) is already
+  // committed in the backend. So the next read-back from /game/{gid}/state
+  // is guaranteed to include the host with a real seat.
+  //
+  // Without this fix, ctx.roleMap.WEREWOLF[0]?.seat is a stale `0` when
+  // host rolls WEREWOLF — flow-12p-sheriff.spec.ts then asks the seer to
+  // check seat 0, which doesn't exist in the DOM grid → "seer check seat
+  // 0 must render" timeout (reproduced locally on the post-#89 main).
+  if (hostJwt && hostUserId) {
+    const stateFilePath = path.join('/tmp', `werewolf-${roomCode.toUpperCase()}.json`)
+    const res = await fetch(`http://localhost:8080/api/game/${gameId}/state`, {
+      headers: { Authorization: `Bearer ${hostJwt}` },
+    })
+    if (!res.ok) {
+      throw new Error(
+        `[setupGame] /api/game/${gameId}/state returned ${res.status} after CONFIRM_ROLE — backend should have full player rows by now`,
+      )
+    }
+    // GameStateDto.players[].seatIndex — NOT `seat`. (Verified by reading
+    // the response: every entry has `seatIndex` populated post-CONFIRM_ROLE.)
+    const data = (await res.json()) as {
+      players?: Array<{ userId: string; seatIndex?: number }>
+    }
+    const hostPlayer = data.players?.find((p) => p.userId === hostUserId)
+    if (hostPlayer?.seatIndex == null) {
+      throw new Error(
+        `[setupGame] host (userId=${hostUserId}) seatIndex missing in /game/${gameId}/state — host present? ${data.players?.some((p) => p.userId === hostUserId)} players=${JSON.stringify(data.players)}`,
+      )
+    }
+    const stateData = JSON.parse(readFileSync(stateFilePath, 'utf-8'))
+    const hostUser = (stateData.users ?? []).find(
+      (u: { userId: string; seat: number }) => u.userId === hostUserId,
+    )
+    if (hostUser) {
+      hostUser.seat = hostPlayer.seatIndex
+      writeFileSync(stateFilePath, JSON.stringify(stateData, null, 2))
+    }
+  }
 
   // ── Step 6: Host confirms role in browser (if still on reveal screen) ──
   // The script confirms roles via API, but we need to ensure the browser state

--- a/frontend/e2e/real/helpers/night-driver.ts
+++ b/frontend/e2e/real/helpers/night-driver.ts
@@ -62,7 +62,16 @@ export async function driveMinimalNight1ViaDom(
     throw new Error('driveMinimalNight1ViaDom: SEER_PICK sub-phase not reached')
   }
   const seerPage = pageOrThrow(ctx, 'SEER')
-  const checkSeat = opts.seerCheckSeat ?? 1
+  // Default seerCheckSeat must NOT be the seer's own seat — seer-self-check
+  // is disallowed (per project_game_rules_clarifications memory), so the
+  // slot renders with aria-disabled="true" and .player-grid intercepts the
+  // click. Without this guard the test hangs on retry-click for 180s and
+  // fails with the misleading "Target page, context or browser has been
+  // closed" error (the page is fine; Playwright tears it down at timeout).
+  // Bot1 always lands at seat 1, and the SEER role rolls onto bot1 ~1/N
+  // of the time → without this guard the test is randomly flaky.
+  const seerSeat = ctx.roleMap.SEER?.[0]?.seat
+  const checkSeat = opts.seerCheckSeat ?? (seerSeat !== 1 ? 1 : 2)
   const seerSlot = seerPage.locator(`.player-grid [data-seat="${checkSeat}"]`)
   await expect(seerSlot, `seer check seat ${checkSeat} must render`).toBeVisible({ timeout: 10_000 })
   await seerSlot.click()


### PR DESCRIPTION
## Summary

Three pre-existing test-infra races in the real-backend Playwright suite, surfaced while verifying Variant C (sheriff election before night reveal). All three are fixed deterministically — no retry loops, no flake-by-default behavior.

- **CLASSIC setup race** — `multi-browser.ts:230` read host JWT via `page.evaluate` *after* `joinBots()` returned. Bot-joining cascades STOMP events to the host's room view; mid-rerender CDP context could be destroyed mid-evaluate. Fix: read JWT *before* joinBots, when the room view is freshly stable.
- **HARD_MODE stale host seat** — `multi-browser.ts:243` injected host with `seat: 0` placeholder, with comment *"will be updated after seat claim"* — that update never happened. After slot-claim, backend assigns the actual `seatIndex` (e.g., 12 for a 12p game) but state file still said 0; `roles.sh` then emits stale seat=0 for host → `ctx.roleMap.WEREWOLF[0]?.seat` is 0 → `seerCheckSeat: wolfBots[0]?.seat` asks for `data-seat="0"` which doesn't exist. Fix: after `act('CONFIRM_ROLE')` (deterministic gate — backend can't mark a non-existent player as confirmed), fetch `/api/game/{gid}/state` once and write the real `seatIndex` back. No retry loop; one read after a deterministic gate.
- **Seer-self-check default** — `night-driver.ts:65` defaulted `seerCheckSeat` to 1. Bot1 always lands at seat 1; when SEER rolls onto bot1 (~1/N games), the seer's own slot at seat 1 renders `aria-disabled="true"` (seer-self-check is disallowed) and `.player-grid` intercepts pointer events → 340 retry-clicks → 180s timeout → misleading "page closed" error. Fix: pick a non-seer seat by default (use seat 1 unless seer is at 1, then seat 2).

## Test plan
- [x] `npx vue-tsc --noEmit` clean
- [x] `npx vitest run` 247/247 pass
- [x] Local Playwright real-backend stability — `flow-12p-sheriff.spec.ts` 3 consecutive 2/2 passes (~5min each)
- [x] Local Playwright real-backend — `sheriff-flow.spec.ts` 5/5 in 46.6s (after seer-self-check fix; was failing on bot1=SEER rolls)
- [ ] CI: full e2e-integration job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)