### PR TITLE
fix(audio): guard audioReplayBuffer watcher against re-iteration spam

### DIFF
--- a/frontend/src/composables/useAudioService.ts
+++ b/frontend/src/composables/useAudioService.ts
@@ -98,11 +98,31 @@ export function useAudioService() {
    * replay every cue missed during the disconnect window. Iterate the
    * buffer in chronological order; tryPlay's playedIds dedup ensures we
    * never double-play a frame the live path already handled.
+   *
+   * `lastReplayTailId` is a cheap content guard. setState replaces
+   * audioReplayBuffer on every getGameState poll (PhaseChanged /
+   * NightSubPhaseChanged handlers refreshState themselves), so this
+   * watcher fires constantly even when the buffer's contents haven't
+   * changed. Iterating + dedup-logging 8 cached entries on every poll
+   * adds enough console + reactive overhead that Playwright's click
+   * stability check fails during high-frequency state-update bursts
+   * (e.g. sheriff voting where 8 bot votes fan out in <2 s). Skipping
+   * the loop when the buffer's tail id hasn't changed cuts that
+   * overhead to ~zero in steady state while still firing the moment a
+   * new audio frame is appended on the wire — which is the only time
+   * the recovery path actually has work to do. Reproduced + fix
+   * verified locally: with this guard removed, sheriff-flow runs ~45 s
+   * 3/3 with `CI=1`; without it, the same sequence hits a 3-min
+   * `locator.click: Target page closed` on test 4 ~30 % of the time.
    */
+  let lastReplayTailId: string | null = null
   watch(
     () => gameStore.state?.audioReplayBuffer,
     (buffer) => {
       if (!buffer || buffer.length === 0) return
+      const tailId = buffer[buffer.length - 1]?.id ?? null
+      if (tailId === lastReplayTailId) return
+      lastReplayTailId = tailId
       for (const seq of buffer) tryPlay(seq, 'replay')
     },
     { deep: true },


### PR DESCRIPTION
## Reproduce
Same `Target page, context or browser has been closed` symptom as PR #102's shard-3 failure. Reproduced locally with `CI=1` against a clean e2e backend:

```
CI=1 npx playwright test ... sheriff-flow.spec.ts
→ 5.8 m, tests 4 & 5 fail
```

Trace evidence:
- `Click getByTestId('sheriff-abstain')` blocked **177 273 ms**.
- Call log: `waiting for getByTestId('sheriff-abstain')` — Playwright never resolved the locator after the first paint.
- Backend log shows the abstain *did* fire and succeed (`SHERIFF_ABSTAIN -> SUCCESS`, `waitingOn=[]`); the click's promise just never resolved.

## Root cause
Host-page console during test 4: **72 lines of `[useAudioService] Skipping duplicate sequence (replay, same ID)`** (9 PhaseChanged-driven setStates × 8 buffer entries). The `audioReplayBuffer` watcher (PR #95) re-iterates the full 8-entry ring on every `gameStore.setState`, even when the buffer hasn't changed. During sheriff voting, 8 bot votes fan out in <2 s → host page is hit with ~64 reactive updates + console writes in tight succession → Playwright's click stability check on the abstain button never satisfies → with `timeout: 0` the auto-wait loops until the 180 s test timeout.

## Fix
Cheap tail-id guard inside the watcher. Track the last-seen tail entry's `id`; if unchanged, skip the loop. The watcher still fires the moment the cache appends a new entry, which is the only time the recovery path has work to do.

## Verification
- `vue-tsc -b --noEmit` clean.
- `vitest run` 268/268 pass.
- Sheriff-flow under `CI=1` with a clean e2e backend:
  - **Before fix:** 5.8 m, tests 4 & 5 fail (3-min hang).
  - **Watcher disabled:** 45.9 / 45.1 / 45.1 s — 3/3 pass.
  - **With this fix:** 45.2 / 45.0 / 44.9 s — 3/3 pass.
- `audio-reconnect-recovery.spec.ts` still passes (1 pass, 41.3 s) — recovery functionality preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
