### PR TITLE
feat(ui): show app version (v0.6.6) bottom-left on every screen

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -12,7 +12,10 @@ export default tseslint.config(
     {
         files: ['src/**/*.{ts,vue}'],
         languageOptions: {
-            globals: globals.browser,
+            globals: {
+                ...globals.browser,
+                __APP_VERSION__: 'readonly',
+            },
             parserOptions: {
                 parser: tseslint.parser,
             },

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,9 @@
 <template>
   <RouterView />
+  <VersionBadge />
 </template>
 
 <script lang="ts" setup>
 import { RouterView } from 'vue-router'
+import VersionBadge from '@/components/VersionBadge.vue'
 </script>

--- a/frontend/src/__tests__/versionBadge.test.ts
+++ b/frontend/src/__tests__/versionBadge.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import VersionBadge from '@/components/VersionBadge.vue'
+
+vi.stubGlobal('__APP_VERSION__', 'v0.6.6')
+
+describe('VersionBadge', () => {
+  it('renders the injected version', () => {
+    const wrapper = mount(VersionBadge)
+    expect(wrapper.text()).toBe('v0.6.6')
+  })
+
+  it('exposes the version-badge testid', () => {
+    const wrapper = mount(VersionBadge)
+    expect(wrapper.find('[data-testid="version-badge"]').exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/VersionBadge.vue
+++ b/frontend/src/components/VersionBadge.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="version-badge" data-testid="version-badge">{{ version }}</div>
+</template>
+
+<script setup lang="ts">
+const version = __APP_VERSION__
+</script>
+
+<style scoped>
+.version-badge {
+  position: fixed;
+  left: max(0.5rem, env(safe-area-inset-left));
+  bottom: max(0.5rem, env(safe-area-inset-bottom));
+  z-index: 100;
+  font-family: 'Noto Serif SC', serif;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--muted);
+  pointer-events: none;
+  user-select: none;
+  font-variant-numeric: tabular-nums;
+}
+
+:global(.night-mode) .version-badge {
+  color: rgba(245, 240, 232, 0.45);
+}
+</style>

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,18 @@ import {defineConfig} from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 import {fileURLToPath, URL} from 'node:url'
+import {execSync} from 'node:child_process'
+
+function resolveAppVersion(): string {
+    try {
+        const tag = execSync('git describe --tags --abbrev=0', {
+            stdio: ['ignore', 'pipe', 'ignore'],
+        }).toString().trim()
+        return tag || 'dev'
+    } catch {
+        return 'dev'
+    }
+}
 
 export default defineConfig({
     plugins: [
@@ -14,6 +26,7 @@ export default defineConfig({
         },
     },
     define: {
+        __APP_VERSION__: JSON.stringify(resolveAppVersion()),
         // Fix for SockJS: add global polyfill
         global: 'globalThis',
     },


### PR DESCRIPTION
## Summary
- New `<VersionBadge>` (fixed bottom-left, 11px serif, muted/parchment, `pointer-events: none`, night-mode color override) mounted once in `App.vue` so it renders on every route — Lobby, Room, Game, Result, Demo, OAuthCallback, BrowserUnsupported.
- Version is injected at Vite build time via `git describe --tags --abbrev=0` into `__APP_VERSION__`, with `'dev'` fallback when git/tags are unavailable. No `package.json` bump required.
- Coexists with the existing bottom-right `VolumeControl` (z-index 100, opposite corner) and respects safe-area insets.

## Test plan
- [x] `npx vitest run versionBadge` — 2 unit tests pass (rendered text, testid)
- [x] `npx vue-tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (registered `__APP_VERSION__` as a readonly eslint global)
- [x] `npm run format:check` — clean
- [x] `npm run build` — succeeds; tag resolution runs in the build step
- [x] Playwright validation at 417×614 viewport:
  - Badge renders `v0.6.6` at (8, 595) on `/` and on `/demo`
  - Rendered text exactly matches `git describe --tags --abbrev=0`
  - Source code grep proves `v0.6.6` literal only appears in the vitest stub, never in production code → confirmed injected, not hardcoded
  - Computed styles match design (position: fixed, z-index 100, color #8a7a65, font Noto Serif SC, pointer-events: none)
  - 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)