### PR TITLE
feat(drawer): sheriff section + abstain voters + voting-phase FAB

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/service/ActionLogService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/ActionLogService.kt
@@ -74,6 +74,16 @@ class ActionLogService(
                 )
             }
 
+        val abstainVoters = votes
+            .filter { it.targetUserId == null }
+            .map { v ->
+                mapOf(
+                    "userId"    to v.voterUserId,
+                    "nickname"  to (users[v.voterUserId]?.nickname ?: v.voterUserId),
+                    "seatIndex" to (players[v.voterUserId]?.seatIndex ?: 0),
+                )
+            }
+
         val payload = mapOf(
             "dayNumber"           to dayNumber,
             "tally"               to tallyList,
@@ -81,6 +91,8 @@ class ActionLogService(
             "eliminatedNickname"  to eliminatedUserId?.let { users[it]?.nickname ?: it },
             "eliminatedSeatIndex" to eliminatedUserId?.let { players[it]?.seatIndex },
             "eliminatedRole"      to eliminatedRole?.name,
+            "abstainCount"        to abstainVoters.size,
+            "abstainVoters"       to abstainVoters,
         )
         gameEventRepository.save(
             GameEvent(
@@ -110,6 +122,69 @@ class ActionLogService(
                 eventType    = "HUNTER_SHOT",
                 message      = mapper.writeValueAsString(payload),
                 targetUserId = targetUserId,
+            )
+        )
+    }
+
+    fun recordSheriffResult(
+        gameId: Int,
+        dayNumber: Int,
+        winnerUserId: String?,
+        votes: List<Vote>,
+        tally: Map<String, Int>,
+    ) {
+        val allUserIds = (votes.map { it.voterUserId } +
+            votes.mapNotNull { it.targetUserId } +
+            listOfNotNull(winnerUserId)).distinct()
+        val users = userRepository.findAllById(allUserIds).associateBy { it.userId }
+        val players = gamePlayerRepository.findByGameId(gameId).associateBy { it.userId }
+
+        val tallyList = tally.entries
+            .sortedByDescending { it.value }
+            .map { (targetId, count) ->
+                val voters = votes
+                    .filter { it.targetUserId == targetId }
+                    .map { v ->
+                        mapOf(
+                            "userId"    to v.voterUserId,
+                            "nickname"  to (users[v.voterUserId]?.nickname ?: v.voterUserId),
+                            "seatIndex" to (players[v.voterUserId]?.seatIndex ?: 0),
+                        )
+                    }
+                mapOf(
+                    "userId"    to targetId,
+                    "nickname"  to (users[targetId]?.nickname ?: targetId),
+                    "seatIndex" to (players[targetId]?.seatIndex ?: 0),
+                    "votes"     to count,
+                    "voters"    to voters,
+                )
+            }
+
+        val abstainVoters = votes
+            .filter { it.targetUserId == null }
+            .map { v ->
+                mapOf(
+                    "userId"    to v.voterUserId,
+                    "nickname"  to (users[v.voterUserId]?.nickname ?: v.voterUserId),
+                    "seatIndex" to (players[v.voterUserId]?.seatIndex ?: 0),
+                )
+            }
+
+        val payload = mapOf(
+            "dayNumber"        to dayNumber,
+            "tally"            to tallyList,
+            "winnerUserId"     to winnerUserId,
+            "winnerNickname"   to winnerUserId?.let { users[it]?.nickname ?: it },
+            "winnerSeatIndex"  to winnerUserId?.let { players[it]?.seatIndex },
+            "abstainCount"     to abstainVoters.size,
+            "abstainVoters"    to abstainVoters,
+        )
+        gameEventRepository.save(
+            GameEvent(
+                gameId       = gameId,
+                eventType    = "SHERIFF_RESULT",
+                message      = mapper.writeValueAsString(payload),
+                targetUserId = winnerUserId,
             )
         )
     }

--- a/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
@@ -28,6 +28,7 @@ class SheriffService(
     private val stompPublisher: StompPublisher,
     private val coroutineScope: CoroutineScope,
     private val timingProperties: GameTimingProperties,
+    private val actionLogService: ActionLogService,
 ) {
     val log = LoggerFactory.getLogger(SheriffService::class.java)
     private val scheduledJobs = mutableMapOf<Int, Job>()
@@ -296,6 +297,9 @@ class SheriffService(
             election.electedSheriffUserId = winnerUserId
             sheriffElectionRepository.save(election)
             electSheriff(winnerUserId, context)
+            actionLogService.recordSheriffResult(
+                context.gameId, context.game.dayNumber, winnerUserId, votes, tally,
+            )
             broadcastAfterCommit(context.gameId, DomainEvent.SheriffElected(context.gameId, winnerUserId))
             broadcastAfterCommit(context.gameId,
                 DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.RESULT.name))
@@ -328,6 +332,16 @@ class SheriffService(
         election.electedSheriffUserId = targetUserId
         sheriffElectionRepository.save(election)
         electSheriff(targetUserId, context)
+
+        // Persist the appoint outcome with whatever sheriff-election votes were
+        // already cast so the action log shows the host's pick was a tie-break.
+        val priorVotes = voteRepository.findByGameIdAndVoteContextAndDayNumber(
+            context.gameId, VoteContext.SHERIFF_ELECTION, context.game.dayNumber,
+        )
+        val priorTally = priorVotes.mapNotNull { it.targetUserId }.groupingBy { it }.eachCount()
+        actionLogService.recordSheriffResult(
+            context.gameId, context.game.dayNumber, targetUserId, priorVotes, priorTally,
+        )
 
         broadcastAfterCommit(context.gameId, DomainEvent.SheriffElected(context.gameId, targetUserId))
         broadcastAfterCommit(context.gameId,

--- a/backend/src/test/kotlin/com/werewolf/unit/service/ActionLogServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/ActionLogServiceTest.kt
@@ -110,6 +110,40 @@ class ActionLogServiceTest {
     }
 
     @Test
+    fun `recordVoteResult - records abstain voters in payload`() {
+        val votes = listOf(
+            Vote(gameId = gameId, voteContext = VoteContext.ELIMINATION, dayNumber = 1,
+                voterUserId = "u1", targetUserId = "u3"),
+            Vote(gameId = gameId, voteContext = VoteContext.ELIMINATION, dayNumber = 1,
+                voterUserId = "u2", targetUserId = null),
+            Vote(gameId = gameId, voteContext = VoteContext.ELIMINATION, dayNumber = 1,
+                voterUserId = "u4", targetUserId = null),
+        )
+        whenever(userRepository.findAllById(any())).thenReturn(
+            listOf(user("u1", "Alice"), user("u2", "Bob"), user("u3", "Carol"), user("u4", "Dave"))
+        )
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(
+            listOf(player("u1", 1), player("u2", 2), player("u3", 3), player("u4", 4))
+        )
+
+        service.recordVoteResult(
+            gameId = gameId, dayNumber = 1,
+            votes = votes, tally = mapOf("u3" to 1.0),
+            sheriffUserId = null, eliminatedUserId = "u3", eliminatedRole = PlayerRole.VILLAGER,
+        )
+
+        val captor = argumentCaptor<GameEvent>()
+        verify(gameEventRepository).save(captor.capture())
+        @Suppress("UNCHECKED_CAST")
+        val payload = mapper.readValue(captor.firstValue.message, Map::class.java) as Map<String, Any>
+        assertThat(payload["abstainCount"]).isEqualTo(2)
+        @Suppress("UNCHECKED_CAST")
+        val abstainers = payload["abstainVoters"] as List<Map<String, Any>>
+        assertThat(abstainers.map { it["seatIndex"] }).containsExactlyInAnyOrder(2, 4)
+        assertThat(abstainers.map { it["nickname"] }).containsExactlyInAnyOrder("Bob", "Dave")
+    }
+
+    @Test
     fun `recordVoteResult - saves row with null eliminatedUserId for tie`() {
         whenever(userRepository.findAllById(any())).thenReturn(emptyList())
         whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(emptyList())
@@ -123,6 +157,97 @@ class ActionLogServiceTest {
         val captor = argumentCaptor<GameEvent>()
         verify(gameEventRepository).save(captor.capture())
         assertThat(captor.firstValue.eventType).isEqualTo("VOTE_RESULT")
+        assertThat(captor.firstValue.targetUserId).isNull()
+    }
+
+    // ── recordSheriffResult ─────────────────────────────────────────────────
+
+    @Test
+    fun `recordSheriffResult - saves SHERIFF_RESULT row with winner and tally`() {
+        val votes = listOf(
+            Vote(gameId = gameId, voteContext = VoteContext.SHERIFF_ELECTION, dayNumber = 1,
+                voterUserId = "u2", targetUserId = "u1"),
+            Vote(gameId = gameId, voteContext = VoteContext.SHERIFF_ELECTION, dayNumber = 1,
+                voterUserId = "u3", targetUserId = "u1"),
+        )
+        whenever(userRepository.findAllById(any())).thenReturn(
+            listOf(user("u1", "Alice"), user("u2", "Bob"), user("u3", "Carol"))
+        )
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(
+            listOf(player("u1", 1), player("u2", 2), player("u3", 3))
+        )
+
+        service.recordSheriffResult(
+            gameId = gameId, dayNumber = 1,
+            winnerUserId = "u1", votes = votes, tally = mapOf("u1" to 2),
+        )
+
+        val captor = argumentCaptor<GameEvent>()
+        verify(gameEventRepository).save(captor.capture())
+        val event = captor.firstValue
+        assertThat(event.eventType).isEqualTo("SHERIFF_RESULT")
+        assertThat(event.targetUserId).isEqualTo("u1")
+        @Suppress("UNCHECKED_CAST")
+        val payload = mapper.readValue(event.message, Map::class.java) as Map<String, Any>
+        assertThat(payload["dayNumber"]).isEqualTo(1)
+        assertThat(payload["winnerUserId"]).isEqualTo("u1")
+        assertThat(payload["winnerNickname"]).isEqualTo("Alice")
+        assertThat(payload["winnerSeatIndex"]).isEqualTo(1)
+        @Suppress("UNCHECKED_CAST")
+        val tally = payload["tally"] as List<Map<String, Any>>
+        assertThat(tally).hasSize(1)
+        assertThat(tally[0]["userId"]).isEqualTo("u1")
+        assertThat(tally[0]["votes"]).isEqualTo(2)
+        @Suppress("UNCHECKED_CAST")
+        val voters = tally[0]["voters"] as List<Map<String, Any>>
+        assertThat(voters.map { it["userId"] }).containsExactlyInAnyOrder("u2", "u3")
+    }
+
+    @Test
+    fun `recordSheriffResult - records abstain voters in payload`() {
+        val votes = listOf(
+            Vote(gameId = gameId, voteContext = VoteContext.SHERIFF_ELECTION, dayNumber = 1,
+                voterUserId = "u1", targetUserId = "u2"),
+            Vote(gameId = gameId, voteContext = VoteContext.SHERIFF_ELECTION, dayNumber = 1,
+                voterUserId = "u3", targetUserId = null),
+        )
+        whenever(userRepository.findAllById(any())).thenReturn(
+            listOf(user("u1", "Alice"), user("u2", "Bob"), user("u3", "Carol"))
+        )
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(
+            listOf(player("u1", 1), player("u2", 2), player("u3", 3))
+        )
+
+        service.recordSheriffResult(
+            gameId = gameId, dayNumber = 1,
+            winnerUserId = "u2", votes = votes, tally = mapOf("u2" to 1),
+        )
+
+        val captor = argumentCaptor<GameEvent>()
+        verify(gameEventRepository).save(captor.capture())
+        @Suppress("UNCHECKED_CAST")
+        val payload = mapper.readValue(captor.firstValue.message, Map::class.java) as Map<String, Any>
+        assertThat(payload["abstainCount"]).isEqualTo(1)
+        @Suppress("UNCHECKED_CAST")
+        val abstainers = payload["abstainVoters"] as List<Map<String, Any>>
+        assertThat(abstainers).hasSize(1)
+        assertThat(abstainers[0]["seatIndex"]).isEqualTo(3)
+        assertThat(abstainers[0]["nickname"]).isEqualTo("Carol")
+    }
+
+    @Test
+    fun `recordSheriffResult - saves row with null winner when nobody is elected`() {
+        whenever(userRepository.findAllById(any())).thenReturn(emptyList())
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(emptyList())
+
+        service.recordSheriffResult(
+            gameId = gameId, dayNumber = 1,
+            winnerUserId = null, votes = emptyList(), tally = emptyMap(),
+        )
+
+        val captor = argumentCaptor<GameEvent>()
+        verify(gameEventRepository).save(captor.capture())
+        assertThat(captor.firstValue.eventType).isEqualTo("SHERIFF_RESULT")
         assertThat(captor.firstValue.targetUserId).isNull()
     }
 

--- a/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
@@ -7,6 +7,7 @@ import com.werewolf.config.GameTimingProperties
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.model.*
 import com.werewolf.repository.*
+import com.werewolf.service.ActionLogService
 import com.werewolf.service.SheriffService
 import com.werewolf.service.StompPublisher
 import org.assertj.core.api.Assertions.assertThat
@@ -31,6 +32,7 @@ class SheriffServiceTest {
     @Mock lateinit var voteRepository: VoteRepository
     @Mock lateinit var userRepository: UserRepository
     @Mock lateinit var stompPublisher: StompPublisher
+    @Mock lateinit var actionLogService: ActionLogService
     private lateinit var sheriffService: SheriffService
 
     @BeforeEach
@@ -40,6 +42,7 @@ class SheriffServiceTest {
             sheriffCandidateRepository, voteRepository, userRepository,
             stompPublisher, CoroutineScope(Dispatchers.Default),
             GameTimingProperties(),
+            actionLogService,
         )
     }
 

--- a/frontend/e2e/action-log-drawer.spec.ts
+++ b/frontend/e2e/action-log-drawer.spec.ts
@@ -91,11 +91,12 @@ test('drawer shows 昨夜出局 section with night death data', async ({ page })
   const round = page.locator('.round-block').first()
   await expect(round.locator('.round-label')).toHaveText('第 1 天')
 
-  // Night death section header
-  await expect(round.locator('.section-title').first()).toContainText('昨夜出局')
+  // Night death section — locate by title text so reorderings don't break us
+  const deathSection = round.locator('.log-section').filter({ hasText: '昨夜出局' })
+  await expect(deathSection.locator('.section-title')).toContainText('昨夜出局')
 
   // Charlie died at seat 3
-  const deathRow = round.locator('.log-section').first().locator('.log-row').first()
+  const deathRow = deathSection.locator('.log-row').first()
   await expect(deathRow.locator('.seat-badge')).toHaveText('3号')
   await expect(deathRow.locator('.log-name')).toHaveText('Charlie')
 })
@@ -104,7 +105,11 @@ test('night death row has no cause or killedBy text', async ({ page }) => {
   await goToDayScenario(page, 'HOST_REVEALED')
   await page.locator('button.log-fab').click()
 
-  const deathSection = page.locator('.round-block').first().locator('.log-section').first()
+  const deathSection = page
+    .locator('.round-block')
+    .first()
+    .locator('.log-section')
+    .filter({ hasText: '昨夜出局' })
   const text = await deathSection.textContent()
   expect(text).not.toContain('cause')
   expect(text).not.toContain('killedBy')
@@ -113,14 +118,64 @@ test('night death row has no cause or killedBy text', async ({ page }) => {
   expect(text).not.toContain('WEREWOLF')
 })
 
+// ── Content: sheriff election ─────────────────────────────────────────────────
+
+test('drawer shows ⭐ 警长选举 section at the top of day 1 when game has a sheriff', async ({ page }) => {
+  await goToDayScenario(page, 'HOST_REVEALED')
+  await page.locator('button.log-fab').click()
+
+  // Sheriff section is the FIRST section inside the day-1 round-block — before
+  // 昨夜出局 — so players see who became sheriff before reading the round.
+  const round = page.locator('.round-block').first()
+  const firstSection = round.locator('.log-section').first()
+  await expect(firstSection.locator('.section-title')).toContainText('警长选举')
+
+  // Bob (seat 2) won the mock sheriff election
+  const winnerRow = firstSection.locator('.log-row').first()
+  await expect(winnerRow.locator('.seat-badge')).toHaveText('2号')
+  await expect(winnerRow.locator('.log-name')).toHaveText('Bob')
+  await expect(winnerRow.locator('.log-tag.tag-gold')).toHaveText('警长')
+})
+
+test('drawer shows sheriff election tally so players can analyse alliances', async ({ page }) => {
+  await goToDayScenario(page, 'HOST_REVEALED')
+  await page.locator('button.log-fab').click()
+
+  const sheriffSection = page.locator('.round-block').first().locator('.log-section').first()
+  // Bob got 4 votes (winning row of the tally)
+  const winnerTally = sheriffSection.locator('.tally-row').first()
+  await expect(winnerTally.locator('.tally-votes')).toHaveText('4 票')
+  await expect(winnerTally.locator('.tally-voters')).toContainText('1号')
+  await expect(winnerTally.locator('.tally-voters')).toContainText('3号')
+  await expect(winnerTally.locator('.tally-voters')).toContainText('5号')
+  await expect(winnerTally.locator('.tally-voters')).toContainText('6号')
+})
+
+test('sheriff section surfaces abstain voters so analysts can flag silent wolves', async ({ page }) => {
+  await goToDayScenario(page, 'HOST_REVEALED')
+  await page.locator('button.log-fab').click()
+
+  const sheriffSection = page.locator('.round-block').first().locator('.log-section').first()
+  const abstainRow = sheriffSection.locator('.tally-abstain')
+  await expect(abstainRow).toBeVisible()
+  await expect(abstainRow.locator('.tally-name')).toHaveText('弃权')
+  await expect(abstainRow.locator('.tally-votes')).toHaveText('1 票')
+  // Mock seeds Grace (seat 7) as the lone abstainer
+  await expect(abstainRow.locator('.tally-voters')).toContainText('7号')
+})
+
 // ── Content: vote results ─────────────────────────────────────────────────────
 
 test('drawer shows 投票结果 section with eliminated player', async ({ page }) => {
   await goToDayScenario(page, 'HOST_REVEALED')
   await page.locator('button.log-fab').click()
 
-  // Vote result section — "☀ 投票结果"
-  const voteSection = page.locator('.round-block').first().locator('.log-section').nth(1)
+  // Vote result section — locate by title text so it survives reorderings
+  const voteSection = page
+    .locator('.round-block')
+    .first()
+    .locator('.log-section')
+    .filter({ hasText: '投票结果' })
   await expect(voteSection.locator('.section-title')).toContainText('投票结果')
 
   // Eve (seat 5) was eliminated
@@ -134,12 +189,62 @@ test('drawer shows vote tally breakdown', async ({ page }) => {
   await goToDayScenario(page, 'HOST_REVEALED')
   await page.locator('button.log-fab').click()
 
-  const voteSection = page.locator('.round-block').first().locator('.log-section').nth(1)
-  const tallyRow = voteSection.locator('.tally-row').first()
+  const voteSection = page
+    .locator('.round-block')
+    .first()
+    .locator('.log-section')
+    .filter({ hasText: '投票结果' })
+  // tally rows include the abstain row, so target the candidate row by class
+  const tallyRow = voteSection
+    .locator('.tally-row')
+    .filter({ hasNotText: '弃权' })
+    .first()
 
   // Eve got 3 votes from seats 1, 2, 4
   await expect(tallyRow.locator('.tally-votes')).toHaveText('3 票')
   await expect(tallyRow.locator('.tally-voters')).toContainText('1号')
   await expect(tallyRow.locator('.tally-voters')).toContainText('2号')
   await expect(tallyRow.locator('.tally-voters')).toContainText('4号')
+})
+
+test('vote-result section surfaces abstain voters', async ({ page }) => {
+  await goToDayScenario(page, 'HOST_REVEALED')
+  await page.locator('button.log-fab').click()
+
+  const voteSection = page
+    .locator('.round-block')
+    .first()
+    .locator('.log-section')
+    .filter({ hasText: '投票结果' })
+  const abstainRow = voteSection.locator('.tally-abstain')
+  await expect(abstainRow).toBeVisible()
+  await expect(abstainRow.locator('.tally-votes')).toHaveText('2 票')
+  // Mock seeds Frank (seat 6) and Henry (seat 8) as abstainers
+  await expect(abstainRow.locator('.tally-voters')).toContainText('6号')
+  await expect(abstainRow.locator('.tally-voters')).toContainText('8号')
+})
+
+// ── VotingPhase coverage ──────────────────────────────────────────────────────
+// The FAB is mirrored into VotingPhase.vue so the game record stays reachable
+// for the entire daytime, not only during DAY_DISCUSSION.
+
+async function goToVotingScenario(page: Page) {
+  await goToDayScenario(page, 'HOST_REVEALED')
+  await page.locator('[data-testid="debug-voting"]').click()
+  await expect(page.locator('.voting-wrap')).toBeVisible({ timeout: 3000 })
+}
+
+test('📋 FAB is visible in voting phase', async ({ page }) => {
+  await goToVotingScenario(page)
+  const fab = page.locator('button.log-fab')
+  await expect(fab).toBeVisible()
+  await expect(fab).toHaveAttribute('aria-label', '游戏记录')
+})
+
+test('clicking FAB opens the drawer in voting phase', async ({ page }) => {
+  await goToVotingScenario(page)
+  await expect(page.locator('.action-log-drawer')).not.toBeVisible()
+  await page.locator('button.log-fab').click()
+  await expect(page.locator('.action-log-drawer')).toBeVisible()
+  await expect(page.locator('.drawer-title')).toHaveText('游戏记录')
 })

--- a/frontend/src/__tests__/votingPhase.test.ts
+++ b/frontend/src/__tests__/votingPhase.test.ts
@@ -94,6 +94,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
         plugins: [pinia, router],
       },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: sheriffUserId, // Current user is the eliminated sheriff
@@ -121,6 +122,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
         plugins: [pinia, router],
       },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: otherPlayerId, // Current user is NOT the eliminated sheriff
@@ -151,6 +153,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
         plugins: [pinia, router],
       },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: hostId, // Current user is the host but NOT the eliminated sheriff
@@ -215,6 +218,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
         plugins: [pinia, router],
       },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: 'player-3',
@@ -263,6 +267,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
         plugins: [pinia, router],
       },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: 'player-2',
@@ -294,6 +299,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
     const wrapper = mount(VotingPhase, {
       global: { plugins: [pinia, router] },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: aliveOtherId,
@@ -317,6 +323,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
     const wrapper = mount(VotingPhase, {
       global: { plugins: [pinia, router] },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: hostId,
@@ -337,6 +344,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
     const wrapper = mount(VotingPhase, {
       global: { plugins: [pinia, router] },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: sheriffUserId,
@@ -397,6 +405,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
         plugins: [pinia, router],
       },
       props: {
+        gameId: 1,
         votingPhase,
         players,
         myUserId: 'player-3',
@@ -462,6 +471,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
         plugins: [pinia, router],
       },
       props: {
+        gameId: 1,
         votingPhase: votingPhaseWithTally,
         players,
         myUserId: 'player-3',
@@ -515,6 +525,7 @@ describe('VotingPhase - Badge Handover UI Bug', () => {
         plugins: [pinia, router],
       },
       props: {
+        gameId: 1,
         votingPhase: votingPhaseWithTally,
         players,
         myUserId: 'player-2',

--- a/frontend/src/components/ActionLogDrawer.vue
+++ b/frontend/src/components/ActionLogDrawer.vue
@@ -24,6 +24,45 @@
             <div v-for="round in rounds" :key="round.day" class="round-block">
               <div class="round-label">第 {{ round.day }} 天</div>
 
+              <!-- Sheriff election (only emitted on the day of the election) -->
+              <div v-if="round.sheriffResult" class="log-section">
+                <div class="section-title">⭐ 警长选举</div>
+                <div v-if="round.sheriffResult.winnerNickname" class="log-row">
+                  <span class="seat-badge">{{ round.sheriffResult.winnerSeatIndex }}号</span>
+                  <span class="log-name">{{ round.sheriffResult.winnerNickname }}</span>
+                  <span class="log-tag tag-gold">警长</span>
+                </div>
+                <div v-else class="log-row muted">无警长</div>
+                <!-- Tally — same shape as vote result so players can analyse alliances -->
+                <div v-if="round.sheriffResult.tally.length > 0" class="tally">
+                  <div
+                    v-for="entry in round.sheriffResult.tally"
+                    :key="entry.userId"
+                    class="tally-row"
+                  >
+                    <span class="tally-name">{{ entry.seatIndex }}号 {{ entry.nickname }}</span>
+                    <span class="tally-votes">{{ entry.votes }} 票</span>
+                    <span class="tally-voters">
+                      （{{ entry.voters.map((v) => v.seatIndex + '号').join('、') }}）
+                    </span>
+                  </div>
+                </div>
+                <div
+                  v-if="(round.sheriffResult.abstainCount ?? 0) > 0"
+                  class="tally-row tally-abstain"
+                >
+                  <span class="tally-name muted">弃权</span>
+                  <span class="tally-votes">{{ round.sheriffResult.abstainCount }} 票</span>
+                  <span class="tally-voters">
+                    （{{
+                      (round.sheriffResult.abstainVoters ?? [])
+                        .map((v) => v.seatIndex + '号')
+                        .join('、')
+                    }}）
+                  </span>
+                </div>
+              </div>
+
               <!-- Deaths at start of day -->
               <div v-if="round.deaths.length > 0" class="log-section">
                 <div class="section-title">☽ 昨夜出局</div>
@@ -71,6 +110,20 @@
                     </span>
                   </div>
                 </div>
+                <div
+                  v-if="(round.voteResult.abstainCount ?? 0) > 0"
+                  class="tally-row tally-abstain"
+                >
+                  <span class="tally-name muted">弃权</span>
+                  <span class="tally-votes">{{ round.voteResult.abstainCount }} 票</span>
+                  <span class="tally-voters">
+                    （{{
+                      (round.voteResult.abstainVoters ?? [])
+                        .map((v) => v.seatIndex + '号')
+                        .join('、')
+                    }}）
+                  </span>
+                </div>
               </div>
 
               <!-- Hunter shot -->
@@ -100,6 +153,7 @@ import type {
   HunterShotPayload,
   IdiotRevealPayload,
   NightDeathPayload,
+  SheriffResultPayload,
   VoteResultPayload,
 } from '@/types'
 
@@ -108,6 +162,7 @@ defineEmits<{ close: [] }>()
 
 interface Round {
   day: number
+  sheriffResult: SheriffResultPayload | null
   deaths: NightDeathPayload[]
   voteResult: VoteResultPayload | null
   hunterShot: HunterShotPayload | null
@@ -122,7 +177,14 @@ function buildRounds(entries: ActionLogEntry[]): Round[] {
 
   const getOrCreate = (day: number): Round => {
     if (!map.has(day)) {
-      map.set(day, { day, deaths: [], voteResult: null, hunterShot: null, idiotReveals: [] })
+      map.set(day, {
+        day,
+        sheriffResult: null,
+        deaths: [],
+        voteResult: null,
+        hunterShot: null,
+        idiotReveals: [],
+      })
     }
     return map.get(day)!
   }
@@ -143,6 +205,9 @@ function buildRounds(entries: ActionLogEntry[]): Round[] {
         break
       case 'IDIOT_REVEAL':
         getOrCreate(day).idiotReveals.push(payload as IdiotRevealPayload)
+        break
+      case 'SHERIFF_RESULT':
+        getOrCreate(day).sheriffResult = payload as SheriffResultPayload
         break
     }
   }
@@ -332,6 +397,16 @@ watch(
   color: var(--red, #b5251a);
   font-weight: 600;
   white-space: nowrap;
+}
+
+.tally-abstain {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px dashed var(--border-l, #ddd6c6);
+}
+
+.tally-abstain .tally-votes {
+  color: var(--muted, #8a7a65);
 }
 
 .tally-voters {

--- a/frontend/src/components/VotingPhase.vue
+++ b/frontend/src/components/VotingPhase.vue
@@ -524,6 +524,12 @@
         </template>
       </footer>
     </template>
+
+    <!-- Floating action log button: full game record across all days -->
+    <button class="log-fab" aria-label="游戏记录" @click="showLog = true">📋</button>
+
+    <!-- Action log drawer -->
+    <ActionLogDrawer :game-id="gameId" :open="showLog" @close="showLog = false" />
   </div>
 </template>
 
@@ -532,8 +538,10 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { GamePlayer, PlayerRole, VoteRoundHistory, VotingState } from '@/types'
 import PlayerSlot from '@/components/PlayerSlot.vue'
 import SunArc from '@/components/SunArc.vue'
+import ActionLogDrawer from '@/components/ActionLogDrawer.vue'
 
 const props = defineProps<{
+  gameId: number
   votingPhase: VotingState
   players: GamePlayer[]
   myUserId: string
@@ -720,6 +728,7 @@ const ROLE_ZH: Record<string, string> = {
 // ── Vote History panel ────────────────────────────────────────────────────────
 const showHistory = ref(false)
 const showRoleCard = ref(false)
+const showLog = ref(false)
 
 watch([showHistory, showRoleCard], ([h, r]) => {
   document.body.style.overflow = h || r ? 'hidden' : ''
@@ -1240,5 +1249,25 @@ function onBadgeTap(player: GamePlayer) {
   color: var(--gold);
   font-size: 0.8125rem;
   font-weight: 600;
+}
+
+/* Floating action log FAB — mirrors DayPhase.log-fab so the game record stays
+   reachable across the entire daytime, not just DAY_DISCUSSION. */
+.log-fab {
+  position: fixed;
+  bottom: 88px;
+  right: 16px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--paper, #f5f0e8);
+  border: 1px solid var(--border, #ccc2b0);
+  font-size: 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -1070,6 +1070,46 @@ export const MOCK_STOMP_EVENTS = {
 
 export const MOCK_ACTION_LOG: ActionLogEntry[] = [
   {
+    id: 0,
+    eventType: 'SHERIFF_RESULT',
+    message: JSON.stringify({
+      dayNumber: 1,
+      tally: [
+        {
+          userId: 'u2',
+          nickname: 'Bob',
+          seatIndex: 2,
+          votes: 4,
+          voters: [
+            { userId: 'u1', nickname: 'You', seatIndex: 1 },
+            { userId: 'u3', nickname: 'Charlie', seatIndex: 3 },
+            { userId: 'u5', nickname: 'Eve', seatIndex: 5 },
+            { userId: 'u6', nickname: 'Frank', seatIndex: 6 },
+          ],
+        },
+        {
+          userId: 'u4',
+          nickname: 'Dave',
+          seatIndex: 4,
+          votes: 2,
+          voters: [
+            { userId: 'u2', nickname: 'Bob', seatIndex: 2 },
+            { userId: 'u4', nickname: 'Dave', seatIndex: 4 },
+          ],
+        },
+      ],
+      winnerUserId: 'u2',
+      winnerNickname: 'Bob',
+      winnerSeatIndex: 2,
+      abstainCount: 1,
+      abstainVoters: [
+        { userId: 'u7', nickname: 'Grace', seatIndex: 7 },
+      ],
+    }),
+    targetUserId: 'u2',
+    createdAt: '2023-12-31T23:59:00Z',
+  },
+  {
     id: 1,
     eventType: 'NIGHT_DEATH',
     message: JSON.stringify({ dayNumber: 1, userId: 'u3', nickname: 'Charlie', seatIndex: 3 }),
@@ -1098,6 +1138,11 @@ export const MOCK_ACTION_LOG: ActionLogEntry[] = [
       eliminatedNickname: 'Eve',
       eliminatedSeatIndex: 5,
       eliminatedRole: 'VILLAGER',
+      abstainCount: 2,
+      abstainVoters: [
+        { userId: 'u6', nickname: 'Frank', seatIndex: 6 },
+        { userId: 'u8', nickname: 'Henry', seatIndex: 8 },
+      ],
     }),
     targetUserId: 'u5',
     createdAt: '2024-01-01T12:00:00Z',

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -1102,9 +1102,7 @@ export const MOCK_ACTION_LOG: ActionLogEntry[] = [
       winnerNickname: 'Bob',
       winnerSeatIndex: 2,
       abstainCount: 1,
-      abstainVoters: [
-        { userId: 'u7', nickname: 'Grace', seatIndex: 7 },
-      ],
+      abstainVoters: [{ userId: 'u7', nickname: 'Grace', seatIndex: 7 }],
     }),
     targetUserId: 'u2',
     createdAt: '2023-12-31T23:59:00Z',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -365,7 +365,7 @@ export interface NightPhaseState {
 
 export interface ActionLogEntry {
   id: number
-  eventType: 'NIGHT_DEATH' | 'VOTE_RESULT' | 'HUNTER_SHOT' | 'IDIOT_REVEAL'
+  eventType: 'NIGHT_DEATH' | 'VOTE_RESULT' | 'HUNTER_SHOT' | 'IDIOT_REVEAL' | 'SHERIFF_RESULT'
   message: string // raw JSON — parse per eventType
   targetUserId: string | null
   createdAt: string | null
@@ -392,6 +392,12 @@ export interface VoteResultTallyEntry {
   voters: VoteResultVoter[]
 }
 
+export interface AbstainVoter {
+  userId: string
+  nickname: string
+  seatIndex: number
+}
+
 export interface VoteResultPayload {
   dayNumber: number
   tally: VoteResultTallyEntry[]
@@ -399,6 +405,8 @@ export interface VoteResultPayload {
   eliminatedNickname: string | null
   eliminatedSeatIndex: number | null
   eliminatedRole: string | null
+  abstainCount?: number
+  abstainVoters?: AbstainVoter[]
 }
 
 export interface HunterShotPayload {
@@ -416,6 +424,16 @@ export interface IdiotRevealPayload {
   userId: string
   nickname: string
   seatIndex: number
+}
+
+export interface SheriffResultPayload {
+  dayNumber: number
+  tally: VoteResultTallyEntry[]
+  winnerUserId: string | null
+  winnerNickname: string | null
+  winnerSeatIndex: number | null
+  abstainCount?: number
+  abstainVoters?: AbstainVoter[]
 }
 
 // ── WebSocket STOMP ───────────────────────────────────────────────────────────

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -106,6 +106,7 @@
     <template v-else-if="gameStore.state?.phase === 'DAY_VOTING' && gameStore.state?.votingPhase">
       <VotingPhase
         :key="`voting-${gameStore.state.votingPhase.subPhase}-${gameStore.state.dayNumber}`"
+        :game-id="Number(route.params.gameId)"
         :voting-phase="gameStore.state.votingPhase"
         :players="gameStore.state.players"
         :my-user-id="userStore.userId ?? ''"


### PR DESCRIPTION
## Summary

The action log drawer now carries the history players need to actually analyze a round.

* Sheriff election renders **first** inside day 1 (winner row + per-seat tally) so players see who became sheriff before reading the round.
* Abstain voters appear as a dashed-top muted footer beneath each tally — both the day vote and the sheriff election. Lets analysts spot wolves who skip while their teammates push someone.
* The floating 📋 FAB now appears during `DAY_VOTING` in addition to `DAY_DISCUSSION` so the log stays one tap away across the whole day.

### Backend
- `ActionLogService.recordSheriffResult`: new method, mirrors `recordVoteResult` shape.
- `recordVoteResult` and `recordSheriffResult` now compute `abstainCount` + `abstainVoters` from the votes list (no caller-signature changes).
- `SheriffService` emits `SHERIFF_RESULT` after both single-winner reveal and host-pick appoint paths. Appoint reads prior election votes from the DB so the log shows the room's tie-breaking pattern.

### Frontend
- New `SHERIFF_RESULT` `eventType` + `SheriffResultPayload`; `AbstainVoter` shape on both `VoteResultPayload` + `SheriffResultPayload`.
- `ActionLogDrawer` renders ⭐ 警长选举 as the first section in each round-block, plus a `弃权 N 票（…）` row beneath each tally.
- `VotingPhase` mounts the FAB and forwards `gameId` from `GameView`.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [x] `vitest run` 268/268 pass
- [x] `gradle test` (full backend suite) passes
- [x] Playwright suites pass: `action-log-drawer`, `check-role-log`, `voting-phase`, `day-phase`
- [x] Mock-mode demo: drawer FAB visible during day discussion AND voting; opening shows ⭐ 警长选举 → 2号 Bob 警长 + abstain footer
- [ ] Reviewer: smoke real flow end-to-end (sheriff election → abstain in day vote → drawer reflects both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)