### PR TITLE
docs: refresh audio + STOMP + sharding docs to match main

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ token() {
   echo "$1: $R" >&2
   [ -z "$R" ] && { echo "ERROR: empty response — is the backend running? (cd backend && ./gradlew bootRun --args='--spring.profiles.active=dev')" >&2; return 1; }
   echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])"
-}f
+}
 T_ALICE=$(token Alice); T_BOB=$(token Bob); T_CAROL=$(token Carol)
 T_DAVE=$(token Dave);   T_EVE=$(token Eve); T_FRANK=$(token Frank)
 

--- a/docs/adr/ADR-006-stomp-events.md
+++ b/docs/adr/ADR-006-stomp-events.md
@@ -24,20 +24,37 @@ the simple class name (e.g. `"PhaseChanged"`, `"PlayerEliminated"`).
 
 ### Key DomainEvent types
 
-| Event                  | Fields                                              | Channel    |
-|------------------------|-----------------------------------------------------|------------|
-| `PhaseChanged`         | `gameId, phase: GamePhase, subPhase: String?`       | game topic |
-| `NightSubPhaseChanged` | `gameId, subPhase: NightSubPhase`                   | game topic |
-| `RoleAssigned`         | `gameId, userId, role: PlayerRole`                  | private    |
-| `PlayerEliminated`     | `gameId, userId, role: PlayerRole`                  | game topic |
-| `VoteTally`            | `gameId, eliminatedUserId?, tally: Map<String,Int>` | game topic |
-| `SeerResult`           | `gameId, checkedUserId, isWerewolf`                 | private    |
-| `GameOver`             | `gameId, winner: WinnerSide`                        | game topic |
-| `HunterShot`           | `gameId, hunterUserId, targetUserId`                | game topic |
-| `BadgeHandover`        | `gameId, fromUserId, toUserId?`                     | game topic |
-| `SheriffElected`       | `gameId, sheriffUserId?`                            | game topic |
-| `RoleConfirmed`        | `gameId, userId`                                    | game topic |
-| `NightResult`          | `gameId, kills: List<String>`                       | game topic |
+Source of truth: `backend/src/main/kotlin/com/werewolf/game/DomainEvent.kt`.
+All subclasses carry a `@JsonTypeName("…")` annotation so renaming the Kotlin
+class does not break the wire format — but the annotation value is the wire
+discriminator and is itself a hard contract with the frontend.
+
+| Event                   | Fields                                              | Channel    |
+|-------------------------|-----------------------------------------------------|------------|
+| `PhaseChanged`          | `gameId, phase: GamePhase, subPhase: String?`       | game topic |
+| `NightSubPhaseChanged`  | `gameId, subPhase: NightSubPhase`                   | game topic |
+| `RoleAssigned`          | `gameId, userId, role: PlayerRole`                  | private    |
+| `RoleConfirmed`         | `gameId, userId`                                    | game topic |
+| `NightResult`           | `gameId, kills: List<String>`                       | game topic |
+| `PlayerEliminated`      | `gameId, userId, role: PlayerRole`                  | game topic |
+| `VoteSubmitted`         | `gameId, voterUserId`                               | game topic |
+| `VoteTally`             | `gameId, eliminatedUserId?, tally: Map<String,Double>` | game topic |
+| `IdiotRevealed`         | `gameId, userId`                                    | game topic |
+| `WolfSelectionChanged`  | `gameId, selectedTargetUserId`                      | game topic |
+| `SeerResult`            | `gameId, checkedUserId, isWerewolf`                 | private    |
+| `HunterShot`            | `gameId, hunterUserId, targetUserId`                | game topic |
+| `BadgeHandover`         | `gameId, fromUserId, toUserId?`                     | game topic |
+| `SheriffElected`        | `gameId, sheriffUserId?`                            | game topic |
+| `GameOver`              | `gameId, winner: WinnerSide?`                       | game topic |
+| `AudioSequence`         | `gameId, audioSequence: AudioSequence`              | game topic |
+| `OpenEyes`              | `gameId, role, phase, nightNumber`                  | game topic |
+| `CloseEyes`             | `gameId, role, phase, nightNumber`                  | game topic |
+| `RoleAction`            | `gameId, userId, role, actionType, targets, canHeal?, canPoison?, timeoutMs` | game topic |
+
+`AudioSequence` is the audio contract — see `docs/adr/audio.md` for the
+server-authoritative model (cache, replay buffer, dedup gate). `tally` is
+`Map<String, Double>` because sheriff voting weight is 1.5× (ADR-009), so
+totals are not always integers.
 
 ### Private channel usage
 

--- a/docs/adr/audio.md
+++ b/docs/adr/audio.md
@@ -1,34 +1,116 @@
 # Audio
 
 Audio files are served by the backend from `backend/src/main/resources/static/audio/`
-(accessible as `/audio/<filename>.mp3`). The frontend triggers playback based on STOMP
-events; volume is controllable via `useAudioService()`.
+(accessible as `/audio/<filename>.mp3`). The architecture is **server-authoritative**:
+the backend computes which files to play and broadcasts an `AudioSequence` STOMP
+event; the frontend's job is purely to play whatever the server told it to play.
 
-## Trigger Map
+## Architecture (server-authoritative)
 
-| Event / sub-phase                     | File                        |
-|---------------------------------------|-----------------------------|
-| `NIGHT` enter                         | `goes_dark_close_eyes.mp3`  |
-| Night atmosphere (loop)               | `crow_night.mp3`            |
-| `NIGHT / WEREWOLF_PICK` enter         | `wolf_howl.mp3` → `wolf_open_eyes.mp3` |
-| Werewolf phase close                  | `wolf_close_eyes.mp3`       |
-| `NIGHT / SEER_PICK` enter             | `seer_open_eyes.mp3`        |
-| Seer phase close                      | `seer_close_eyes.mp3`       |
-| `NIGHT / WITCH_ACT` enter             | `witch_open_eyes.mp3`       |
-| Witch phase close                     | `witch_close_eyes.mp3`      |
-| `NIGHT / GUARD_PICK` enter            | `guard_open_eyes.mp3`       |
-| Guard phase close                     | `guard_close_eyes.mp3`      |
-| Dawn / `DAY_PENDING`                  | `rooster_crowing.mp3`       |
-| `DAY_DISCUSSION` / `DAY_VOTING` enter | `day_time.mp3`              |
+```
+Backend                                   Frontend
+─────────                                 ──────────
+NightOrchestrator / GamePhasePipeline /
+SheriffService construct an AudioSequence
+        │
+        ▼
+StompPublisher.broadcastGame              [stomp] AudioSequence event
+  ├─ side-effects into AudioReplayCache   ────────────────────────────►
+  └─ /topic/game/{gameId}                                              │
+                                                                       ▼
+                                                         gameStore.state.audioSequence
+                                                                       │
+                                                                       ▼
+                                                         useAudioService watcher
+                                                                       │
+                                                                       ▼
+                                                         audioService.playSequential
+                                                         (HTMLAudioElement queue)
+```
+
+The frontend never decides "what to play" — it dedups by `AudioSequence.id`
+(useAudioService `playedIds` Set, capped at 50) and plays the supplied file list.
+A second watcher on `audioReplayBuffer` (see below) handles reconnect recovery
+through the same `tryPlay` gate, so the live STOMP path and the HTTP recovery
+path share one dedup.
+
+### Reconnect recovery (`AudioReplayCache`)
+
+Spring's `SimpleBroker` is fire-and-forget — broadcasts to a momentarily-offline
+subscriber are dropped on the wire. STOMP-JS auto-reconnects after
+`reconnectDelay: 3000` ms, so any AudioSequence broadcast during the disconnect
+window would otherwise be permanently lost (background-tab heartbeat throttling
+on macOS Spaces / mobile background is the typical trigger).
+
+`AudioReplayCache` (in `backend/src/main/kotlin/com/werewolf/audio/`) keeps a
+small per-game ring buffer (default 8 frames) of recent broadcasts.
+`StompPublisher.broadcastGame` side-effects into the cache for every
+`DomainEvent.AudioSequence` and clears it on `DomainEvent.GameOver`.
+`GameService.getGameState` surfaces both fields:
+
+- `audioSequence` — most recent (legacy single-field contract)
+- `audioReplayBuffer` — full ring (recovery path)
+
+On reconnect, `GameView.refreshState()` picks up the buffer; the frontend's
+`useAudioService` iterates each entry through the same dedup gate as live
+events, so missed cues replay and already-played ones skip.
+
+## Trigger Map (role narration + transition cues)
+
+Computed by `AudioService.kt` (`calculatePhaseTransition`,
+`calculateNightSubPhaseTransition`) and by per-cue `broadcastAudio` calls in
+`NightOrchestrator.nightRoleLoop`.
+
+| Event / sub-phase                                      | File(s)                                  |
+|--------------------------------------------------------|------------------------------------------|
+| Enter `NIGHT` (any night)                              | `goes_dark_close_eyes.mp3`, `wolf_howl.mp3` |
+| `WEREWOLF_PICK` opens                                  | `wolf_open_eyes.mp3`                     |
+| `WEREWOLF_PICK` → `SEER_PICK` close                    | `wolf_close_eyes.mp3`                    |
+| `SEER_PICK` opens                                      | `seer_open_eyes.mp3`                     |
+| `SEER_RESULT` close (after seer confirms)              | `seer_close_eyes.mp3`                    |
+| `WITCH_ACT` opens                                      | `witch_open_eyes.mp3`                    |
+| `WITCH_ACT` close                                      | `witch_close_eyes.mp3`                   |
+| `GUARD_PICK` opens                                     | `guard_open_eyes.mp3`                    |
+| `GUARD_PICK` close                                     | `guard_close_eyes.mp3`                   |
+| `NIGHT` → `DAY_DISCUSSION/RESULT_HIDDEN` (Day 2+)      | `rooster_crowing.mp3`, `day_time.mp3`    |
+| `NIGHT` → `SHERIFF_ELECTION/SIGNUP` (Variant B Day 1)  | `rooster_crowing.mp3`, `day_time.mp3` (delayed by `sheriffMorningCueDelayMs`) |
 
 Dead roles still receive the same open-eyes → delay → close-eyes sequence (see
-ADR-010 Dead-Role Information Hiding). Audio is identical whether the role player is
-alive or dead.
+ADR-010 Dead-Role Information Hiding). Audio is identical whether the role
+player is alive or dead.
+
+## Background music (BGM)
+
+Optional looping music per room, picked by the host on the create-room screen
+and persisted inside the room's `GameConfig` JSONB column. Tracks are scanned
+from `backend/src/main/resources/static/audio/bgm/` at startup
+(`AudioTracksController`, 60 s TTL cache).
+
+The BGM lifecycle is driven by frontend watchers in `useAudioService`:
+
+| Watcher source                          | Action                                   |
+|-----------------------------------------|------------------------------------------|
+| `gameStore.state.phase === 'NIGHT'`     | `audioService.startBgm(track)`           |
+| Any other phase                         | `audioService.stopBgm()`                 |
+| `nightPhase.subPhase` ∈ HIGH_VOL_NIGHT_SUBPHASES | `setBgmLevel('HIGH')` (1.0×)     |
+| Any other sub-phase                     | `setBgmLevel('LOW')` (0.45×)             |
+| Narration queue active                  | `duckBgm()` (0.15×)                      |
+
+Volume modulation is a 150 ms `requestAnimationFrame` tween on
+`HTMLAudioElement.volume`. The earlier Web-Audio routing
+(`createMediaElementSource → GainNode`) was replaced because
+`AudioContext.resume()` is async and was not awaited before `play()`, leaving
+the FIRST night silent. See PR #95 for the full rationale.
 
 ## Frontend usage
 
 ```ts
-const { setVolume, getVolume } = useAudioService()
-setVolume(0.5)         // 0–1
-const volume = getVolume()
+const { setVolume, getVolume, setBgmVolume, getBgmVolume, toggleMute, isMuted } =
+  useAudioService()
+setVolume(0.5)              // narration volume, 0–1
+setBgmVolume(0.5)           // BGM base volume, 0–1, persisted to localStorage
+const muted = toggleMute()  // also persisted
 ```
+
+The `VolumeControl.vue` component wraps these and is rendered in the room +
+game views.

--- a/docs/superpowers/plans/2026-04-19-e2e-integration-sharding.md
+++ b/docs/superpowers/plans/2026-04-19-e2e-integration-sharding.md
@@ -1,6 +1,29 @@
 # E2E Integration — CI Sharding + Nickname Namespacing
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Status: SUPERSEDED (kept for history).**
+>
+> Patch 1 (CI sharding) was applied as proposed in this plan, but the layout
+> evolved beyond `--shard=N/3`:
+>
+>   - PR #97 (2026-05-04) — replaced `--shard=N/3` with a hand-curated
+>     5-shard matrix that pins specific spec files per shard, balanced by
+>     measured runtime. Wall-clock dropped from ~14m to ~7m24s.
+>   - PR #100 (2026-05-05) — split `flow-12p-sheriff.spec.ts` across two
+>     shards via Playwright `--grep` (one per describe block) and bumped
+>     to a 6-shard layout. Wall-clock dropped to ~6m36s.
+>
+> Patch 2 (nickname namespacing) was **not** applied. Additional shards
+> parallelize workloads that would have needed `workers > 1`, so the 30+
+> specs that depend on the literal `'Host'` nickname were left untouched.
+>
+> The current shard map and per-spec runtime budget is documented inline
+> in `.github/workflows/ci.yml` under the `e2e-integration` job.
+>
+> The blueprint below is preserved as the original 2026-04-19 proposal —
+> useful context for understanding the path the repo took, not a current
+> spec of CI behaviour.
+
+---
 
 **Goal:** Cut E2E integration wall-clock (~7 min → ~3 min) and make parallel runs safe by (1) sharding the CI job and (2) namespacing hard-coded nicknames that collide when the same backend sees concurrent sessions.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -101,5 +101,5 @@ CI runs these as separate jobs (see `.github/workflows/ci.yml`):
 | CI Job | Script | Notes |
 |---|---|---|
 | `checks` | `npm run test:unit:coverage` | Also runs lint, format, type-check |
-| `e2e-ui` | `npm run test:e2e:ui` | Sharded 3-way for speed |
-| `e2e-integration` | `npm run test:e2e:integration` | Runs after backend build passes |
+| `e2e-ui` | `npm run test:e2e:ui` — `--shard=N/3` | 3 parallel shards for speed |
+| `e2e-integration` | `npx playwright test --config=playwright.real.config.ts <files>` | 6 hand-curated shards, balanced by measured runtime; matrix in `.github/workflows/ci.yml` is the source of truth. Runs after backend build passes |


### PR DESCRIPTION
## Summary
Reviewed tracked .md files against current main and updated only the ones with concrete factual staleness.

- `docs/adr/audio.md` — full rewrite. Old version missed the entire BGM feature (PR #95), the server-authoritative `AudioSequence` event, and the `AudioReplayCache` + `audioReplayBuffer` reconnect-recovery path. Now captures architecture, cache mechanism, trigger map, BGM lifecycle.
- `docs/adr/ADR-006-stomp-events.md` — added missing `DomainEvent` types: `AudioSequence`, `OpenEyes`/`CloseEyes`, `RoleAction`, `VoteSubmitted`, `WolfSelectionChanged`, `IdiotRevealed`. Corrected `VoteTally.tally` from `Map<String,Int>` → `Map<String,Double>` (sheriff weight is 1.5×, ADR-009).
- `docs/superpowers/plans/2026-04-19-e2e-integration-sharding.md` — marked SUPERSEDED. `--shard=N/3` was replaced by PR #97 (5-shard) and PR #100 (6-shard with `--grep`). Nickname-namespacing patch not applied; extra shards covered the parallelism need.
- `frontend/README.md` — CI table reflects 6 hand-curated integration shards.
- `README.md` — fixed `}f` typo in dev-login bash example.

Skipped: `docs/game-phase-flow.md` (self-attested current 2026-05-03), `docs/real-backend-testing.md`, `docs/scenarios/`, `docs/superpowers/specs/`, `docs/e2e-evidence/`. `docs/ci-tests-issues.md` is local-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
