### PR TITLE
fix(audio): self-heal stuck playback queue when prior onended never fires

### DIFF
--- a/frontend/src/__tests__/audioService.test.ts
+++ b/frontend/src/__tests__/audioService.test.ts
@@ -188,4 +188,35 @@ describe('audioService', () => {
     })
     expect(mockAudioInstances[1]?.play).toHaveBeenCalled()
   })
+
+  // ── Stuck-queue watchdog ─────────────────────────────────────────────────
+  //
+  // Documented failure mode (audioService.ts:246–259): if a prior playback's
+  // onended never fires (paused mid-stream, AudioContext suspended in a
+  // background tab, play() promise hung), isPlayingQueue stays true forever.
+  // The next playSequential queues files but skips processing because of the
+  // !isPlayingQueue gate, leaving the host's phone silent for the rest of the
+  // game. Reproduced indirectly: game 17, room 21, 2026-05-09 — seer/witch
+  // audio played on their phones but the host heard nothing.
+
+  it('playSequential recovers from a stuck queue when no playback has started in >15s', () => {
+    // Simulate a stuck state: isPlayingQueue = true but lastPlaybackStartTime
+    // is 16 seconds in the past (as if play() hung and onended never fired).
+    ;(audioService as any).isPlayingQueue = true
+    ;(audioService as any).lastPlaybackStartTime = performance.now() - 16000
+
+    const warnSpy = vi.spyOn(console, 'warn')
+
+    audioService.playSequential(['seer_open_eyes.mp3'])
+
+    // The watchdog should have reset the stuck state so play() is called.
+    expect(mockAudioInstances).toHaveLength(1)
+    expect(mockAudioInstances[0]?.play).toHaveBeenCalledTimes(1)
+
+    // The watchdog warn must fire to help with future debugging.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[AudioService] Stuck queue detected'),
+      expect.any(Object),
+    )
+  })
 })

--- a/frontend/src/services/audioService.ts
+++ b/frontend/src/services/audioService.ts
@@ -63,6 +63,7 @@ class AudioService {
 
   private audioQueue: Array<{ filename: string; options: AudioOptions }> = []
   private isPlayingQueue = false
+  private lastPlaybackStartTime = 0
 
   /**
    * Setup tracking for user interaction to enable audio playback
@@ -131,6 +132,22 @@ class AudioService {
   playSequential(filenames: string[], options: AudioOptions = {}): void {
     if (this.muted || filenames.length === 0) return
 
+    // Stuck-queue self-heal. Documented failure (see stopAll() comment): if
+    // a prior playback's onended never fires (paused mid-stream, AudioContext
+    // suspended in background tab, play() promise hung), isPlayingQueue stays
+    // true forever and every subsequent playSequential is silently dropped
+    // because of the !isPlayingQueue gate. Detect via wall-clock: if we are
+    // "playing" but no item has started for >15s, the queue is stuck — drain
+    // and reset so this call gets to play.
+    if (this.isPlayingQueue && performance.now() - this.lastPlaybackStartTime > 15000) {
+      console.warn(
+        '[AudioService] Stuck queue detected (no playback start in >15s) — force-recovering',
+        { queueLen: this.audioQueue.length, lastStart: this.lastPlaybackStartTime },
+      )
+      this.audioQueue = []
+      this.isPlayingQueue = false
+    }
+
     // Add to queue with options
     filenames.forEach((filename) => {
       this.audioQueue.push({ filename, options })
@@ -192,6 +209,9 @@ class AudioService {
         this.playNextInQueue() // Continue to next audio
         return
       }
+
+      // Record start time for stuck-queue watchdog in playSequential.
+      this.lastPlaybackStartTime = performance.now()
 
       // Handle play errors and continue to next
       audio.play().catch((error) => {


### PR DESCRIPTION
## Summary

- Adds a 15-second wall-clock **stuck-queue watchdog** at the top of `playSequential` in `audioService.ts`. If `isPlayingQueue` is `true` but no item has started within 15 seconds, the queue is drained and reset before enqueueing the new sequence — so the next narration plays instead of being silently dropped.
- Adds a private field `lastPlaybackStartTime` (initialized to `0`). In `playNextInQueue`, immediately before each `audio.play()` call, the field is set to `performance.now()` so the watchdog has an accurate baseline.
- Adds a unit test: **`playSequential recovers from a stuck queue when no playback has started in >15s`** — sets `isPlayingQueue = true` and `lastPlaybackStartTime` 16 seconds in the past, then asserts that a fresh `playSequential` call actually starts playback and fires the watchdog `console.warn`.

## Background: documented failure mode

`audioService.ts:246–259` documents this bug in the `stopAll()` comment:

> Pausing a mid-narration HTMLAudioElement does NOT fire its `onended` handler, so `playNextInQueue` is never called and `isPlayingQueue` would otherwise stay stuck at true. The next `playSequential` then queues files but skips processing because of its `!isPlayingQueue` gate, leaving every subsequent narration silent forever.

`stopAll()` was already patched to reset the gate, but the same stuck state can arise from other paths (Safari AudioContext suspended in a background tab, `play()` promise hanging on a slow mobile connection) — none of which go through `stopAll()`.

**Production evidence is indirect**: game 17, room 21, 2026-05-09 — seer/witch audio played on their phones but the host's phone was silent. No browser logs from the host's device are available (players cannot paste logs), so this is purely defensive hardening of a known-fragile code path.

## Test plan

- [x] New failing test written first — watched it fail (`expected [] to have a length of 1 but got 0`)
- [x] Fix applied — watched the same test pass
- [x] Full audio suite: `audioService.test.ts`, `useAudioService.test.ts`, `audioServiceBgm.test.ts`, `gameViewAudioEventOrder.test.ts` — **58/58 passed, 0 regressions**
- [x] TypeScript: `vue-tsc --noEmit` — **no errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)