### PR TITLE
fix(sheriff): auto-advance to DAY_DISCUSSION when last candidate quits during SPEECH

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
@@ -378,13 +378,19 @@ class SheriffService(
         val allCandidates = sheriffCandidateRepository.findByElectionId(election.id)
         val anyRunningLeft = allCandidates.any { it.status == CandidateStatus.RUNNING && speakingOrderIds.contains(it.userId) }
         if (!anyRunningLeft) {
-            // No running candidates remain → show RESULT phase with auto-advance to night
-            election.subPhase = ElectionSubPhase.RESULT
-            sheriffElectionRepository.save(election)
-            broadcastAfterCommit(context.gameId,
-                DomainEvent.PhaseChanged(context.gameId, GamePhase.SHERIFF_ELECTION, ElectionSubPhase.RESULT.name))
-            // Sheriff is shown on the RESULT screen until the host clicks
-            // 显示结果 (SHERIFF_END_RESULT) — no auto-timer.
+            // No running candidates remain — mirrors startSpeech's empty-candidates
+            // branch: advance straight to DAY_DISCUSSION/RESULT_HIDDEN instead of
+            // landing on SHERIFF_ELECTION/RESULT. The RESULT screen would show an
+            // empty winner card and empty tally (no sheriff was elected), leaving
+            // the host with nothing to dismiss — a dead-end (game 18 / room 22,
+            // 2026-05-09). endResult() performs the identical write; inline it here.
+            context.game.phase = GamePhase.DAY_DISCUSSION
+            context.game.subPhase = DaySubPhase.RESULT_HIDDEN.name
+            gameRepository.save(context.game)
+            broadcastAfterCommit(
+                context.gameId,
+                DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_HIDDEN.name),
+            )
             return GameActionResult.Success()
         }
 

--- a/backend/src/test/kotlin/com/werewolf/integration/SheriffElectionEdgeCaseIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/SheriffElectionEdgeCaseIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.werewolf.integration.TestConstants.FIELD_TOKEN
 import com.werewolf.integration.TestConstants.FIELD_TOTAL_PLAYERS
 import com.werewolf.integration.TestConstants.JOIN_ROOM_URL
 import com.werewolf.integration.TestConstants.LOGIN_URL
+import com.werewolf.model.DaySubPhase
 import com.werewolf.model.ElectionSubPhase
 import com.werewolf.model.GamePhase
 import com.werewolf.model.NightPhase
@@ -210,10 +211,18 @@ class SheriffElectionEdgeCaseIntegrationTest {
         assertThat(g1Player.sheriff).isTrue()
     }
 
-    // ── Case 1.a: All candidates quit → RESULT with auto-advance ──────────────
+    // ── Case 1.a: All candidates quit → auto-advance to DAY_DISCUSSION ──────────
+    //
+    // Bug: before the fix, quitCampaign landed on SHERIFF_ELECTION/RESULT when the
+    // last candidate quit during SPEECH. The host RESULT screen showed an empty winner
+    // card and empty tally — nothing to dismiss. Game 18 / room 22 (2026-05-09) was
+    // stuck in this state for 14+ hours.
+    //
+    // Fix: mirror startSpeech's empty-candidates branch — advance directly to
+    // DAY_DISCUSSION/RESULT_HIDDEN (same write as SHERIFF_END_RESULT performs).
 
     @Test
-    fun `sheriff election - all candidates quit shows RESULT not direct NIGHT`() {
+    fun `sheriff election - all candidates quit auto-advances to DAY_DISCUSSION RESULT_HIDDEN`() {
         val (players, roomId) = setupSheriffRoom("EC1a")
         val host = players[0]; val g1 = players[1]; val g2 = players[2]; val g3 = players[3]
         val g4 = players[4]; val g5 = players[5]
@@ -233,20 +242,14 @@ class SheriffElectionEdgeCaseIntegrationTest {
         // All three quit during speech
         assertThat(action(g1.token, gameId, "SHERIFF_QUIT_CAMPAIGN").statusCode).isEqualTo(HttpStatus.OK)
         assertThat(action(g2.token, gameId, "SHERIFF_QUIT_CAMPAIGN").statusCode).isEqualTo(HttpStatus.OK)
-        // After g3 quits, no running candidates remain → RESULT (not direct NIGHT)
+        // After g3 quits, no running candidates remain → auto-advance to DAY_DISCUSSION
         assertThat(action(g3.token, gameId, "SHERIFF_QUIT_CAMPAIGN").statusCode).isEqualTo(HttpStatus.OK)
 
-        // Assert: election in RESULT sub-phase, game still in SHERIFF_ELECTION
-        val election = sheriffElectionRepository.findByGameId(gameId).orElseThrow()
-        assertThat(election.subPhase).isEqualTo(ElectionSubPhase.RESULT)
-        assertThat(election.electedSheriffUserId).isNull()
-
+        // Assert: game has advanced to DAY_DISCUSSION/RESULT_HIDDEN — no sheriff elected
         val game = gameRepository.findById(gameId).orElseThrow()
-        assertThat(game.phase).isEqualTo(GamePhase.SHERIFF_ELECTION)
+        assertThat(game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(game.subPhase).isEqualTo(DaySubPhase.RESULT_HIDDEN.name)
         assertThat(game.sheriffUserId).isNull()
-
-        // Cancel auto-advance to prevent it from firing during test cleanup
-        sheriffService.cancelScheduledJob(gameId)
     }
 
     // ── Case 1.b: All abstain → TIED → host appoints ─────────────────────────

--- a/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
@@ -372,33 +372,76 @@ class SheriffServiceTest {
     }
 
     @Test
-    fun `quitCampaign - transitions to RESULT when last running candidate quits`() {
+    fun `quitCampaign - auto-advances to DAY_DISCUSSION when last running candidate quits`() {
+        // Updated: old behavior was SHERIFF_ELECTION/RESULT (a dead-end — nothing
+        // for the host to dismiss on the RESULT screen when there's no winner).
+        // Fixed behavior mirrors startSpeech's empty-candidates branch: advance
+        // directly to DAY_DISCUSSION/RESULT_HIDDEN. See quitCampaign_lastCandidateInSpeech
+        // test for the canonical regression test covering game 18 / room 22.
         val speakingOrder = guestId
         val election = election(subPhase = ElectionSubPhase.SPEECH, speakingOrder = speakingOrder)
         val ctx = context(election = election)
 
         val guestCandidate = SheriffCandidate(electionId = electionId, userId = guestId, status = CandidateStatus.RUNNING)
 
-        // After save, the candidate is QUIT and there are no more RUNNING candidates in the speaking order
         whenever(sheriffCandidateRepository.findByElectionId(electionId))
             .thenReturn(listOf(guestCandidate))
             .thenReturn(listOf(
                 SheriffCandidate(electionId = electionId, userId = guestId, status = CandidateStatus.QUIT),
             ))
         whenever(sheriffCandidateRepository.save(any<SheriffCandidate>())).thenAnswer { it.arguments[0] }
-        whenever(sheriffElectionRepository.save(any<SheriffElection>())).thenAnswer { it.arguments[0] }
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
 
         val req = GameActionRequest(gameId, guestId, ActionType.SHERIFF_QUIT_CAMPAIGN)
         val result = sheriffService.handle(req, ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
-        // Should transition to RESULT, not directly to night
-        assertThat(election.subPhase).isEqualTo(ElectionSubPhase.RESULT)
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_HIDDEN.name)
 
         val captor = argumentCaptor<DomainEvent>()
         verify(stompPublisher).broadcastGame(eq(gameId), captor.capture())
-        assertThat((captor.firstValue as DomainEvent.PhaseChanged).subPhase).isEqualTo(ElectionSubPhase.RESULT.name)
-        // Should NOT call startNightPhase directly — auto-advance is scheduled
+        assertThat((captor.firstValue as DomainEvent.PhaseChanged).subPhase).isEqualTo(DaySubPhase.RESULT_HIDDEN.name)
+    }
+
+    @Test
+    fun `quitCampaign_lastCandidateInSpeech_advancesToDayDiscussionRESULT_HIDDEN`() {
+        // Regression: game 18 / room 22 (2026-05-09) got stuck 14+ hours in
+        // SHERIFF_ELECTION/RESULT because all 8 candidates quit during SPEECH.
+        // The quitCampaign path landed on ELECTION/RESULT (waiting for host to
+        // click 显示结果), but the host screen showed an empty winner card and
+        // empty tally — a dead-end with nothing to dismiss.
+        //
+        // Fix: mirror startSpeech's empty-candidates branch — when the last
+        // running candidate quits during SPEECH, auto-advance directly to
+        // DAY_DISCUSSION/RESULT_HIDDEN (same as SHERIFF_END_RESULT would do).
+        val speakingOrder = guestId
+        val election = election(subPhase = ElectionSubPhase.SPEECH, speakingOrder = speakingOrder)
+        val ctx = context(election = election)
+
+        val guestCandidate = SheriffCandidate(electionId = electionId, userId = guestId, status = CandidateStatus.RUNNING)
+
+        whenever(sheriffCandidateRepository.findByElectionId(electionId))
+            .thenReturn(listOf(guestCandidate))
+            .thenReturn(listOf(
+                SheriffCandidate(electionId = electionId, userId = guestId, status = CandidateStatus.QUIT),
+            ))
+        whenever(sheriffCandidateRepository.save(any<SheriffCandidate>())).thenAnswer { it.arguments[0] }
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+
+        val req = GameActionRequest(gameId, guestId, ActionType.SHERIFF_QUIT_CAMPAIGN)
+        val result = sheriffService.handle(req, ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        // Game phase must advance — NOT stay in SHERIFF_ELECTION/RESULT
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_HIDDEN.name)
+
+        val captor = argumentCaptor<DomainEvent>()
+        verify(stompPublisher).broadcastGame(eq(gameId), captor.capture())
+        val phaseChanged = captor.firstValue as DomainEvent.PhaseChanged
+        assertThat(phaseChanged.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(phaseChanged.subPhase).isEqualTo(DaySubPhase.RESULT_HIDDEN.name)
     }
 
     // ── Group 4: revealResult() empty votes / all-abstain ────────────────────────


### PR DESCRIPTION
## Summary

- **Bug:** Game 18 / room 22 (2026-05-09) was stuck in `SHERIFF_ELECTION/RESULT` for 14+ hours. All 8 sheriff candidates quit during the SPEECH sub-phase. The host RESULT screen showed an empty winner card and empty tally — a dead-end with nothing to dismiss.
- **Root cause:** `quitCampaign`'s `!anyRunningLeft` branch landed on `SHERIFF_ELECTION/RESULT`, unlike `startSpeech`'s empty-candidates branch which auto-advances directly to `DAY_DISCUSSION/RESULT_HIDDEN`. Both paths reach the same logical state ("no sheriff was elected") but only the `startSpeech` path correctly advanced the game.
- **Fix:** When the last running candidate quits during SPEECH, `quitCampaign` now mirrors `startSpeech`'s empty-candidates branch: sets `game.phase = DAY_DISCUSSION`, `game.subPhase = RESULT_HIDDEN`, saves game, and broadcasts `PhaseChanged(DAY_DISCUSSION, RESULT_HIDDEN)`. This is the same write that `endResult()` (SHERIFF_END_RESULT host action) performs.

## Changes

- `SheriffService.kt` — surgical fix to `quitCampaign`'s `!anyRunningLeft` branch (13 lines changed)
- `SheriffServiceTest.kt` — new regression test `quitCampaign_lastCandidateInSpeech_advancesToDayDiscussionRESULT_HIDDEN`; updated existing test that was asserting the broken behavior
- `SheriffElectionEdgeCaseIntegrationTest.kt` — updated integration test (`all candidates quit`) to assert the fixed behavior (`DAY_DISCUSSION/RESULT_HIDDEN` instead of `SHERIFF_ELECTION/RESULT`)

## Test plan

- [x] New unit test `quitCampaign_lastCandidateInSpeech_advancesToDayDiscussionRESULT_HIDDEN` confirmed failing before fix, passing after
- [x] Full `SheriffServiceTest` class: all tests pass
- [x] `SheriffElectionIntegrationTest` + `SheriffElectionEdgeCaseIntegrationTest`: all 6 tests pass
- [x] Full backend test suite: `BUILD SUCCESSFUL` (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)