### PR TITLE
feat(timer): host-controlled optional countdown for DAY_DISCUSSION + SHERIFF SPEECH

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/controller/GameController.kt
+++ b/backend/src/main/kotlin/com/werewolf/controller/GameController.kt
@@ -6,6 +6,7 @@ import com.werewolf.game.action.GameActionDispatcher
 import com.werewolf.game.action.GameActionRequest
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.service.ActionLogService
 import com.werewolf.service.GameService
 import org.slf4j.Logger
@@ -14,6 +15,8 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 
+data class TimerStartRequest(val durationSeconds: Long)
+
 @RestController
 @RequestMapping("/api/game")
 class GameController(
@@ -21,6 +24,7 @@ class GameController(
     private val gameActionDispatcher: GameActionDispatcher,
     private val nightOrchestrator: NightOrchestrator,
     private val actionLogService: ActionLogService,
+    private val hostTimerService: HostTimerService,
 ) {
     val log: Logger = LoggerFactory.getLogger(GameController::class.java)
     @PostMapping("/start")
@@ -86,6 +90,35 @@ class GameController(
         @PathVariable gameId: Int,
         authentication: Authentication,
     ) = ResponseEntity.ok(actionLogService.getLog(gameId))
+
+    @PostMapping("/{gameId}/timer/start")
+    fun startTimer(
+        @PathVariable gameId: Int,
+        @RequestBody req: TimerStartRequest,
+        authentication: Authentication,
+    ): ResponseEntity<Map<String, Any?>> {
+        val userId = authentication.principal as String
+        return when (val result = hostTimerService.start(userId, gameId, req.durationSeconds)) {
+            is GameActionResult.Success ->
+                ResponseEntity.ok(mapOf("success" to true))
+            is GameActionResult.Rejected ->
+                ResponseEntity.badRequest().body(mapOf("success" to false, "error" to result.reason))
+        }
+    }
+
+    @PostMapping("/{gameId}/timer/stop")
+    fun stopTimer(
+        @PathVariable gameId: Int,
+        authentication: Authentication,
+    ): ResponseEntity<Map<String, Any?>> {
+        val userId = authentication.principal as String
+        return when (val result = hostTimerService.stop(userId, gameId)) {
+            is GameActionResult.Success ->
+                ResponseEntity.ok(mapOf("success" to true))
+            is GameActionResult.Rejected ->
+                ResponseEntity.badRequest().body(mapOf("success" to false, "error" to result.reason))
+        }
+    }
 
     // DEBUG ONLY: Manually advance night from WAITING to WEREWOLF_PICK
     @PostMapping("/{gameId}/debug/advance-night")

--- a/backend/src/main/kotlin/com/werewolf/game/DomainEvent.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/DomainEvent.kt
@@ -82,4 +82,12 @@ sealed class DomainEvent {
         val canPoison: Boolean? = null,
         val timeoutMs: Long
     ) : DomainEvent()
+
+    @JsonTypeName("TimerUpdated")
+    data class TimerUpdated(
+        val gameId: Int,
+        val remainingMs: Long,
+        val durationMs: Long,
+        val running: Boolean,
+    ) : DomainEvent()
 }

--- a/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
@@ -5,6 +5,7 @@ import com.werewolf.game.GameContext
 import com.werewolf.game.action.GameActionRequest
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.model.*
 import com.werewolf.repository.GamePlayerRepository
 import com.werewolf.repository.GameRepository
@@ -30,6 +31,7 @@ class GamePhasePipeline(
     private val sheriffService: SheriffService,
     private val nightOrchestrator: NightOrchestrator,
     private val actionLogService: com.werewolf.service.ActionLogService,
+    private val hostTimerService: HostTimerService,
 ) {
     val log: Logger = LoggerFactory.getLogger(GamePhasePipeline::class.java)
     // ── Phase transition actions ───────────────────────────────────────────────
@@ -101,6 +103,7 @@ class GamePhasePipeline(
             return GameActionResult.Rejected("Reveal the night result before starting the vote")
         }
 
+        hostTimerService.cancel(context.gameId)
         context.game.phase = GamePhase.DAY_VOTING
         context.game.subPhase = VotingSubPhase.VOTING.name
         gameRepository.save(context.game)

--- a/backend/src/main/kotlin/com/werewolf/game/timer/HostTimerService.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/timer/HostTimerService.kt
@@ -1,0 +1,181 @@
+package com.werewolf.game.timer
+
+import com.werewolf.game.DomainEvent
+import com.werewolf.game.action.GameActionResult
+import com.werewolf.model.*
+import com.werewolf.repository.GameRepository
+import com.werewolf.repository.SheriffElectionRepository
+import com.werewolf.service.StompPublisher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.milliseconds
+
+data class TimerSnapshot(
+    val remainingMs: Long,
+    val durationMs: Long,
+    val running: Boolean,
+)
+
+@Service
+class HostTimerService(
+    private val gameRepository: GameRepository,
+    private val sheriffElectionRepository: SheriffElectionRepository,
+    private val stompPublisher: StompPublisher,
+    private val coroutineScope: CoroutineScope,
+) {
+    private val log = LoggerFactory.getLogger(HostTimerService::class.java)
+
+    companion object {
+        const val COUNTDOWN_WARNING_FILE = "countdown_warning.mp3"
+        private val ALLOWED_DURATIONS_S = setOf(60L, 120L)
+    }
+
+    private val expirationJobs = ConcurrentHashMap<Int, Job>()
+    private val warningJobs    = ConcurrentHashMap<Int, Job>()
+
+    @Transactional
+    fun start(hostUserId: String, gameId: Int, durationSeconds: Long): GameActionResult {
+        if (durationSeconds !in ALLOWED_DURATIONS_S)
+            return GameActionResult.Rejected("durationSeconds must be 60 or 120")
+
+        val game = gameRepository.findById(gameId).orElse(null)
+            ?: return GameActionResult.Rejected("Game not found")
+        if (game.hostUserId != hostUserId)
+            return GameActionResult.Rejected("Only the host can control the timer")
+
+        if (!isPhaseAllowed(game))
+            return GameActionResult.Rejected("Timer not allowed in current phase/sub-phase")
+
+        val durationMs = durationSeconds * 1_000L
+        val startedAt  = System.currentTimeMillis()
+
+        game.timerStartedAt  = startedAt
+        game.timerDurationMs = durationMs
+        game.timerRunning    = true
+        gameRepository.save(game)
+
+        log.info("[HostTimerService] start game=$gameId duration=${durationMs}ms")
+
+        // Cancel any prior jobs
+        cancelJobs(gameId)
+
+        // Broadcast: remaining = full duration at the moment of start
+        stompPublisher.broadcastGame(gameId, DomainEvent.TimerUpdated(gameId, durationMs, durationMs, true))
+
+        // Schedule warning at T-10s (skip if duration ≤ 10s)
+        if (durationMs > 10_000L) {
+            val warningDelayMs = durationMs - 10_000L
+            warningJobs[gameId] = coroutineScope.launch {
+                delay(warningDelayMs.milliseconds)
+                broadcastWarningCue(gameId, durationMs)
+            }
+        }
+
+        // Schedule expiration
+        expirationJobs[gameId] = coroutineScope.launch {
+            delay(durationMs.milliseconds)
+            commitStop(gameId, durationMs)
+        }
+
+        return GameActionResult.Success()
+    }
+
+    @Transactional
+    fun stop(hostUserId: String, gameId: Int): GameActionResult {
+        val game = gameRepository.findById(gameId).orElse(null)
+            ?: return GameActionResult.Rejected("Game not found")
+        if (game.hostUserId != hostUserId)
+            return GameActionResult.Rejected("Only the host can control the timer")
+        if (!isPhaseAllowed(game))
+            return GameActionResult.Rejected("Timer not allowed in current phase/sub-phase")
+
+        val durationMs = game.timerDurationMs
+        log.info("[HostTimerService] stop game=$gameId")
+
+        cancelJobs(gameId)
+        game.timerRunning    = false
+        game.timerStartedAt  = null
+        gameRepository.save(game)
+
+        stompPublisher.broadcastGame(gameId, DomainEvent.TimerUpdated(gameId, 0L, durationMs, false))
+        return GameActionResult.Success()
+    }
+
+    /** Cancel any active timer for this game. No auth check — called on phase exit. */
+    fun cancel(gameId: Int) {
+        val hadJobs = expirationJobs.containsKey(gameId) || warningJobs.containsKey(gameId)
+        cancelJobs(gameId)
+
+        val game = gameRepository.findById(gameId).orElse(null) ?: return
+        val durationMs = game.timerDurationMs
+        if (game.timerRunning) {
+            game.timerRunning   = false
+            game.timerStartedAt = null
+            gameRepository.save(game)
+            log.info("[HostTimerService] cancel game=$gameId (was running)")
+            stompPublisher.broadcastGame(gameId, DomainEvent.TimerUpdated(gameId, 0L, durationMs, false))
+        } else if (hadJobs) {
+            log.info("[HostTimerService] cancel game=$gameId (jobs cleared, was not running)")
+        }
+    }
+
+    fun snapshot(gameId: Int): TimerSnapshot {
+        val game = gameRepository.findById(gameId).orElse(null)
+            ?: return TimerSnapshot(0L, 0L, false)
+        if (!game.timerRunning) return TimerSnapshot(0L, game.timerDurationMs, false)
+        val startedAt = game.timerStartedAt ?: return TimerSnapshot(0L, game.timerDurationMs, false)
+        val remaining = maxOf(0L, (startedAt + game.timerDurationMs) - System.currentTimeMillis())
+        return TimerSnapshot(remaining, game.timerDurationMs, true)
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
+
+    private fun isPhaseAllowed(game: Game): Boolean {
+        if (game.phase == GamePhase.DAY_DISCUSSION) return true
+        if (game.phase == GamePhase.SHERIFF_ELECTION) {
+            val election = sheriffElectionRepository.findByGameId(game.gameId ?: return false).orElse(null)
+                ?: return false
+            return election.subPhase == ElectionSubPhase.SPEECH
+        }
+        return false
+    }
+
+    private fun cancelJobs(gameId: Int) {
+        warningJobs.remove(gameId)?.cancel()
+        expirationJobs.remove(gameId)?.cancel()
+    }
+
+    private fun broadcastWarningCue(gameId: Int, durationMs: Long) {
+        val game = gameRepository.findById(gameId).orElse(null) ?: return
+        if (!game.timerRunning) return  // stopped before warning fired
+        val remaining = maxOf(0L, (game.timerStartedAt ?: 0L) + durationMs - System.currentTimeMillis())
+        val seq = AudioSequence(
+            id          = "timer-warning-$gameId-${game.timerStartedAt}",
+            phase       = game.phase,
+            subPhase    = game.subPhase,
+            audioFiles  = listOf(COUNTDOWN_WARNING_FILE),
+            priority    = 0,
+            timestamp   = System.currentTimeMillis(),
+        )
+        log.info("[HostTimerService] broadcasting warning cue game=$gameId remaining=${remaining}ms")
+        stompPublisher.broadcastGame(gameId, DomainEvent.AudioSequence(gameId, seq))
+    }
+
+    private fun commitStop(gameId: Int, durationMs: Long) {
+        expirationJobs.remove(gameId)
+        warningJobs.remove(gameId)?.cancel()
+        val game = gameRepository.findById(gameId).orElse(null) ?: return
+        if (!game.timerRunning) return   // already stopped externally
+        game.timerRunning   = false
+        game.timerStartedAt = null
+        gameRepository.save(game)
+        log.info("[HostTimerService] expired game=$gameId")
+        stompPublisher.broadcastGame(gameId, DomainEvent.TimerUpdated(gameId, 0L, durationMs, false))
+    }
+}

--- a/backend/src/main/kotlin/com/werewolf/game/voting/VotingPipeline.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/voting/VotingPipeline.kt
@@ -9,6 +9,7 @@ import com.werewolf.game.phase.HardModeCounterplay
 import com.werewolf.game.phase.WinCheckTrigger
 import com.werewolf.game.phase.WinConditionChecker
 import com.werewolf.game.role.RoleHandler
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.model.*
 import com.werewolf.repository.EliminationHistoryRepository
 import com.werewolf.repository.GamePlayerRepository
@@ -35,6 +36,7 @@ class VotingPipeline(
     private val contextLoader: GameContextLoader,
     private val nightOrchestrator: NightOrchestrator,
     private val actionLogService: ActionLogService,
+    private val hostTimerService: HostTimerService,
 ) {
     private val log = LoggerFactory.getLogger(VotingPipeline::class.java)
 
@@ -181,6 +183,7 @@ class VotingPipeline(
                 return GameActionResult.Rejected("Voting was not skipped — cannot advance to night from DAY_DISCUSSION")
             if (context.game.subPhase !in setOf(DaySubPhase.RESULT_HIDDEN.name, DaySubPhase.RESULT_REVEALED.name))
                 return GameActionResult.Rejected("Not in a day discussion sub-phase")
+            hostTimerService.cancel(context.gameId)
             goToNight(context)
             return GameActionResult.Success()
         }

--- a/backend/src/main/kotlin/com/werewolf/model/Game.kt
+++ b/backend/src/main/kotlin/com/werewolf/model/Game.kt
@@ -46,6 +46,15 @@ class Game(
 
     @Column(name = "day_skip_voting", nullable = false)
     var daySkipVoting: Boolean = false,
+
+    @Column(name = "timer_started_at")
+    var timerStartedAt: Long? = null,
+
+    @Column(name = "timer_duration_ms", nullable = false)
+    var timerDurationMs: Long = 0,
+
+    @Column(name = "timer_running", nullable = false)
+    var timerRunning: Boolean = false,
 ) {
     init {
         require(roomId > 0) { "roomId must be a valid ID, got $roomId" }

--- a/backend/src/main/kotlin/com/werewolf/service/GameService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/GameService.kt
@@ -4,6 +4,7 @@ import com.werewolf.audio.AudioReplayCache
 import com.werewolf.game.DomainEvent
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.game.voting.TallyCalculator
 import com.werewolf.model.*
 import com.werewolf.repository.*
@@ -26,6 +27,7 @@ class GameService(
     private val voteRepository: VoteRepository,
     private val eliminationHistoryRepository: EliminationHistoryRepository,
     private val audioReplayCache: AudioReplayCache,
+    private val hostTimerService: HostTimerService,
 ) {
     @Transactional
     fun startGame(hostUserId: String, roomId: Int): GameActionResult {
@@ -308,9 +310,15 @@ class GameService(
             )
         } else null
 
+        val timerSnapshot = hostTimerService.snapshot(gameId)
         return mapOf(
             "gameId" to gameId,
             "hostId" to game.hostUserId,
+            "timer" to mapOf(
+                "remainingMs" to timerSnapshot.remainingMs,
+                "durationMs"  to timerSnapshot.durationMs,
+                "running"     to timerSnapshot.running,
+            ),
             "phase" to game.phase.name,
             "subPhase" to game.subPhase,
             "dayNumber" to game.dayNumber,

--- a/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/SheriffService.kt
@@ -5,6 +5,7 @@ import com.werewolf.game.GameContext
 import com.werewolf.game.action.GameActionRequest
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.config.GameTimingProperties
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import kotlinx.coroutines.CoroutineScope
@@ -29,6 +30,7 @@ class SheriffService(
     private val coroutineScope: CoroutineScope,
     private val timingProperties: GameTimingProperties,
     private val actionLogService: ActionLogService,
+    private val hostTimerService: HostTimerService,
 ) {
     val log = LoggerFactory.getLogger(SheriffService::class.java)
     private val scheduledJobs = mutableMapOf<Int, Job>()
@@ -312,6 +314,9 @@ class SheriffService(
         if (election.subPhase != ElectionSubPhase.SPEECH)
             return GameActionResult.Rejected("Not in SPEECH sub-phase")
 
+        // Cancel any running timer for the departing candidate before advancing
+        hostTimerService.cancel(context.gameId)
+
         val order = election.speakingOrder?.split(",") ?: emptyList()
         val candidates = sheriffCandidateRepository.findByElectionId(election.id ?: error("Election has no ID"))
         val candidateStatusMap = candidates.associateBy { it.userId }.mapValues { it.value.status }
@@ -478,6 +483,7 @@ class SheriffService(
         val allCandidates = sheriffCandidateRepository.findByElectionId(election.id)
         val anyRunningLeft = allCandidates.any { it.status == CandidateStatus.RUNNING && speakingOrderIds.contains(it.userId) }
         if (!anyRunningLeft) {
+            hostTimerService.cancel(context.gameId)
             // No running candidates remain — mirrors startSpeech's empty-candidates
             // branch: advance straight to DAY_DISCUSSION/RESULT_HIDDEN instead of
             // landing on SHERIFF_ELECTION/RESULT. The RESULT screen would show an

--- a/backend/src/main/resources/db/migration/V13__add_timer_columns.sql
+++ b/backend/src/main/resources/db/migration/V13__add_timer_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE games
+  ADD COLUMN timer_started_at   BIGINT,
+  ADD COLUMN timer_duration_ms  BIGINT  NOT NULL DEFAULT 0,
+  ADD COLUMN timer_running      BOOLEAN NOT NULL DEFAULT false;

--- a/backend/src/test/kotlin/com/werewolf/integration/DayPhaseResultRevealTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/DayPhaseResultRevealTest.kt
@@ -2,6 +2,8 @@ package com.werewolf.integration
 
 import com.werewolf.audio.AudioReplayCache
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
+import com.werewolf.game.timer.TimerSnapshot
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.GameService
@@ -22,6 +24,7 @@ import java.util.*
  * Verifies that when the host reveals night results, the correct death information is displayed.
  */
 @ExtendWith(MockitoExtension::class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
 class DayPhaseResultRevealTest {
 
     @Mock lateinit var gameRepository: GameRepository
@@ -36,6 +39,7 @@ class DayPhaseResultRevealTest {
     @Mock lateinit var nightOrchestrator: NightOrchestrator
     @Mock lateinit var sheriffService: SheriffService
     @Mock lateinit var audioReplayCache: AudioReplayCache
+    @Mock lateinit var hostTimerService: HostTimerService
 
     private lateinit var gameService: GameService
 
@@ -60,7 +64,10 @@ class DayPhaseResultRevealTest {
             voteRepository = voteRepository,
             eliminationHistoryRepository = eliminationHistoryRepository,
             audioReplayCache = audioReplayCache,
+            hostTimerService = hostTimerService,
         )
+        whenever(hostTimerService.snapshot(any())).thenReturn(TimerSnapshot(0L, 0L, false))
+        whenever(roomPlayerRepository.findByRoomId(any())).thenReturn(emptyList())
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────

--- a/backend/src/test/kotlin/com/werewolf/unit/role/HookInvocationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/role/HookInvocationTest.kt
@@ -8,6 +8,7 @@ import com.werewolf.game.night.NightOrchestrator
 import com.werewolf.game.phase.WinConditionChecker
 import com.werewolf.game.role.EliminationModifier
 import com.werewolf.game.role.RoleHandler
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.game.voting.VotingPipeline
 import com.werewolf.model.*
 import com.werewolf.repository.*
@@ -34,6 +35,7 @@ class HookInvocationTest {
     @Mock lateinit var contextLoader: GameContextLoader
     @Mock lateinit var audioService: com.werewolf.service.AudioService
     @Mock lateinit var nightOrchestrator: NightOrchestrator
+    @Mock lateinit var hostTimerService: HostTimerService
 
     private val gameId = 1
     private val hostId = "host:001"
@@ -115,6 +117,7 @@ class HookInvocationTest {
         contextLoader = contextLoader,
         nightOrchestrator = nightOrchestrator,
         actionLogService = mock(),
+        hostTimerService = hostTimerService,
     )
 
     // ── onDayEnter ───────────────────────────────────────────────────────────

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameControllerTimerTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameControllerTimerTest.kt
@@ -1,0 +1,106 @@
+package com.werewolf.unit.service
+
+import com.werewolf.controller.GameController
+import com.werewolf.controller.TimerStartRequest
+import com.werewolf.game.action.GameActionDispatcher
+import com.werewolf.game.action.GameActionResult
+import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
+import com.werewolf.service.ActionLogService
+import com.werewolf.service.GameService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
+
+@ExtendWith(MockitoExtension::class)
+class GameControllerTimerTest {
+
+    @Mock lateinit var gameService: GameService
+    @Mock lateinit var gameActionDispatcher: GameActionDispatcher
+    @Mock lateinit var nightOrchestrator: NightOrchestrator
+    @Mock lateinit var actionLogService: ActionLogService
+    @Mock lateinit var hostTimerService: HostTimerService
+    @Mock lateinit var authentication: Authentication
+
+    private lateinit var controller: GameController
+
+    private val gameId = 1
+    private val hostId = "host:001"
+    private val guestId = "guest:001"
+
+    @BeforeEach
+    fun setUp() {
+        controller = GameController(
+            gameService, gameActionDispatcher, nightOrchestrator,
+            actionLogService, hostTimerService,
+        )
+        whenever(authentication.principal).thenReturn(hostId)
+    }
+
+    // ── startTimer ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `startTimer returns 200 for host during DAY_DISCUSSION`() {
+        whenever(hostTimerService.start(hostId, gameId, 60L)).thenReturn(GameActionResult.Success())
+        val response = controller.startTimer(gameId, TimerStartRequest(60L), authentication)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `startTimer returns 200 for host during SHERIFF_ELECTION SPEECH`() {
+        whenever(hostTimerService.start(hostId, gameId, 120L)).thenReturn(GameActionResult.Success())
+        val response = controller.startTimer(gameId, TimerStartRequest(120L), authentication)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `startTimer returns 400 for host during disallowed phase`() {
+        whenever(hostTimerService.start(hostId, gameId, 60L))
+            .thenReturn(GameActionResult.Rejected("Timer not allowed in current phase/sub-phase"))
+        val response = controller.startTimer(gameId, TimerStartRequest(60L), authentication)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    @Test
+    fun `startTimer returns 400 for invalid duration`() {
+        whenever(hostTimerService.start(hostId, gameId, 30L))
+            .thenReturn(GameActionResult.Rejected("durationSeconds must be 60 or 120"))
+        val response = controller.startTimer(gameId, TimerStartRequest(30L), authentication)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    @Test
+    fun `startTimer returns 400 for non-host`() {
+        whenever(authentication.principal).thenReturn(guestId)
+        whenever(hostTimerService.start(guestId, gameId, 60L))
+            .thenReturn(GameActionResult.Rejected("Only the host can control the timer"))
+        val response = controller.startTimer(gameId, TimerStartRequest(60L), authentication)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    // ── stopTimer ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `stopTimer returns 200 for host`() {
+        whenever(hostTimerService.stop(hostId, gameId)).thenReturn(GameActionResult.Success())
+        val response = controller.stopTimer(gameId, authentication)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `stopTimer returns 400 for non-host`() {
+        whenever(authentication.principal).thenReturn(guestId)
+        whenever(hostTimerService.stop(guestId, gameId))
+            .thenReturn(GameActionResult.Rejected("Only the host can control the timer"))
+        val response = controller.stopTimer(gameId, authentication)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+}

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GamePhasePipelineDayTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GamePhasePipelineDayTest.kt
@@ -5,6 +5,7 @@ import com.werewolf.game.action.GameActionRequest
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.game.night.NightOrchestrator
 import com.werewolf.game.phase.GamePhasePipeline
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.model.*
 import com.werewolf.repository.GamePlayerRepository
 import com.werewolf.repository.GameRepository
@@ -37,6 +38,7 @@ class GamePhasePipelineDayTest {
     @Mock lateinit var sheriffService: SheriffService
     @Mock lateinit var nightOrchestrator: NightOrchestrator
     @Mock lateinit var actionLogService: ActionLogService
+    @Mock lateinit var hostTimerService: HostTimerService
     @InjectMocks lateinit var pipeline: GamePhasePipeline
 
     private val gameId = 10

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
@@ -5,6 +5,7 @@ import com.werewolf.game.action.GameActionRequest
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.game.night.NightOrchestrator
 import com.werewolf.game.phase.GamePhasePipeline
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.ActionLogService
@@ -44,6 +45,7 @@ class GamePipelineSheriffTest {
     @Mock lateinit var sheriffService: SheriffService
     @Mock lateinit var nightOrchestrator: NightOrchestrator
     @Mock lateinit var actionLogService: ActionLogService
+    @Mock lateinit var hostTimerService: HostTimerService
     @InjectMocks lateinit var pipeline: GamePhasePipeline
 
     private val gameId = 10

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceDayPhaseTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceDayPhaseTest.kt
@@ -2,6 +2,8 @@ package com.werewolf.unit.service
 
 import com.werewolf.audio.AudioReplayCache
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
+import com.werewolf.game.timer.TimerSnapshot
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.AudioService
@@ -36,6 +38,7 @@ class GameServiceDayPhaseTest {
     @Mock lateinit var voteRepository: VoteRepository
     @Mock lateinit var eliminationHistoryRepository: EliminationHistoryRepository
     @Mock lateinit var audioReplayCache: AudioReplayCache
+    @Mock lateinit var hostTimerService: HostTimerService
     @InjectMocks lateinit var gameService: GameService
 
     private val gameId = 1
@@ -71,6 +74,7 @@ class GameServiceDayPhaseTest {
     @BeforeEach
     fun setupCommon() {
         whenever(roomRepository.findById(1)).thenReturn(Optional.of(room()))
+        whenever(hostTimerService.snapshot(any())).thenReturn(TimerSnapshot(0L, 0L, false))
     }
 
     private fun setupGameAndPlayers(game: Game, players: List<GamePlayer>, users: List<User>) {

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceNightPhaseTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceNightPhaseTest.kt
@@ -2,6 +2,8 @@ package com.werewolf.unit.service
 
 import com.werewolf.audio.AudioReplayCache
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
+import com.werewolf.game.timer.TimerSnapshot
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.GameService
@@ -37,6 +39,7 @@ class GameServiceNightPhaseTest {
     @Mock lateinit var voteRepository: VoteRepository
     @Mock lateinit var eliminationHistoryRepository: EliminationHistoryRepository
     @Mock lateinit var audioReplayCache: AudioReplayCache
+    @Mock lateinit var hostTimerService: HostTimerService
     @InjectMocks lateinit var gameService: GameService
 
     private val gameId = 1
@@ -78,6 +81,7 @@ class GameServiceNightPhaseTest {
     @BeforeEach
     fun setupCommon() {
         whenever(roomRepository.findById(1)).thenReturn(Optional.of(room()))
+        whenever(hostTimerService.snapshot(any())).thenReturn(TimerSnapshot(0L, 0L, false))
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameServicePlayerProjectionTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameServicePlayerProjectionTest.kt
@@ -2,12 +2,15 @@ package com.werewolf.unit.service
 
 import com.werewolf.audio.AudioReplayCache
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
+import com.werewolf.game.timer.TimerSnapshot
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.GameService
 import com.werewolf.service.SheriffService
 import com.werewolf.service.StompPublisher
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -25,6 +28,7 @@ import java.util.*
  * the OAuth login → User row → RoomPlayer override.
  */
 @ExtendWith(MockitoExtension::class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
 @Suppress("UNCHECKED_CAST")
 class GameServicePlayerProjectionTest {
 
@@ -40,6 +44,7 @@ class GameServicePlayerProjectionTest {
     @Mock lateinit var voteRepository: VoteRepository
     @Mock lateinit var eliminationHistoryRepository: EliminationHistoryRepository
     @Mock lateinit var audioReplayCache: AudioReplayCache
+    @Mock lateinit var hostTimerService: HostTimerService
     @InjectMocks lateinit var gameService: GameService
 
     private val gameId = 1
@@ -62,6 +67,11 @@ class GameServicePlayerProjectionTest {
 
     private fun roomPlayer(userId: String, displayName: String?) =
         RoomPlayer(roomId = roomId, userId = userId, displayName = displayName)
+
+    @BeforeEach
+    fun setupCommon() {
+        whenever(hostTimerService.snapshot(any())).thenReturn(TimerSnapshot(0L, 0L, false))
+    }
 
     @Test
     fun `getGameState includes avatar URL on every player from User_avatarUrl`() {

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceStartTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceStartTest.kt
@@ -3,6 +3,7 @@ package com.werewolf.unit.service
 import com.werewolf.audio.AudioReplayCache
 import com.werewolf.game.action.GameActionResult
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.GameService
@@ -32,6 +33,7 @@ class GameServiceStartTest {
     @Mock lateinit var voteRepository: VoteRepository
     @Mock lateinit var eliminationHistoryRepository: EliminationHistoryRepository
     @Mock lateinit var audioReplayCache: AudioReplayCache
+    @Mock lateinit var hostTimerService: HostTimerService
     @InjectMocks lateinit var gameService: GameService
 
     private val hostId = "host:001"

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceStateTimerTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceStateTimerTest.kt
@@ -1,0 +1,112 @@
+package com.werewolf.unit.service
+
+import com.werewolf.audio.AudioReplayCache
+import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
+import com.werewolf.game.timer.TimerSnapshot
+import com.werewolf.model.*
+import com.werewolf.repository.*
+import com.werewolf.service.GameService
+import com.werewolf.service.SheriffService
+import com.werewolf.service.StompPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+class GameServiceStateTimerTest {
+
+    @Mock lateinit var gameRepository: GameRepository
+    @Mock lateinit var roomRepository: RoomRepository
+    @Mock lateinit var roomPlayerRepository: RoomPlayerRepository
+    @Mock lateinit var gamePlayerRepository: GamePlayerRepository
+    @Mock lateinit var stompPublisher: StompPublisher
+    @Mock lateinit var nightOrchestrator: NightOrchestrator
+    @Mock lateinit var userRepository: UserRepository
+    @Mock lateinit var sheriffService: SheriffService
+    @Mock lateinit var nightPhaseRepository: NightPhaseRepository
+    @Mock lateinit var voteRepository: VoteRepository
+    @Mock lateinit var eliminationHistoryRepository: EliminationHistoryRepository
+    @Mock lateinit var audioReplayCache: AudioReplayCache
+    @Mock lateinit var hostTimerService: HostTimerService
+
+    private lateinit var gameService: GameService
+
+    private val gameId = 1
+    private val hostId = "host:001"
+    private val day = 1
+
+    @BeforeEach
+    fun setUp() {
+        gameService = GameService(
+            gameRepository, roomRepository, roomPlayerRepository, gamePlayerRepository,
+            stompPublisher, nightOrchestrator, userRepository, sheriffService,
+            nightPhaseRepository, voteRepository, eliminationHistoryRepository,
+            audioReplayCache, hostTimerService,
+        )
+    }
+
+    private fun game() = Game(roomId = 1, hostUserId = hostId).also { g ->
+        val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(g, gameId)
+        g.phase = GamePhase.DAY_DISCUSSION
+        g.subPhase = DaySubPhase.RESULT_HIDDEN.name
+        g.dayNumber = day
+    }
+
+    private fun room() = Room(roomCode = "ABCD", hostUserId = hostId, totalPlayers = 4, hasSheriff = false)
+    private fun player(userId: String, seat: Int) =
+        GamePlayer(gameId = gameId, userId = userId, seatIndex = seat, role = PlayerRole.VILLAGER)
+    private fun user(userId: String, nick: String) = User(userId = userId, nickname = nick)
+
+    @Test
+    fun `getGameState includes timer field with remainingMs, durationMs, running`() {
+        val players = listOf(player(hostId, 0))
+        val users = listOf(user(hostId, "Host"))
+        whenever(gameRepository.findById(gameId)).thenReturn(Optional.of(game()))
+        whenever(roomRepository.findById(1)).thenReturn(Optional.of(room()))
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(players)
+        whenever(userRepository.findAllById(players.map { it.userId })).thenReturn(users)
+        whenever(roomPlayerRepository.findByRoomId(1)).thenReturn(emptyList())
+        whenever(audioReplayCache.getLatest(gameId)).thenReturn(null)
+        whenever(audioReplayCache.snapshot(gameId)).thenReturn(emptyList())
+        whenever(hostTimerService.snapshot(gameId)).thenReturn(TimerSnapshot(0L, 0L, false))
+
+        val result = gameService.getGameState(gameId, hostId)
+
+        @Suppress("UNCHECKED_CAST")
+        val timer = result["timer"] as Map<String, Any?>
+        assertThat(timer).containsKey("remainingMs")
+        assertThat(timer).containsKey("durationMs")
+        assertThat(timer).containsKey("running")
+        assertThat(timer["running"]).isEqualTo(false)
+    }
+
+    @Test
+    fun `getGameState returns freshly-decremented remainingMs from snapshot`() {
+        val players = listOf(player(hostId, 0))
+        val users = listOf(user(hostId, "Host"))
+        whenever(gameRepository.findById(gameId)).thenReturn(Optional.of(game()))
+        whenever(roomRepository.findById(1)).thenReturn(Optional.of(room()))
+        whenever(gamePlayerRepository.findByGameId(gameId)).thenReturn(players)
+        whenever(userRepository.findAllById(players.map { it.userId })).thenReturn(users)
+        whenever(roomPlayerRepository.findByRoomId(1)).thenReturn(emptyList())
+        whenever(audioReplayCache.getLatest(gameId)).thenReturn(null)
+        whenever(audioReplayCache.snapshot(gameId)).thenReturn(emptyList())
+        // Simulate 5 seconds elapsed on a 60s timer
+        whenever(hostTimerService.snapshot(gameId)).thenReturn(TimerSnapshot(55_000L, 60_000L, true))
+
+        val result = gameService.getGameState(gameId, hostId)
+
+        @Suppress("UNCHECKED_CAST")
+        val timer = result["timer"] as Map<String, Any?>
+        assertThat(timer["remainingMs"]).isEqualTo(55_000L)
+        assertThat(timer["durationMs"]).isEqualTo(60_000L)
+        assertThat(timer["running"]).isEqualTo(true)
+    }
+}

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceVotingPhaseTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GameServiceVotingPhaseTest.kt
@@ -2,6 +2,8 @@ package com.werewolf.unit.service
 
 import com.werewolf.audio.AudioReplayCache
 import com.werewolf.game.night.NightOrchestrator
+import com.werewolf.game.timer.HostTimerService
+import com.werewolf.game.timer.TimerSnapshot
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.GameService
@@ -14,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import java.util.*
 
@@ -33,6 +36,7 @@ class GameServiceVotingPhaseTest {
     @Mock lateinit var voteRepository: VoteRepository
     @Mock lateinit var eliminationHistoryRepository: EliminationHistoryRepository
     @Mock lateinit var audioReplayCache: AudioReplayCache
+    @Mock lateinit var hostTimerService: HostTimerService
     @InjectMocks lateinit var gameService: GameService
 
     private val gameId = 1
@@ -57,6 +61,7 @@ class GameServiceVotingPhaseTest {
     @BeforeEach
     fun setupCommon() {
         whenever(roomRepository.findById(1)).thenReturn(Optional.of(room()))
+        whenever(hostTimerService.snapshot(any())).thenReturn(TimerSnapshot(0L, 0L, false))
     }
 
     private fun setupGameAndPlayers(game: Game, players: List<GamePlayer>, users: List<User>) {

--- a/backend/src/test/kotlin/com/werewolf/unit/service/HostTimerServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/HostTimerServiceTest.kt
@@ -1,0 +1,282 @@
+package com.werewolf.unit.service
+
+import com.werewolf.game.DomainEvent
+import com.werewolf.game.action.GameActionResult
+import com.werewolf.game.timer.HostTimerService
+import com.werewolf.model.*
+import com.werewolf.repository.GameRepository
+import com.werewolf.repository.SheriffElectionRepository
+import com.werewolf.service.StompPublisher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.*
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+class HostTimerServiceTest {
+
+    @Mock lateinit var gameRepository: GameRepository
+    @Mock lateinit var sheriffElectionRepository: SheriffElectionRepository
+    @Mock lateinit var stompPublisher: StompPublisher
+
+    private lateinit var service: HostTimerService
+
+    private val gameId = 1
+    private val hostId = "host:001"
+    private val guestId = "guest:001"
+
+    @BeforeEach
+    fun setUp() {
+        service = HostTimerService(
+            gameRepository,
+            sheriffElectionRepository,
+            stompPublisher,
+            CoroutineScope(Dispatchers.Default),
+        )
+    }
+
+    private fun game(
+        phase: GamePhase = GamePhase.DAY_DISCUSSION,
+        running: Boolean = false,
+        durationMs: Long = 0,
+    ): Game {
+        val g = Game(roomId = 1, hostUserId = hostId)
+        val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(g, gameId)
+        g.phase = phase
+        g.timerRunning = running
+        g.timerDurationMs = durationMs
+        return g
+    }
+
+    private fun mockGame(g: Game) {
+        whenever(gameRepository.findById(gameId)).thenReturn(Optional.of(g))
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+    }
+
+    private fun mockSheriffElection(subPhase: ElectionSubPhase) {
+        val election = SheriffElection(gameId = gameId, subPhase = subPhase)
+        whenever(sheriffElectionRepository.findByGameId(gameId)).thenReturn(Optional.of(election))
+    }
+
+    // ── Phase guard ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `start - rejected when phase is DAY_VOTING`() {
+        val g = game(phase = GamePhase.DAY_VOTING)
+        mockGame(g)
+        val result = service.start(hostId, gameId, 60L)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+        verify(stompPublisher, never()).broadcastGame(any(), any())
+    }
+
+    @Test
+    fun `start - rejected when phase is NIGHT`() {
+        val g = game(phase = GamePhase.NIGHT)
+        mockGame(g)
+        val result = service.start(hostId, gameId, 60L)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+    }
+
+    @Test
+    fun `start - rejected during SHERIFF_ELECTION SIGNUP sub-phase`() {
+        val g = game(phase = GamePhase.SHERIFF_ELECTION)
+        mockGame(g)
+        mockSheriffElection(ElectionSubPhase.SIGNUP)
+        val result = service.start(hostId, gameId, 60L)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+    }
+
+    @Test
+    fun `start - rejected during SHERIFF_ELECTION VOTING sub-phase`() {
+        val g = game(phase = GamePhase.SHERIFF_ELECTION)
+        mockGame(g)
+        mockSheriffElection(ElectionSubPhase.VOTING)
+        val result = service.start(hostId, gameId, 60L)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+    }
+
+    @Test
+    fun `start - rejected during SHERIFF_ELECTION RESULT sub-phase`() {
+        val g = game(phase = GamePhase.SHERIFF_ELECTION)
+        mockGame(g)
+        mockSheriffElection(ElectionSubPhase.RESULT)
+        val result = service.start(hostId, gameId, 60L)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+    }
+
+    @Test
+    fun `start - accepted during DAY_DISCUSSION`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION)
+        mockGame(g)
+        val result = service.start(hostId, gameId, 60L)
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+    }
+
+    @Test
+    fun `start - accepted during SHERIFF_ELECTION SPEECH sub-phase`() {
+        val g = game(phase = GamePhase.SHERIFF_ELECTION)
+        mockGame(g)
+        mockSheriffElection(ElectionSubPhase.SPEECH)
+        val result = service.start(hostId, gameId, 60L)
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+    }
+
+    // ── Auth guard ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `start - rejected when caller is not host`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION)
+        mockGame(g)
+        val result = service.start(guestId, gameId, 60L)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+        assertThat((result as GameActionResult.Rejected).reason).contains("host")
+    }
+
+    // ── Duration validation ────────────────────────────────────────────────────
+
+    @Test
+    fun `start - rejected for invalid duration 30s`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION)
+        mockGame(g)
+        val result = service.start(hostId, gameId, 30L)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+    }
+
+    @Test
+    fun `start - rejected for invalid duration 0s`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION)
+        mockGame(g)
+        val result = service.start(hostId, gameId, 0L)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+    }
+
+    // ── State write + broadcast ────────────────────────────────────────────────
+
+    @Test
+    fun `start - writes timerRunning=true and broadcasts TimerUpdated(running=true)`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION)
+        mockGame(g)
+        service.start(hostId, gameId, 60L)
+
+        val savedCaptor = argumentCaptor<Game>()
+        verify(gameRepository).save(savedCaptor.capture())
+        assertThat(savedCaptor.firstValue.timerRunning).isTrue()
+        assertThat(savedCaptor.firstValue.timerDurationMs).isEqualTo(60_000L)
+        assertThat(savedCaptor.firstValue.timerStartedAt).isNotNull()
+
+        val eventCaptor = argumentCaptor<Any>()
+        verify(stompPublisher, atLeastOnce()).broadcastGame(eq(gameId), eventCaptor.capture())
+        val timerEvent = eventCaptor.allValues.filterIsInstance<DomainEvent.TimerUpdated>().first()
+        assertThat(timerEvent.running).isTrue()
+        assertThat(timerEvent.durationMs).isEqualTo(60_000L)
+        assertThat(timerEvent.remainingMs).isEqualTo(60_000L)
+    }
+
+    // ── Stop ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `stop - broadcasts TimerUpdated(running=false) and no AudioSequence`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION, running = true, durationMs = 60_000L)
+        g.timerStartedAt = System.currentTimeMillis()
+        mockGame(g)
+        val result = service.stop(hostId, gameId)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+
+        val eventCaptor = argumentCaptor<Any>()
+        verify(stompPublisher).broadcastGame(eq(gameId), eventCaptor.capture())
+        val timerEvent = eventCaptor.firstValue as DomainEvent.TimerUpdated
+        assertThat(timerEvent.running).isFalse()
+
+        // No AudioSequence must be broadcast on stop
+        assertThat(eventCaptor.allValues.none { it is DomainEvent.AudioSequence }).isTrue()
+    }
+
+    // ── Cancel ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `cancel - broadcasts TimerUpdated(running=false) when timer was running`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION, running = true, durationMs = 60_000L)
+        g.timerStartedAt = System.currentTimeMillis()
+        mockGame(g)
+
+        service.cancel(gameId)
+
+        val eventCaptor = argumentCaptor<Any>()
+        verify(stompPublisher).broadcastGame(eq(gameId), eventCaptor.capture())
+        val timerEvent = eventCaptor.firstValue as DomainEvent.TimerUpdated
+        assertThat(timerEvent.running).isFalse()
+        // No AudioSequence on cancel
+        assertThat(eventCaptor.allValues.none { it is DomainEvent.AudioSequence }).isTrue()
+    }
+
+    @Test
+    fun `cancel - no broadcast when timer was not running`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION, running = false, durationMs = 0L)
+        mockGame(g)
+        service.cancel(gameId)
+        verify(stompPublisher, never()).broadcastGame(any(), any())
+    }
+
+    // ── Snapshot ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `snapshot - returns running=true and decremented remainingMs when timer active`() {
+        val durationMs = 60_000L
+        val g = game(phase = GamePhase.DAY_DISCUSSION, running = true, durationMs = durationMs)
+        g.timerStartedAt = System.currentTimeMillis() - 5_000L  // 5 seconds elapsed
+        whenever(gameRepository.findById(gameId)).thenReturn(Optional.of(g))
+
+        val snap = service.snapshot(gameId)
+
+        assertThat(snap.running).isTrue()
+        assertThat(snap.remainingMs).isBetween(54_000L, 56_000L)
+        assertThat(snap.durationMs).isEqualTo(durationMs)
+    }
+
+    @Test
+    fun `snapshot - returns running=false and remainingMs=0 when not running`() {
+        val g = game(phase = GamePhase.DAY_DISCUSSION, running = false, durationMs = 60_000L)
+        whenever(gameRepository.findById(gameId)).thenReturn(Optional.of(g))
+
+        val snap = service.snapshot(gameId)
+
+        assertThat(snap.running).isFalse()
+        assertThat(snap.remainingMs).isEqualTo(0L)
+    }
+
+    // ── Concurrent re-start cancels prior jobs ─────────────────────────────────
+
+    @Test
+    fun `start - re-starting does not leave orphan jobs`() = runBlocking {
+        val g = game(phase = GamePhase.DAY_DISCUSSION)
+        mockGame(g)
+
+        // Start a 120s timer
+        service.start(hostId, gameId, 120L)
+        // Immediately start a 60s timer — must cancel the 120s jobs
+        service.start(hostId, gameId, 60L)
+
+        // Stop it immediately so no jobs linger past test teardown
+        val runningGame = game(phase = GamePhase.DAY_DISCUSSION, running = true, durationMs = 60_000L)
+        runningGame.timerStartedAt = System.currentTimeMillis()
+        whenever(gameRepository.findById(gameId)).thenReturn(Optional.of(runningGame))
+        service.stop(hostId, gameId)
+
+        val eventCaptor = argumentCaptor<Any>()
+        verify(stompPublisher, atLeast(3)).broadcastGame(eq(gameId), eventCaptor.capture())
+        // The last TimerUpdated event must be running=false (from stop)
+        val lastTimer = eventCaptor.allValues
+            .filterIsInstance<DomainEvent.TimerUpdated>()
+            .last()
+        assertThat(lastTimer.running).isFalse()
+    }
+}

--- a/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/SheriffServiceTest.kt
@@ -5,6 +5,7 @@ import com.werewolf.game.GameContext
 import com.werewolf.game.action.GameActionRequest
 import com.werewolf.config.GameTimingProperties
 import com.werewolf.game.action.GameActionResult
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.model.*
 import com.werewolf.repository.*
 import com.werewolf.service.ActionLogService
@@ -33,6 +34,7 @@ class SheriffServiceTest {
     @Mock lateinit var userRepository: UserRepository
     @Mock lateinit var stompPublisher: StompPublisher
     @Mock lateinit var actionLogService: ActionLogService
+    @Mock lateinit var hostTimerService: HostTimerService
     private lateinit var sheriffService: SheriffService
 
     @BeforeEach
@@ -43,6 +45,7 @@ class SheriffServiceTest {
             stompPublisher, CoroutineScope(Dispatchers.Default),
             GameTimingProperties(),
             actionLogService,
+            hostTimerService,
         )
     }
 
@@ -1239,5 +1242,68 @@ class SheriffServiceTest {
         val phaseChanged = captor.firstValue as DomainEvent.PhaseChanged
         assertThat(phaseChanged.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
         assertThat(phaseChanged.subPhase).isEqualTo(DaySubPhase.RESULT_HIDDEN.name)
+    }
+
+    // ── Timer cancel hooks ─────────────────────────────────────────────────────
+
+    @Test
+    fun `advanceSpeech - cancels timer before advancing to next candidate`() {
+        val order = "$hostId,$guestId"
+        val ctx = context(
+            election = election(subPhase = ElectionSubPhase.SPEECH, speakingOrder = order, currentSpeakerIdx = 0),
+            players = listOf(player(hostId), player(guestId)),
+        )
+        val candidateHost = SheriffCandidate(electionId = electionId, userId = hostId, status = CandidateStatus.RUNNING)
+        val candidateGuest = SheriffCandidate(electionId = electionId, userId = guestId, status = CandidateStatus.RUNNING)
+        whenever(sheriffCandidateRepository.findByElectionId(electionId)).thenReturn(listOf(candidateHost, candidateGuest))
+        whenever(sheriffElectionRepository.save(any<SheriffElection>())).thenAnswer { it.arguments[0] }
+
+        val req = GameActionRequest(gameId, hostId, ActionType.SHERIFF_ADVANCE_SPEECH)
+        sheriffService.handle(req, ctx)
+
+        // hostTimerService.cancel must have been called
+        verify(hostTimerService).cancel(gameId)
+    }
+
+    @Test
+    fun `advanceSpeech - cancels timer when transitioning to VOTING (all spoke)`() {
+        val order = "$guestId"
+        val ctx = context(
+            election = election(subPhase = ElectionSubPhase.SPEECH, speakingOrder = order, currentSpeakerIdx = 0),
+            players = listOf(player(hostId), player(guestId)),
+        )
+        val candidate = SheriffCandidate(electionId = electionId, userId = guestId, status = CandidateStatus.RUNNING)
+        whenever(sheriffCandidateRepository.findByElectionId(electionId)).thenReturn(listOf(candidate))
+        whenever(sheriffElectionRepository.save(any<SheriffElection>())).thenAnswer { it.arguments[0] }
+
+        val req = GameActionRequest(gameId, hostId, ActionType.SHERIFF_ADVANCE_SPEECH)
+        sheriffService.handle(req, ctx)
+
+        verify(hostTimerService).cancel(gameId)
+
+        val eventCaptor = argumentCaptor<DomainEvent>()
+        verify(stompPublisher).broadcastGame(eq(gameId), eventCaptor.capture())
+        assertThat((eventCaptor.firstValue as DomainEvent.PhaseChanged).subPhase)
+            .isEqualTo(ElectionSubPhase.VOTING.name)
+    }
+
+    @Test
+    fun `quitCampaign - cancels timer when last candidate quits (SPEECH exits to DAY_DISCUSSION)`() {
+        val order = "$guestId"
+        val ctx = context(
+            election = election(subPhase = ElectionSubPhase.SPEECH, speakingOrder = order, currentSpeakerIdx = 0),
+            players = listOf(player(hostId), player(guestId)),
+        )
+        val candidate = SheriffCandidate(electionId = electionId, userId = guestId, status = CandidateStatus.RUNNING)
+        whenever(sheriffCandidateRepository.findByElectionId(electionId)).thenReturn(listOf(candidate))
+        whenever(sheriffCandidateRepository.save(any<SheriffCandidate>())).thenAnswer {
+            (it.arguments[0] as SheriffCandidate).also { c -> c.status = CandidateStatus.QUIT }
+        }
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+
+        val req = GameActionRequest(gameId, guestId, ActionType.SHERIFF_QUIT_CAMPAIGN)
+        sheriffService.handle(req, ctx)
+
+        verify(hostTimerService).cancel(gameId)
     }
 }

--- a/backend/src/test/kotlin/com/werewolf/unit/service/VotingPipelineSheriffWeightTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/VotingPipelineSheriffWeightTest.kt
@@ -6,6 +6,7 @@ import com.werewolf.game.action.GameActionResult
 import com.werewolf.game.night.NightOrchestrator
 import com.werewolf.game.phase.WinConditionChecker
 import com.werewolf.game.role.RoleHandler
+import com.werewolf.game.timer.HostTimerService
 import com.werewolf.game.voting.VotingPipeline
 import com.werewolf.model.*
 import com.werewolf.repository.EliminationHistoryRepository
@@ -35,6 +36,7 @@ class VotingPipelineSheriffWeightTest {
     @Mock lateinit var stompPublisher: StompPublisher
     @Mock lateinit var contextLoader: GameContextLoader
     @Mock lateinit var nightOrchestrator: NightOrchestrator
+    @Mock lateinit var hostTimerService: HostTimerService
 
     private lateinit var votingPipeline: VotingPipeline
 
@@ -54,6 +56,7 @@ class VotingPipelineSheriffWeightTest {
         contextLoader = contextLoader,
         nightOrchestrator = nightOrchestrator,
         actionLogService = mock(),
+        hostTimerService = hostTimerService,
     )
 
     private val gameId = 1

--- a/backend/src/test/kotlin/com/werewolf/unit/service/VotingPipelineTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/VotingPipelineTest.kt
@@ -55,6 +55,7 @@ class VotingPipelineTest {
         contextLoader = contextLoader,
         nightOrchestrator = nightOrchestrator,
         actionLogService = mock(),
+        hostTimerService = mock(),
     )
 
     private val gameId = 1
@@ -939,6 +940,7 @@ class VotingPipelineTest {
         contextLoader = contextLoader,
         nightOrchestrator = nightOrchestrator,
         actionLogService = actionLogService,
+        hostTimerService = mock(),
     )
 
     @Test

--- a/frontend/e2e/real/host-countdown.spec.ts
+++ b/frontend/e2e/real/host-countdown.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Real-backend E2E: Host countdown timer — DAY_DISCUSSION + SHERIFF SPEECH.
+ *
+ * Five flows:
+ * A. DAY_DISCUSSION host start / stop, sync across clients
+ * B. SHERIFF SPEECH host start, advance-speech cancels, re-arm for next candidate
+ * C. Reconnect mid-timer (DAY_DISCUSSION) recovers correct remaining
+ * D. Phase exit cancels timer (DAY_DISCUSSION → DAY_VOTING)
+ * E. Sub-phase exit cancels timer (SHERIFF SPEECH → VOTING)
+ */
+import { expect, type Page, test } from '@playwright/test'
+import { type GameContext, setupGame } from './helpers/multi-browser'
+import { act, actName, type RoleName } from './helpers/shell-runner'
+import { waitForCondition, waitForPhase } from './helpers/state-polling'
+import { attachCompositeOnFailure } from './helpers/composite-screenshot'
+import { driveMinimalNight1ViaDom } from './helpers/night-driver'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Wait until all provided pages show [data-testid="phase-countdown"] with
+ *  data-remaining-ms within [minMs, maxMs]. */
+async function waitForTimerOnAllPages(
+  pages: Page[],
+  minMs: number,
+  maxMs: number,
+  timeoutMs = 5_000,
+) {
+  await Promise.all(
+    pages.map((page, idx) =>
+      waitForCondition(
+        async () => {
+          const el = await page.$('[data-testid="phase-countdown"]')
+          if (!el) return false
+          const raw = await el.getAttribute('data-remaining-ms')
+          if (!raw) return false
+          const ms = Number(raw)
+          return ms >= minMs && ms <= maxMs
+        },
+        `page[${idx}] phase-countdown remainingMs in [${minMs},${maxMs}]`,
+        timeoutMs,
+        200,
+      ),
+    ),
+  )
+}
+
+/** Return the data-remaining-ms attribute value from all pages. */
+async function getRemainingMsAll(pages: Page[]): Promise<number[]> {
+  return Promise.all(
+    pages.map(async (p) => {
+      const el = await p.$('[data-testid="phase-countdown"]')
+      if (!el) return 0
+      const raw = await el.getAttribute('data-remaining-ms')
+      return raw ? Number(raw) : 0
+    }),
+  )
+}
+
+/** Drive the game from ROLE_REVEAL through Night 1 to DAY_DISCUSSION.
+ *  Uses existing night-driver helper for DOM-driven night actions. */
+async function driveToDay(ctx: GameContext) {
+  await driveMinimalNight1ViaDom(ctx, { wolfTargetSeat: 4 })
+
+  // Reveal night result
+  await waitForPhase(ctx.hostPage, ctx.gameId, 'DAY_DISCUSSION', 30_000)
+  const hostBot = ctx.allBots.find((b) => b.nick === 'Host') ?? ctx.allBots[0]
+  act('REVEAL_NIGHT_RESULT', actName(hostBot), { room: ctx.roomCode })
+  await waitForCondition(
+    async () => {
+      const el = await ctx.hostPage.$('[data-testid="phase-countdown"]')
+      return el !== null
+    },
+    'host page sees [data-testid="phase-countdown"]',
+    10_000,
+    300,
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow A: DAY_DISCUSSION host start / stop, sync across clients
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Flow A — DAY_DISCUSSION timer start/stop syncs to all clients', () => {
+  let ctx: GameContext
+
+  test.setTimeout(180_000)
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(120_000)
+    ctx = await setupGame(browser, {
+      totalPlayers: 4,
+      hasSheriff: false,
+      roles: ['WEREWOLF', 'SEER', 'WITCH'] as RoleName[],
+      browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'VILLAGER'] as RoleName[],
+    })
+  })
+
+  test.afterAll(async () => {
+    await ctx?.cleanup()
+  })
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'failed' && ctx?.pages) {
+      await attachCompositeOnFailure(ctx.pages, testInfo)
+    }
+  })
+
+  test('A.1 drive to DAY_DISCUSSION', async () => {
+    await driveToDay(ctx)
+  })
+
+  test('A.2 host starts 60s timer — all clients see remaining ≈ 60s within 1s', async () => {
+    const allPages = [ctx.hostPage, ...ctx.pages.values()]
+
+    // Click 1:00 pill on host browser
+    await ctx.hostPage.click('[data-testid="phase-countdown-start-60"]')
+
+    await waitForTimerOnAllPages(allPages, 55_000, 60_500)
+  })
+
+  test('A.3 wait 3s — data-remaining-ms decrements by 2500-3500 on every client', async () => {
+    const allPages = [ctx.hostPage, ...ctx.pages.values()]
+    const before = await getRemainingMsAll(allPages)
+
+    await new Promise((r) => setTimeout(r, 3_000))
+    await new Promise((r) => setTimeout(r, 200)) // extra tick
+
+    const after = await getRemainingMsAll(allPages)
+    for (let i = 0; i < allPages.length; i++) {
+      const delta = before[i] - after[i]
+      expect(delta).toBeGreaterThanOrEqual(2_500)
+      expect(delta).toBeLessThanOrEqual(4_000)
+    }
+  })
+
+  test('A.4 host stops timer — all clients converge to remainingMs=0 and see preset pills', async () => {
+    const allPages = [ctx.hostPage, ...ctx.pages.values()]
+
+    await ctx.hostPage.click('[data-testid="phase-countdown-stop"]')
+
+    // All clients see running=false (remainingMs=0)
+    await waitForTimerOnAllPages(allPages, 0, 0, 3_000)
+
+    // Host sees preset pills again
+    await ctx.hostPage.waitForSelector('[data-testid="phase-countdown-start-60"]', { timeout: 3_000 })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow C: Reconnect mid-timer recovers correct remaining
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Flow C — reconnect mid-timer recovers correct remaining', () => {
+  let ctx: GameContext
+
+  test.setTimeout(180_000)
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(120_000)
+    ctx = await setupGame(browser, {
+      totalPlayers: 4,
+      hasSheriff: false,
+      roles: ['WEREWOLF', 'SEER', 'WITCH'] as RoleName[],
+      browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'VILLAGER'] as RoleName[],
+    })
+  })
+
+  test.afterAll(async () => {
+    await ctx?.cleanup()
+  })
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'failed' && ctx?.pages) {
+      await attachCompositeOnFailure(ctx.pages, testInfo)
+    }
+  })
+
+  test('C.1 drive to DAY_DISCUSSION and start 60s timer', async () => {
+    await driveToDay(ctx)
+    await ctx.hostPage.click('[data-testid="phase-countdown-start-60"]')
+    await waitForTimerOnAllPages([ctx.hostPage], 55_000, 60_500)
+  })
+
+  test('C.2 wait 5s, one player reloads — recovers 50-56s remaining', async () => {
+    await new Promise((r) => setTimeout(r, 5_000))
+
+    // Pick any non-host page to reload
+    const playerPage = [...ctx.pages.values()][0]
+    await playerPage.reload()
+    await playerPage.waitForSelector('[data-testid="phase-countdown"]', { timeout: 15_000 })
+
+    const el = await playerPage.$('[data-testid="phase-countdown"]')!
+    const raw = await el!.getAttribute('data-remaining-ms')
+    const ms = Number(raw ?? '0')
+    expect(ms).toBeGreaterThanOrEqual(50_000)
+    expect(ms).toBeLessThanOrEqual(56_000)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow D: Phase exit cancels timer (DAY_DISCUSSION → DAY_VOTING)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Flow D — DAY_DISCUSSION exit cancels timer', () => {
+  let ctx: GameContext
+
+  test.setTimeout(180_000)
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(120_000)
+    ctx = await setupGame(browser, {
+      totalPlayers: 4,
+      hasSheriff: false,
+      roles: ['WEREWOLF', 'SEER', 'WITCH'] as RoleName[],
+      browserRoles: ['WEREWOLF', 'SEER', 'WITCH', 'VILLAGER'] as RoleName[],
+    })
+  })
+
+  test.afterAll(async () => {
+    await ctx?.cleanup()
+  })
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'failed' && ctx?.pages) {
+      await attachCompositeOnFailure(ctx.pages, testInfo)
+    }
+  })
+
+  test('D.1 drive to DAY_DISCUSSION and start 120s timer', async () => {
+    await driveToDay(ctx)
+    await ctx.hostPage.click('[data-testid="phase-countdown-start-120"]')
+    await waitForTimerOnAllPages([ctx.hostPage], 115_000, 120_500)
+  })
+
+  test('D.2 host starts vote — all clients see timer running=false within 2s', async () => {
+    const allPages = [ctx.hostPage, ...ctx.pages.values()]
+    const hostBot = ctx.allBots.find((b) => b.nick === 'Host') ?? ctx.allBots[0]
+
+    // Advance DAY_DISCUSSION to DAY_VOTING
+    act('START_VOTE', actName(hostBot), { room: ctx.roomCode })
+
+    await waitForTimerOnAllPages(allPages, 0, 0, 3_000)
+  })
+})

--- a/frontend/src/__tests__/countdownArc.test.ts
+++ b/frontend/src/__tests__/countdownArc.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CountdownArc from '@/components/CountdownArc.vue'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function make(overrides: {
+  remainingMs?: number
+  durationMs?: number
+  running?: boolean
+  isHost?: boolean
+}) {
+  return mount(CountdownArc, {
+    props: {
+      remainingMs: 0,
+      durationMs: 0,
+      running: false,
+      isHost: false,
+      ...overrides,
+    },
+  })
+}
+
+describe('CountdownArc — idle state', () => {
+  it('renders "—" when idle (running=false, durationMs=0)', () => {
+    const w = make({ remainingMs: 0, durationMs: 0, running: false })
+    expect(w.find('.ca-inner').text()).toBe('—')
+  })
+
+  it('host sees 1:00 and 2:00 preset pills when idle', () => {
+    const w = make({ remainingMs: 0, durationMs: 0, running: false, isHost: true })
+    expect(w.find('[data-testid="phase-countdown-start-60"]').exists()).toBe(true)
+    expect(w.find('[data-testid="phase-countdown-start-120"]').exists()).toBe(true)
+    expect(w.find('[data-testid="phase-countdown-stop"]').exists()).toBe(false)
+  })
+
+  it('non-host does not see preset pills', () => {
+    const w = make({ remainingMs: 0, durationMs: 0, running: false, isHost: false })
+    expect(w.find('[data-testid="phase-countdown-start-60"]').exists()).toBe(false)
+  })
+})
+
+describe('CountdownArc — running state', () => {
+  it('renders time label and no urgent class when remainingMs > 10_000', () => {
+    const w = make({ remainingMs: 30_000, durationMs: 60_000, running: true })
+    expect(w.find('.ca-inner').text()).toBe('0:30')
+    expect(w.find('.ca-inner').classes()).not.toContain('urgent')
+  })
+
+  it('applies urgent class when remainingMs <= 10_000', () => {
+    const w = make({ remainingMs: 8_000, durationMs: 60_000, running: true })
+    expect(w.find('.ca-inner').classes()).toContain('urgent')
+  })
+
+  it('host sees Stop pill when running', () => {
+    const w = make({ remainingMs: 30_000, durationMs: 60_000, running: true, isHost: true })
+    expect(w.find('[data-testid="phase-countdown-stop"]').exists()).toBe(true)
+    expect(w.find('[data-testid="phase-countdown-start-60"]').exists()).toBe(false)
+  })
+})
+
+describe('CountdownArc — stopped state (running=false, durationMs>0)', () => {
+  it('renders muted text when stopped', () => {
+    const w = make({ remainingMs: 0, durationMs: 60_000, running: false })
+    // idle from host perspective: pill is displayed (stopped renders as idle for host)
+    expect(w.find('.ca-inner').classes()).toContain('idle')
+  })
+})
+
+describe('CountdownArc — testid and data-remaining-ms', () => {
+  it('root has data-testid="phase-countdown"', () => {
+    const w = make({})
+    expect(w.find('[data-testid="phase-countdown"]').exists()).toBe(true)
+  })
+
+  it('data-remaining-ms reflects localRemaining', () => {
+    const w = make({ remainingMs: 30_000, durationMs: 60_000, running: true })
+    const root = w.find('[data-testid="phase-countdown"]')
+    const attr = Number(root.attributes('data-remaining-ms'))
+    expect(attr).toBeGreaterThanOrEqual(29_800)
+    expect(attr).toBeLessThanOrEqual(30_200)
+  })
+})
+
+describe('CountdownArc — tick decrement', () => {
+  it('decreases data-remaining-ms by ~1000 after 1 second', async () => {
+    const w = make({ remainingMs: 30_000, durationMs: 60_000, running: true })
+    const before = Number(w.find('[data-testid="phase-countdown"]').attributes('data-remaining-ms'))
+
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    await w.vm.$nextTick()
+
+    const after = Number(w.find('[data-testid="phase-countdown"]').attributes('data-remaining-ms'))
+    expect(before - after).toBeGreaterThanOrEqual(800)
+    expect(before - after).toBeLessThanOrEqual(1200)
+  })
+})
+
+describe('CountdownArc — prop reset', () => {
+  it('resets snapshot when remainingMs prop changes', async () => {
+    const w = make({ remainingMs: 30_000, durationMs: 60_000, running: true })
+
+    // Advance 2 ticks so localRemaining has decremented a bit
+    vi.advanceTimersByTime(400)
+    await flushPromises()
+    await w.vm.$nextTick()
+
+    // Server sends a new remainingMs update
+    await w.setProps({ remainingMs: 55_000, durationMs: 60_000, running: true })
+    await w.vm.$nextTick()
+
+    const attr = Number(w.find('[data-testid="phase-countdown"]').attributes('data-remaining-ms'))
+    // Should be close to the new prop value (snapshot reset)
+    expect(attr).toBeGreaterThanOrEqual(54_500)
+    expect(attr).toBeLessThanOrEqual(55_500)
+  })
+})
+
+describe('CountdownArc — emit events', () => {
+  it('emits start-timer with 60 when host clicks 1:00 pill', async () => {
+    const w = make({ remainingMs: 0, durationMs: 0, running: false, isHost: true })
+    await w.find('[data-testid="phase-countdown-start-60"]').trigger('click')
+    expect(w.emitted('start-timer')?.[0]).toEqual([60])
+  })
+
+  it('emits start-timer with 120 when host clicks 2:00 pill', async () => {
+    const w = make({ remainingMs: 0, durationMs: 0, running: false, isHost: true })
+    await w.find('[data-testid="phase-countdown-start-120"]').trigger('click')
+    expect(w.emitted('start-timer')?.[0]).toEqual([120])
+  })
+
+  it('emits stop-timer when host clicks Stop pill', async () => {
+    const w = make({ remainingMs: 30_000, durationMs: 60_000, running: true, isHost: true })
+    await w.find('[data-testid="phase-countdown-stop"]').trigger('click')
+    expect(w.emitted('stop-timer')).toBeTruthy()
+  })
+})

--- a/frontend/src/__tests__/gameStore.test.ts
+++ b/frontend/src/__tests__/gameStore.test.ts
@@ -150,4 +150,34 @@ describe('gameStore', () => {
     store.setState({ ...freshState(), audioSequence: next })
     expect(store.state?.audioSequence).toEqual(next)
   })
+
+  // ── setTimer ──────────────────────────────────────────────────────────────
+
+  it('setTimer() produces a new object reference (Vue reactivity requirement)', () => {
+    const store = useGameStore()
+    store.setState(freshState())
+    const prev = store.state
+
+    store.setTimer({ remainingMs: 45_000, durationMs: 60_000, running: true })
+
+    expect(store.state).not.toBe(prev)
+    expect(store.state?.timer).toEqual({ remainingMs: 45_000, durationMs: 60_000, running: true })
+  })
+
+  it('setTimer() updates timer without changing other state fields', () => {
+    const store = useGameStore()
+    store.setState(freshState())
+    store.setTimer({ remainingMs: 0, durationMs: 0, running: false })
+
+    expect(store.state?.phase).toBe('DAY_DISCUSSION')
+    expect(store.state?.dayNumber).toBe(1)
+    expect(store.state?.timer?.running).toBe(false)
+  })
+
+  it('setTimer() is a no-op when state is null', () => {
+    const store = useGameStore()
+    // Should not throw
+    store.setTimer({ remainingMs: 0, durationMs: 0, running: false })
+    expect(store.state).toBeNull()
+  })
 })

--- a/frontend/src/components/CountdownArc.vue
+++ b/frontend/src/components/CountdownArc.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { ref, computed, watch, onUnmounted } from 'vue'
+
+const props = defineProps<{
+  remainingMs: number
+  durationMs: number
+  running: boolean
+  isHost: boolean
+}>()
+
+const emit = defineEmits<{
+  'start-timer': [seconds: number]
+  'stop-timer': []
+}>()
+
+const CIRCUM = 2 * Math.PI * 22 // r=22 in viewBox 50×50
+const URGENT_THRESHOLD_MS = 10_000
+const PRESETS = [60, 120]
+
+// Snapshot: when the prop changes, record the prop value and the local clock
+const snapshotRemainingMs = ref(props.remainingMs)
+const snapshotAt = ref(Date.now())
+
+watch(
+  () => [props.remainingMs, props.durationMs, props.running] as const,
+  ([r]) => {
+    snapshotRemainingMs.value = r
+    snapshotAt.value = Date.now()
+    // Immediately reflect the new value so tests/E2E don't wait for the next tick
+    if (props.running) localRemaining.value = r
+  },
+)
+
+// Local 200ms tick — only active when running
+const localRemaining = ref(props.remainingMs)
+let intervalId = 0
+
+function startTicking() {
+  stopTicking()
+  intervalId = window.setInterval(() => {
+    localRemaining.value = Math.max(0, snapshotRemainingMs.value - (Date.now() - snapshotAt.value))
+  }, 200)
+}
+
+function stopTicking() {
+  if (intervalId) {
+    clearInterval(intervalId)
+    intervalId = 0
+  }
+}
+
+watch(
+  () => props.running,
+  (isRunning) => {
+    if (isRunning) startTicking()
+    else {
+      stopTicking()
+      localRemaining.value = props.running ? snapshotRemainingMs.value : 0
+    }
+  },
+  { immediate: true },
+)
+
+onUnmounted(stopTicking)
+
+const urgent = computed(
+  () => props.running && localRemaining.value > 0 && localRemaining.value <= URGENT_THRESHOLD_MS,
+)
+
+const idle = computed(() => !props.running && props.durationMs === 0)
+const stopped = computed(() => !props.running && props.durationMs > 0)
+const visuallyIdle = computed(() => (props.isHost ? idle.value || stopped.value : idle.value))
+
+const pct = computed(() =>
+  props.durationMs > 0 && !visuallyIdle.value ? localRemaining.value / props.durationMs : 0,
+)
+
+const arcClass = computed(() =>
+  urgent.value ? 'urgent' : visuallyIdle.value || stopped.value ? 'idle' : '',
+)
+
+function fmt(ms: number): string {
+  const s = Math.ceil(ms / 1000)
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`
+}
+
+const displayLabel = computed(() => (visuallyIdle.value ? '—' : fmt(localRemaining.value)))
+</script>
+
+<template>
+  <div class="ca-root" data-testid="phase-countdown" :data-remaining-ms="localRemaining">
+    <div class="ca-wrap">
+      <svg viewBox="0 0 50 50">
+        <circle cx="25" cy="25" r="22" :class="['ca-bg', arcClass]" />
+        <circle
+          cx="25"
+          cy="25"
+          r="22"
+          :class="['ca-fg', arcClass]"
+          :stroke-dasharray="CIRCUM"
+          :stroke-dashoffset="CIRCUM * (1 - pct)"
+        />
+      </svg>
+      <div :class="['ca-inner', arcClass]">{{ displayLabel }}</div>
+    </div>
+
+    <div v-if="isHost" class="ca-controls">
+      <button
+        v-if="running"
+        type="button"
+        class="ca-pill ca-pill--danger"
+        data-testid="phase-countdown-stop"
+        @click="emit('stop-timer')"
+      >
+        停止 Stop
+      </button>
+      <template v-else>
+        <button
+          v-for="seconds in PRESETS"
+          :key="seconds"
+          type="button"
+          class="ca-pill"
+          :data-testid="`phase-countdown-start-${seconds}`"
+          @click="emit('start-timer', seconds)"
+        >
+          {{ fmt(seconds * 1000) }}
+        </button>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ca-root {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.ca-wrap {
+  position: relative;
+  width: 56px;
+  height: 56px;
+}
+
+.ca-wrap svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.ca-bg {
+  fill: none;
+  stroke: var(--border-l, #ddd6c6);
+  stroke-width: 4;
+  transition: stroke 0.3s;
+}
+
+.ca-bg.urgent {
+  stroke: rgba(181, 37, 26, 0.32);
+}
+
+.ca-fg {
+  fill: none;
+  stroke: var(--ink, #2a1f14);
+  stroke-width: 4;
+  stroke-linecap: round;
+  transition:
+    stroke 0.3s,
+    stroke-dashoffset 0.5s linear;
+}
+
+.ca-fg.urgent {
+  stroke: var(--red, #b5251a);
+}
+
+.ca-fg.idle {
+  stroke: var(--border-l, #ddd6c6);
+}
+
+.ca-inner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Noto Serif SC', serif;
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink, #2a1f14);
+  line-height: 1;
+  transition: color 0.3s;
+}
+
+.ca-inner.urgent {
+  color: var(--red, #b5251a);
+  animation: ca-pulse 1s ease-in-out infinite;
+}
+
+.ca-inner.idle {
+  color: var(--muted, #8a7a65);
+}
+
+.ca-controls {
+  display: flex;
+  gap: 4px;
+}
+
+.ca-pill {
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  border-radius: 100px;
+  background: var(--ink, #2a1f14);
+  color: var(--paper, #f5f0e8);
+  border: none;
+  font-family: inherit;
+  transition: background 0.12s;
+}
+
+.ca-pill:hover {
+  background: #000;
+}
+
+.ca-pill--danger {
+  background: transparent;
+  color: var(--red, #b5251a);
+  border: 1px solid rgba(181, 37, 26, 0.3);
+}
+
+.ca-pill--danger:hover {
+  background: rgba(181, 37, 26, 0.08);
+}
+
+@keyframes ca-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+</style>

--- a/frontend/src/components/DayPhase.vue
+++ b/frontend/src/components/DayPhase.vue
@@ -1,9 +1,16 @@
 <template>
   <div class="day-wrap">
-    <!-- Header: pill badge left | large timer right -->
+    <!-- Header: pill badge left | countdown arc right -->
     <header class="day-header">
       <div class="day-pill">第 {{ dayPhase.dayNumber }} 天 · Day {{ dayPhase.dayNumber }}</div>
-      <div class="day-timer">{{ formattedTime }}</div>
+      <CountdownArc
+        :remaining-ms="timer?.remainingMs ?? 0"
+        :duration-ms="timer?.durationMs ?? 0"
+        :running="timer?.running ?? false"
+        :is-host="isHost"
+        @start-timer="(s) => emit('start-timer', s)"
+        @stop-timer="emit('stop-timer')"
+      />
     </header>
 
     <!-- Sun arc -->
@@ -186,12 +193,13 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
-import type { DayPhaseState, GamePlayer, PlayerRole } from '@/types'
+import { computed, ref, watch } from 'vue'
+import type { DayPhaseState, GamePlayer, PlayerRole, TimerState } from '@/types'
 import PlayerSlot from '@/components/PlayerSlot.vue'
 import SunArc from '@/components/SunArc.vue'
 import ActionLogDrawer from '@/components/ActionLogDrawer.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
+import CountdownArc from '@/components/CountdownArc.vue'
 
 const props = defineProps<{
   gameId: number
@@ -199,6 +207,7 @@ const props = defineProps<{
   players: GamePlayer[]
   myUserId: string
   isHost: boolean
+  timer?: TimerState | null
   myRole?: PlayerRole
   isAlive?: boolean
   daySkipVoting?: boolean
@@ -216,6 +225,8 @@ const emit = defineEmits<{
   selectPlayer: [userId: string]
   'self-destruct': []
   continueToNight: []
+  'start-timer': [seconds: number]
+  'stop-timer': []
 }>()
 
 type ViewRole = 'HOST' | 'DEAD' | 'ALIVE' | 'GUEST'
@@ -226,26 +237,6 @@ const viewRole = computed<ViewRole>(() => {
   if (!me) return 'GUEST'
   if (!me.isAlive) return 'DEAD'
   return 'ALIVE'
-})
-
-const now = ref(Date.now())
-let intervalId = 0
-
-onMounted(() => {
-  intervalId = window.setInterval(() => {
-    now.value = Date.now()
-  }, 1000)
-})
-
-onUnmounted(() => {
-  clearInterval(intervalId)
-})
-
-const formattedTime = computed(() => {
-  const remaining = Math.max(0, props.dayPhase.phaseDeadline - now.value) / 1000
-  const m = Math.floor(remaining / 60)
-  const s = Math.floor(remaining % 60)
-  return `${m}:${String(s).padStart(2, '0')}`
 })
 
 // Selection is local UI state — server is notified but not authoritative for display

--- a/frontend/src/components/SheriffElection.vue
+++ b/frontend/src/components/SheriffElection.vue
@@ -1,10 +1,17 @@
 <template>
   <div class="sheriff-wrap">
-    <!-- Header: phase chip + timer -->
+    <!-- Header: phase chip + countdown arc (SPEECH only) -->
     <div class="sheriff-header">
       <div class="phase-chip">{{ phaseChipLabel }}</div>
-      <div class="timer">{{ election.subPhase !== 'RESULT' ? election.timeRemaining : '' }}</div>
-      <div v-if="election.subPhase === 'RESULT'" class="timer-result">Result</div>
+      <CountdownArc
+        v-if="election.subPhase === 'SPEECH'"
+        :remaining-ms="timer?.remainingMs ?? 0"
+        :duration-ms="timer?.durationMs ?? 0"
+        :running="timer?.running ?? false"
+        :is-host="isHost"
+        @start-timer="(s) => emit('start-timer', s)"
+        @stop-timer="emit('stop-timer')"
+      />
     </div>
 
     <!-- Below-header row: Action chip on the right (wolf self-destruct) -->
@@ -586,12 +593,14 @@
 import { computed, ref } from 'vue'
 import Avatar from '@/components/Avatar.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
-import type { PlayerRole, SheriffCandidate, SheriffElectionState } from '@/types'
+import CountdownArc from '@/components/CountdownArc.vue'
+import type { PlayerRole, SheriffCandidate, SheriffElectionState, TimerState } from '@/types'
 
 const props = defineProps<{
   election: SheriffElectionState
   myUserId: string
   isHost: boolean
+  timer?: TimerState | null
   myRole?: PlayerRole
   isAlive?: boolean
   actionPending?: boolean
@@ -609,6 +618,8 @@ const emit = defineEmits<{
   endResult: []
   appoint: [userId: string]
   'self-destruct': []
+  'start-timer': [seconds: number]
+  'stop-timer': []
 }>()
 
 const iAmCandidate = computed(() =>

--- a/frontend/src/services/gameService.ts
+++ b/frontend/src/services/gameService.ts
@@ -30,4 +30,12 @@ export const gameService = {
     const { data } = await http.get<ActionLogEntry[]>(`/game/${gameId}/events`)
     return data
   },
+
+  async startTimer(gameId: number, durationSeconds: number): Promise<void> {
+    await http.post(`/game/${gameId}/timer/start`, { durationSeconds })
+  },
+
+  async stopTimer(gameId: number): Promise<void> {
+    await http.post(`/game/${gameId}/timer/stop`)
+  },
 }

--- a/frontend/src/stores/gameStore.ts
+++ b/frontend/src/stores/gameStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import type { GameEvent, GameState, PlayerRole } from '@/types'
+import type { GameEvent, GameState, PlayerRole, TimerState } from '@/types'
 
 export const useGameStore = defineStore('game', () => {
   const state = ref<GameState | null>(null)
@@ -69,6 +69,11 @@ export const useGameStore = defineStore('game', () => {
     state.value = { ...state.value, daySkipVoting: value }
   }
 
+  function setTimer(payload: TimerState) {
+    if (!state.value) return
+    state.value = { ...state.value, timer: { ...payload } }
+  }
+
   return {
     state,
     setState,
@@ -78,5 +83,6 @@ export const useGameStore = defineStore('game', () => {
     updateNightPhaseSelection,
     setMyRole,
     setDaySkipVoting,
+    setTimer,
   }
 })

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -88,6 +88,14 @@ export interface AudioSequence {
   timestamp: number
 }
 
+// ── Timer ─────────────────────────────────────────────────────────────────────
+
+export interface TimerState {
+  remainingMs: number
+  durationMs: number
+  running: boolean
+}
+
 // ── Game ──────────────────────────────────────────────────────────────────────
 
 export type GamePhase =
@@ -157,6 +165,7 @@ export interface GameState {
   /** True when a wolf self-destructed this day — host sees "进入夜晚" instead of voting. */
   daySkipVoting?: boolean
   events: GameEvent[]
+  timer?: TimerState
   roleReveal?: RoleRevealState
   sheriffElection?: SheriffElectionState
   dayPhase?: DayPhaseState

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -68,6 +68,7 @@
         :election="gameStore.state.sheriffElection"
         :my-user-id="userStore.userId ?? ''"
         :is-host="isHost"
+        :timer="gameStore.state?.timer ?? null"
         :my-role="gameStore.state?.myRole"
         :is-alive="
           gameStore.state?.players.find((p) => p.userId === userStore.userId)?.isAlive ?? false
@@ -84,6 +85,8 @@
         @end-result="handleSheriffEndResult"
         @appoint="handleSheriffAppoint"
         @self-destruct="handleSelfDestruct"
+        @start-timer="(s) => handleTimerStart(Number(route.params.gameId), s)"
+        @stop-timer="() => handleTimerStop(Number(route.params.gameId))"
       />
     </template>
 
@@ -145,6 +148,7 @@
         :players="gameStore.state.players"
         :my-user-id="userStore.userId ?? ''"
         :is-host="isHost"
+        :timer="gameStore.state?.timer ?? null"
         :my-role="gameStore.state?.myRole"
         :is-alive="
           gameStore.state?.players.find((p) => p.userId === userStore.userId)?.isAlive ?? false
@@ -158,6 +162,8 @@
         @select-player="handleDaySelectPlayer"
         @self-destruct="handleSelfDestruct"
         @continue-to-night="handleVotingContinue"
+        @start-timer="(s) => handleTimerStart(Number(route.params.gameId), s)"
+        @stop-timer="() => handleTimerStop(Number(route.params.gameId))"
       />
     </template>
 
@@ -760,6 +766,22 @@ async function handleDaySelectPlayer(userId: string) {
   await action({ actionType: 'SELECT_PLAYER', targetId: userId })
 }
 
+async function handleTimerStart(gameId: number, durationSeconds: number) {
+  try {
+    await gameService.startTimer(gameId, durationSeconds)
+  } catch {
+    /* host sees no feedback — timer state arrives via STOMP TimerUpdated */
+  }
+}
+
+async function handleTimerStop(gameId: number) {
+  try {
+    await gameService.stopTimer(gameId)
+  } catch {
+    /* same as above */
+  }
+}
+
 async function handleNightSelect(userId: string) {
   // Wolf selection is shared with teammates in real-time; other roles select locally only
   if (gameStore.state?.nightPhase?.subPhase === 'WEREWOLF_PICK') {
@@ -1092,6 +1114,14 @@ onMounted(async () => {
         // This is the main event that should trigger UI update; PhaseChanged is also sent but VoteTally is more complete
         if (data.type === 'VoteTally') {
           await refreshState()
+        }
+        // Timer update from host: update timer state in store directly (no state refetch needed)
+        if (data.type === 'TimerUpdated') {
+          gameStore.setTimer({
+            remainingMs: data.remainingMs,
+            durationMs: data.durationMs,
+            running: data.running,
+          })
         }
         // Both mock (GAME_OVER) and real backend (GameOver) navigate to result
         if (data.type === 'GAME_OVER' || data.type === 'GameOver') {


### PR DESCRIPTION
## Summary

Server-authoritative host-controlled countdown timer. Host opts in (or doesn't) per phase. Visible in two phases only: DAY_DISCUSSION and SHERIFF_ELECTION → SPEECH sub-phase. Other phases unchanged.

- New 56×56 `<CountdownArc>` mounted in DayPhase + SheriffElection headers (replaces broken `.day-timer` slot that was reading `phaseDeadline = 0L`)
- Wire format: backend pushes `{ remainingMs, durationMs, running }` deltas — clients never see absolute server times
- Server-fired expiration via `kotlinx.coroutines` (mirrors `NightOrchestrator.kt` pattern)
- Single audio cue at T-10s warning (`countdown_warning.mp3` — placeholder filename; visual countdown still works if missing). Silent on expire and on host stop.
- `cancel(gameId)` hooks: `GamePhasePipeline.dayAdvance`, `VotingPipeline.continueToNight`, `SheriffService.advanceSpeech`, `SheriffService.quitCampaign` — no stale ticks across phase boundaries

## Verification

### Automated
- [x] backend: `./gradlew test --tests '*HostTimer*'` green
- [x] backend: `./gradlew test --tests '*Sheriff*' '*GameServiceState*' '*GameController*'` green
- [x] frontend: `vitest countdownArc gameStore` (26 tests) green
- [x] frontend: `vue-tsc --noEmit` clean
- [x] frontend: `tsc -p tsconfig.e2e.json --noEmit` clean
- [x] frontend: `npm run lint` 0 errors (21 pre-existing warnings)
- [ ] CI: full GHA matrix green

### E2E flows (in `frontend/e2e/real/host-countdown.spec.ts`)
- Flow A: DAY_DISCUSSION host start/stop, sync across 4 clients
- Flow C: reconnect mid-timer recovers correct remaining
- Flow D: DAY_DISCUSSION → DAY_VOTING transition cancels timer cleanly

### Plan-critical compliance
- [x] `@JsonTypeName("TimerUpdated")` on the new event (Jackson polymorphic name; without it the frontend dispatcher silently misses the type)
- [x] No `endsAt` anywhere — client only sees `remainingMs` deltas (`grep` zero matches across backend + frontend)
- [x] `gameStore.setTimer` uses object spread (Vue reactivity guarantee)
- [x] All e2e assertions use `getByTestId` + `data-remaining-ms` attribute (no `getByText`)
- [x] Phase guard: `start`/`stop` accept only DAY_DISCUSSION or (SHERIFF_ELECTION AND SPEECH)

### On-device manual (deferred)
- [ ] Two-tab local manual sync test — covered by e2e Flow A
- [ ] Audio file confirmation: rename `COUNTDOWN_WARNING_FILE` constant if user's actual filename differs from `countdown_warning.mp3`

## Files

27 changed, 1592 insertions(+), 29 deletions(-). Full breakdown in commit body.

## Out of scope

- Auto-start in any phase (host always opts in)
- Timer for DAY_VOTING / NIGHT / other SHERIFF sub-phases
- Custom durations beyond 60/120s
- Pause/resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)