### PR TITLE
fix(audio): stopAll resets queue state so the next game plays

### DIFF
--- a/frontend/src/__tests__/audioService.test.ts
+++ b/frontend/src/__tests__/audioService.test.ts
@@ -103,6 +103,32 @@ describe('audioService', () => {
     expect(mockAudioInstances).toHaveLength(1)
   })
 
+  // ── stopAll mid-playback resets queue state ─────────────────────────────
+  //
+  // Regression: pausing an HTMLAudioElement does NOT fire its `onended`
+  // handler, so playNextInQueue is never invoked and `isPlayingQueue`
+  // stayed stuck at true. The next playSequential queued files but
+  // skipped processing because of the `!isPlayingQueue` gate, leaving
+  // the next game's audio silent forever. Reproduced 2026-05-04 when
+  // game 23 ended mid-witch_close_eyes; game 24 played no audio.
+
+  it('stopAll mid-playback resets isPlayingQueue so the next playSequential plays', () => {
+    audioService.playSequential(['a.mp3', 'b.mp3'])
+    expect(audioService.isQueueActive()).toBe(true)
+    expect(mockAudioInstances[0]?.play).toHaveBeenCalledTimes(1)
+
+    // Simulate component unmount mid-playback (a.mp3 is still playing,
+    // never received onended). useAudioService.onUnmounted does this.
+    audioService.stopAll()
+    expect(mockAudioInstances[0]?.pause).toHaveBeenCalled()
+    expect(audioService.isQueueActive()).toBe(false)
+
+    // Next mount → next playSequential MUST start a new playback.
+    audioService.playSequential(['c.mp3'])
+    expect(mockAudioInstances).toHaveLength(2)
+    expect(mockAudioInstances[1]?.play).toHaveBeenCalledTimes(1)
+  })
+
   // ── Mute ────────────────────────────────────────────────────────────────
 
   it('toggleMute toggles state and persists to localStorage', () => {

--- a/frontend/src/services/audioService.ts
+++ b/frontend/src/services/audioService.ts
@@ -243,7 +243,19 @@ class AudioService {
   }
 
   /**
-   * Stop all playing audio
+   * Stop all playing audio AND drain the queue / reset queue state.
+   *
+   * Pausing a mid-narration HTMLAudioElement does NOT fire its `onended`
+   * handler, so [playNextInQueue] is never called and `isPlayingQueue`
+   * would otherwise stay stuck at true. The next [playSequential] then
+   * queues files but skips processing because of its `!isPlayingQueue`
+   * gate, leaving every subsequent narration silent forever.
+   *
+   * Reproduced when a game ends mid-narration: GameView unmount fires
+   * useAudioService.onUnmounted → stopAll() while witch_close_eyes is
+   * still playing → next game's NIGHT init audio is queued but never
+   * starts. Surface symptom is the host hearing nothing for the entire
+   * second game.
    */
   stopAll(): void {
     try {
@@ -251,6 +263,8 @@ class AudioService {
         audio.pause()
         audio.currentTime = 0
       }
+      this.audioQueue = []
+      this.isPlayingQueue = false
     } catch (error) {
       console.warn('[AudioService] Error stopping all audio:', error)
     }


### PR DESCRIPTION
## Summary
Game 24 played no audio on the host because `audioService.stopAll()`, called from `useAudioService.onUnmounted` at game 23's teardown, paused a mid-playback HTMLAudioElement without firing its `onended` handler. `playNextInQueue` was never invoked, `isPlayingQueue` stayed stuck at `true`, and every subsequent `playSequential` in game 24 silently appended to the queue without restarting processing — gated at `audioService.ts:140` (`if (!this.isPlayingQueue) { ... playNextInQueue() ... }`).

## Repro from `console_log.md`
```
game 23: Starting playback: witch_close_eyes.mp3      (mid-narration)
game 23: GameOver                                      (no "Finished playback")
            ↓ unmount → stopAll() pauses, isPlayingQueue stays true
game 24: [useAudioService] AudioSequence (live)        (logs)
game 24: (no "Starting playback" — ever, for the rest of the game)
```

## Fix
`stopAll()` now drains `audioQueue` and resets `isPlayingQueue=false` after pausing each cached element. Idempotent reset; matches what every caller already wants (`toggleMute`, `clearCache`, `useAudioService.onUnmounted`).

## Test plan
- [x] vitest run 268/268 pass (added 1 regression case at `audioService.test.ts`: "stopAll mid-playback resets isPlayingQueue so the next playSequential plays"). The test fails on `main` without the fix.
- [x] vue-tsc -b --noEmit clean.
- [ ] CI green on this PR.
- [ ] Manual: play through one game to GameOver, immediately start a second game, confirm host hears NIGHT cue + role audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)