### PR TITLE
fix(audio): drain stuck queue on tab wake without replaying stale cues

### DIFF
--- a/frontend/src/__tests__/useAudioService.test.ts
+++ b/frontend/src/__tests__/useAudioService.test.ts
@@ -690,4 +690,117 @@ describe('useAudioService', () => {
     expect(mockPlaySequential).toHaveBeenCalledTimes(1)
     expect(mockPlaySequential).toHaveBeenLastCalledWith(['new_audio.mp3'])
   })
+
+  // ── Tab-wake no-side-effect recovery (PR C) ──────────────────────────────
+
+  /**
+   * Test A — "no stale replay after tab wake"
+   *
+   * Constraint (from plan): If a player resumes their phone during the game,
+   * audio cues that already played on other players' phones must NOT replay
+   * on the resumed phone.
+   *
+   * Mechanism: on visibilitychange→hidden the composable pre-dedupes every id
+   * in the current audioReplayBuffer into playedIds. When refreshState() lands
+   * the same buffer after reconnect, the audioReplayBuffer watcher's tryPlay
+   * calls are all dedup-skipped. Only ids that arrive AFTER the wake (new ids)
+   * are absent from playedIds and will play normally.
+   */
+  it('does not replay stale buffer cues after tab wake (pre-dedup on hidden)', async () => {
+    const gameStore = useGameStore()
+    setupComposable()
+
+    // 1. Populate the replay buffer with 3 cues before the composable mounts.
+    const buf = [
+      makeSequence(['seer_open_eyes.mp3'], 'seq-1'),
+      makeSequence(['witch_open_eyes.mp3'], 'seq-2'),
+      makeSequence(['guard_open_eyes.mp3'], 'seq-3'),
+    ]
+    gameStore.setState(makeState({ audioReplayBuffer: buf }))
+    await nextTick()
+
+    // 2. Trigger one live audioSequence so the composable has at least one
+    //    played id (proves the composable is active / watchers are running).
+    const liveSeq = makeSequence(['goes_dark_close_eyes.mp3'], 'seq-live-pre')
+    gameStore.setState(makeState({ audioSequence: liveSeq, audioReplayBuffer: buf }))
+    await nextTick()
+    expect(mockPlaySequential).toHaveBeenCalledWith(['goes_dark_close_eyes.mp3'])
+
+    // 3. Tab goes to background — composable should pre-dedup buffer ids.
+    mockPlaySequential.mockClear()
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    // 4. Simulate refreshState() landing after STOMP reconnect on resume.
+    //    Same 3 cues + 1 new one (seq-4). The 3 stale cues must NOT play.
+    const bufAfterResume = [
+      ...buf,
+      makeSequence(['wolf_open_eyes.mp3'], 'seq-4'),
+    ]
+    gameStore.setState(makeState({ audioReplayBuffer: bufAfterResume }))
+    await nextTick()
+
+    // 5. Tab becomes visible.
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await nextTick()
+
+    // Assert: zero new play() calls — all 3 stale cues were pre-deduped.
+    // (seq-4 is in the buffer but not in a separate audioSequence broadcast,
+    // so it also won't play here — it would only play if a live audioSequence
+    // or a new-tail-id replay watcher triggers tryPlay with seq-4.)
+    expect(mockPlaySequential).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Test B — "live cue after tab wake plays"
+   *
+   * After the tab wakes and the stale buffer is pre-deduped, a brand-new
+   * audioSequence broadcast (new id, never seen by this device) must still
+   * play normally. This proves the fix doesn't over-suppress future audio.
+   */
+  it('plays a live cue that arrives after tab wake (new id not in playedIds)', async () => {
+    const gameStore = useGameStore()
+    setupComposable()
+
+    // 1. Set up buffer with 3 stale cues.
+    const buf = [
+      makeSequence(['seer_open_eyes.mp3'], 'seq-1'),
+      makeSequence(['witch_open_eyes.mp3'], 'seq-2'),
+      makeSequence(['guard_open_eyes.mp3'], 'seq-3'),
+    ]
+    gameStore.setState(makeState({ audioReplayBuffer: buf }))
+    await nextTick()
+
+    // 2. Tab goes hidden → pre-dedup triggered.
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    // 3. Tab becomes visible again.
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+    await nextTick()
+    mockPlaySequential.mockClear()
+
+    // 4. A fresh live audioSequence arrives after wake (new id — not in playedIds).
+    const liveAfterWake = makeSequence(['wolf_howl.mp3'], 'seq-live-after-wake')
+    gameStore.setState(makeState({ audioSequence: liveAfterWake, audioReplayBuffer: buf }))
+    await nextTick()
+
+    // Assert: exactly this one cue plays — the live post-wake cue.
+    expect(mockPlaySequential).toHaveBeenCalledTimes(1)
+    expect(mockPlaySequential).toHaveBeenCalledWith(['wolf_howl.mp3'])
+  })
 })

--- a/frontend/src/__tests__/useAudioService.test.ts
+++ b/frontend/src/__tests__/useAudioService.test.ts
@@ -736,10 +736,7 @@ describe('useAudioService', () => {
 
     // 4. Simulate refreshState() landing after STOMP reconnect on resume.
     //    Same 3 cues + 1 new one (seq-4). The 3 stale cues must NOT play.
-    const bufAfterResume = [
-      ...buf,
-      makeSequence(['wolf_open_eyes.mp3'], 'seq-4'),
-    ]
+    const bufAfterResume = [...buf, makeSequence(['wolf_open_eyes.mp3'], 'seq-4')]
     gameStore.setState(makeState({ audioReplayBuffer: bufAfterResume }))
     await nextTick()
 

--- a/frontend/src/composables/useAudioService.ts
+++ b/frontend/src/composables/useAudioService.ts
@@ -123,6 +123,15 @@ export function useAudioService() {
       const tailId = buffer[buffer.length - 1]?.id ?? null
       if (tailId === lastReplayTailId) return
       lastReplayTailId = tailId
+      // If the tab was backgrounded, pre-dedup the entire incoming buffer before
+      // iterating. This suppresses any cues that accumulated during suspension —
+      // replaying them would duplicate audio other players already heard.
+      // Forward-only recovery: only live audioSequence events (new ids) play.
+      if (wasHidden) {
+        wasHidden = false
+        for (const seq of buffer) playedIds.add(seq.id)
+        return
+      }
       for (const seq of buffer) tryPlay(seq, 'replay')
     },
     { deep: true },
@@ -157,10 +166,35 @@ export function useAudioService() {
     { immediate: true },
   )
 
+  // On tab background: snapshot every id in the current audioReplayBuffer into
+  // playedIds. When the tab resumes and refreshState() delivers the same buffer
+  // (or a buffer with additional missed cues) via a STOMP reconnect's setState,
+  // the audioReplayBuffer watcher's tryPlay calls are all dedup-skipped.
+  //
+  // Constraint (from plan): "If a player resumes their phone during the game,
+  // audio cues that already played on other players' phones must NOT replay on
+  // the resumed phone." Audio recovery is forward-only: only subsequent live
+  // audioSequence STOMP events (new ids never in the buffer) play normally.
+  //
+  // wasHidden tracks a pending resume: when the next audioReplayBuffer state
+  // change arrives after wake, we pre-dedup its contents before tryPlay runs,
+  // suppressing any cues that accumulated in the buffer during suspension.
+  let wasHidden = false
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      wasHidden = true
+      // Pre-dedup the buffer as it stands now.
+      const buf = gameStore.state?.audioReplayBuffer
+      if (buf) for (const seq of buf) playedIds.add(seq.id)
+    }
+  }
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+
   /**
    * Cleanup on unmount
    */
   onUnmounted(() => {
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
     audioService.stopAll()
     audioService.stopBgm()
   })

--- a/frontend/src/services/audioService.ts
+++ b/frontend/src/services/audioService.ts
@@ -102,12 +102,24 @@ class AudioService {
       document.addEventListener(eventName, enableAudio, { capture: true })
     })
 
-    // On returning to foreground, defensively resume the audio context.
+    // On returning to foreground: resume the audio context, then drain any queue
+    // that got stuck during suspension. Do NOT replay stale narration — playing
+    // audio that other players already heard would confuse the resumed player.
+    // PR #113's stuck-queue watchdog (in playSequential) remains as the backstop.
     document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible' && this.audioContext?.state === 'suspended') {
+      if (document.visibilityState !== 'visible') return
+      if (this.audioContext?.state === 'suspended') {
         this.audioContext.resume().catch(() => {
           /* swallow */
         })
+      }
+      // Drain queue stuck from suspension. Do NOT replay — playing stale narration
+      // on a freshly-woken device duplicates what other players already heard
+      // (the action is over). Just reset state so subsequent live STOMP cues play.
+      if (this.isPlayingQueue) {
+        console.warn('[AudioService] Tab resumed with stuck queue — draining without replay')
+        this.audioQueue = []
+        this.isPlayingQueue = false
       }
     })
   }


### PR DESCRIPTION
## Background

Follow-up to PR #113 (`fix(audio): self-heal stuck playback queue when prior onended never fires`). That PR added a wall-clock watchdog as a backstop. This PR closes the deeper gap: **iOS Safari tab suspension during long idle periods**.

When the host's phone screen locks during the witch's 60+ second deliberation, iOS Safari suspends the tab — `AudioContext` suspends, in-flight `play()` calls hang, `onended` never fires, the audio queue gets stuck. When the host unlocks the phone, the existing `audioReplayBuffer` reconnect path would replay every missed cue, **duplicating narration other players already heard**.

Full root-cause analysis and design rationale: `/Users/dq/.claude/plans/structured-marinating-balloon.md`

## Hard constraint (verbatim from the user)

> **No side effect should be introduced. If a player resumes their phone during the game, audio cues that already played on other players' phones must NOT replay on the resumed phone.**

This rules out the obvious "replay the audioReplayBuffer on tab wake" recovery.

## Why we deliberately do NOT replay missed audio

Audio recovery is forward-only by design. The resumed host who slept through the witch's turn will silently miss `witch_open_eyes` / `witch_close_eyes`. The next live STOMP `audioSequence` event (a new id, never in `playedIds`) plays normally. Replaying stale cues would confuse the resumed player — the game action is already over.

## What changed

### `frontend/src/composables/useAudioService.ts`

Added a `visibilitychange` listener:
- On **hidden**: sets `wasHidden = true` and pre-dedups all current `audioReplayBuffer` ids into `playedIds`.
- The `audioReplayBuffer` watcher checks `wasHidden` on the next `setState`: if set, it snapshots all incoming buffer ids (including cues that arrived during suspension) into `playedIds` and skips `tryPlay` entirely. `wasHidden` is then cleared.

Result: stale cues in the buffer — whether from before or during suspension — are silently skipped on the reconnect's `setState`. Only fresh `audioSequence` STOMP events with new ids play.

### `frontend/src/services/audioService.ts`

Extended the existing `visibilitychange → visible` handler (line ~104) to drain a stuck queue **without triggering playback** after `audioContext.resume()`. PR #113's `playSequential`-entry watchdog remains as the backstop for the residual stuck-queue case.

### `frontend/src/__tests__/useAudioService.test.ts`

Two new regression tests:

- **"does not replay stale buffer cues after tab wake (pre-dedup on hidden)"** — proves the no-side-effect constraint: 3 stale cues + 1 newly-buffered cue are all skipped on resume. Zero `audio.play()` calls after `visibilitychange → hidden → setState → visible`.
- **"plays a live cue that arrives after tab wake (new id not in playedIds)"** — proves forward-only recovery: a fresh `audioSequence` STOMP event after wake plays normally.

## Test plan

- [x] `npx vitest run src/__tests__/useAudioService.test.ts` — 25/25 passed (2 new tests green)
- [x] Full audio suite: `npx vitest run src/__tests__/audioService.test.ts src/__tests__/useAudioService.test.ts src/__tests__/audioServiceBgm.test.ts src/__tests__/gameViewAudioEventOrder.test.ts` — 59/59 passed, 0 regressions
- [x] `npx vue-tsc --noEmit` — clean, 0 errors
- [ ] Manual: open game on iPhone Safari, be host, lock screen during witch's 60 s turn, unlock and verify next live cue plays; console should show `[AudioService] Tab resumed with stuck queue — draining without replay`

🤖 Generated with [Claude Code](https://claude.com/claude-code)