### PR TITLE
docs(deploy): add gh release create step to release runbook

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -110,6 +110,20 @@ gh run watch                            # latest workflow run
 
 Don't proceed until both images are published.
 
+#### A2. Local — create the GitHub Release (so it shows on /releases)
+
+Pushing a tag does NOT auto-create a GitHub Release; the tag exists in
+git but the `/releases` page won't list it until you run:
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes
+```
+
+`--generate-notes` builds the body from merged PRs since the previous
+tag. Use `--notes "<one-liner>"` instead if you want a custom message.
+Verify at `https://github.com/<your>/werewolf-simple/releases` — the new
+tag should be marked **Latest**.
+
 #### B. On the VM — advance the tree, pin, pull, recreate
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds **Step A2** to `deploy/README.md` between the existing tag-push (A) and VM-deploy (B) steps.
- Documents that pushing a tag does NOT auto-create a GitHub Release — `gh release create vX.Y.Z --generate-notes` has to be run separately for the tag to appear on `/releases`.

## Why

After pushing the `v0.4.0` tag and waiting for `publish-images.yml` to go green, the `/releases` page still showed `v0.3.1` as Latest because no GitHub Release object was ever created. The runbook had a silent gap. Step A2 closes it.

## Test plan

- [x] Diff renders cleanly (no broken markdown).
- [ ] Reviewer agrees the runbook change matches what was actually needed during v0.4.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)