### PR TITLE
fix(e2e): sheriff-flow — pick a non-host browser for DOM signup

### DIFF
--- a/frontend/e2e/real/sheriff-flow.spec.ts
+++ b/frontend/e2e/real/sheriff-flow.spec.ts
@@ -20,6 +20,10 @@ let ctx: GameContext
 // response deliberately hides other candidates' identities (2026-05-11),
 // so we can't recover this from the state itself.
 let test2CampaignerUserIds = new Set<string>()
+// Nickname of the bot that signed up via DOM in test 2 — test 4 votes for
+// this exact bot. Chosen at runtime as the first non-host browser-page
+// role, so the host is structurally guaranteed not to become a candidate.
+let test2BrowserCandidateNick: string | null = null
 
 test.describe('Sheriff election — multi-browser STOMP verification', () => {
   test.setTimeout(180_000)
@@ -94,32 +98,51 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
   test('2. Sheriff signup — browser player signs up, button changes', async ({}, testInfo) => {
     // Strong contract — three things this test exercises that no other
     // sheriff-flow test does:
-    //   (a) The seer's browser shows `sheriff-run` while in SIGNUP.
+    //   (a) A non-host player's browser shows `sheriff-run` while in SIGNUP.
     //   (b) Clicking it round-trips through STOMP and the same browser
     //       sees `sheriff-withdraw` (proves signup registered + state
     //       broadcast back to the originating browser).
     //   (c) Bot campaigns submitted via the REST script appear in the
-    //       seer's candidate list (cross-browser STOMP fan-out).
+    //       decision counter (cross-browser STOMP fan-out).
     //
     // Earlier versions wrapped (b) in `if (await runBtn.isVisible())` and
     // (c) in `try { ... } catch {}`, so the test passed silently even when
     // the signup feature was completely broken. Same anti-pattern as
     // `test.skip()` — replaced with positive assertions.
-
-    const seerPage = ctx.pages.get('SEER')
-    if (!seerPage) {
+    //
+    // The browser used for DOM signup MUST be non-host. Earlier this test
+    // hardcoded `ctx.pages.get('SEER')`, but setupGame maps host's role to
+    // hostPage (multi-browser.ts:469-470) — so when the random role
+    // assignment puts the host into SEER, the seer-browser click became a
+    // host signup, leaving the host in the candidate list. Tests 4-5 then
+    // failed because `sheriff-abstain` is replaced by a disabled
+    // "Candidates can't vote" button for candidates (SheriffElection.vue
+    // :286-305). Picking the first browser-page role that is not the
+    // host's role guarantees a bot's browser and removes that edge case
+    // entirely.
+    const candidateRole = (['SEER', 'WITCH', 'GUARD', 'WEREWOLF', 'VILLAGER'] as const).find(
+      (r) => r !== ctx.hostRole && ctx.pages.has(r),
+    )
+    if (!candidateRole) {
       throw new Error(
-        `ctx.pages.get('SEER') is undefined — setupGame did not assign a SEER page. ` +
-          `Check beforeAll's browserRoles (must include 'SEER') and the role kit ` +
-          `(room.hasSeer must be true). hostRole=${ctx.hostRole}.`,
+        `No non-host browser available for DOM signup. ` +
+          `hostRole=${ctx.hostRole}, pages=${Array.from(ctx.pages.keys()).join(',')}`,
       )
     }
+    const candidatePage = ctx.pages.get(candidateRole)!
+    const candidateBot = (ctx.roleMap[candidateRole] ?? []).find((b) => b.nick !== 'Host')
+    if (!candidateBot) {
+      throw new Error(
+        `roleMap[${candidateRole}] has no non-host bot — host pinning is wrong`,
+      )
+    }
+    test2BrowserCandidateNick = candidateBot.nick
 
     // Wait for SHERIFF_ELECTION/SIGNUP — only sub-phase where `sheriff-run`
     // renders. Backend may take a moment after role-reveal-end to enter it.
     await waitForCondition(
       async () => {
-        const state = await seerPage.evaluate(async (id: string) => {
+        const state = await candidatePage.evaluate(async (id: string) => {
           const token = localStorage.getItem('jwt')
           const res = await fetch(`/api/game/${id}/state`, {
             headers: { Authorization: `Bearer ${token}` },
@@ -134,25 +157,24 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
 
     // (a) sheriff-run must render. If it doesn't, that's a regression in
     //     SheriffElection.vue's signup template (or an aliveness bug).
-    const runBtn = seerPage.getByTestId('sheriff-run')
+    const runBtn = candidatePage.getByTestId('sheriff-run')
     await expect(runBtn).toBeVisible({ timeout: 10_000 })
 
     // (b) Click → button toggles to "Withdraw" (signup confirmed).
     await runBtn.click()
-    await expect(seerPage.getByTestId('sheriff-withdraw')).toBeVisible({
+    await expect(candidatePage.getByTestId('sheriff-withdraw')).toBeVisible({
       timeout: 10_000,
     })
 
-    // (c) Drive 3 bot campaigns via script and assert all 3 appear in the
-    //     seer's candidate list (1 self-signup + 3 bots = 4 candidates).
-    //     Filter Host out: the seer just signed up via the seerPage click;
-    //     if host rolled SEER, seerPage IS hostPage and the host is already
-    //     in the list — feeding host into `sheriff campaign` here would be
-    //     a duplicate signup that the backend rejects.
+    // (c) Drive 3 bot campaigns via script and assert the decision counter
+    //     reflects them. 1 self-signup + 3 bots = 4 decisions. Filter Host
+    //     out of the bot list (we never want host in the candidate set —
+    //     see test 4's host-abstain step). Also filter the bot we just
+    //     signed up via DOM (no duplicate signup).
     const wolfBots = ctx.roleMap.WEREWOLF ?? []
     const villagerBots = ctx.roleMap.VILLAGER ?? []
     const campaigners = [...wolfBots.slice(0, 1), ...villagerBots.slice(0, 2)].filter(
-      (b) => b.nick !== 'Host',
+      (b) => b.nick !== 'Host' && b.userId !== candidateBot.userId,
     )
     expect(campaigners.length, 'need at least one non-host bot to campaign').toBeGreaterThan(0)
     for (const bot of campaigners) {
@@ -161,20 +183,18 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
 
     // 2026-05-11 behaviour: SIGNUP no longer renders per-candidate rows
     // (identities are hidden). The observable signal that the bot fan-out
-    // landed is the decision-progress counter on the seer's UI: it must
-    // reflect the count of decided alive players. The seer signed up via
-    // (b) above, so the expected `decided` is 1 (seer) + campaigners.length.
-    await expect(seerPage.getByTestId('sheriff-decision-progress')).toContainText(
+    // landed is the decision-progress counter on the candidate's UI: it must
+    // reflect the count of decided alive players. The candidate signed up
+    // via (b) above, so the expected `decided` is 1 + campaigners.length.
+    await expect(candidatePage.getByTestId('sheriff-decision-progress')).toContainText(
       new RegExp(`${1 + campaigners.length}\\s*/`),
       { timeout: 10_000 },
     )
 
     // Record campaigner userIds so test 3 can leave them alone when driving
-    // remaining alive players to pass. The seer's own userId comes from
-    // ctx.roleMap.SEER[0] (the same browser that just clicked sheriff-run).
-    const seerForCtx = ctx.roleMap.SEER?.[0]
+    // remaining alive players to pass.
     test2CampaignerUserIds = new Set<string>([
-      ...(seerForCtx?.userId ? [seerForCtx.userId] : []),
+      candidateBot.userId,
       ...campaigners.map((b) => b.userId),
     ])
 
@@ -291,12 +311,15 @@ test.describe('Sheriff election — multi-browser STOMP verification', () => {
       15_000,
     )
 
-    // All non-host non-candidate bots vote for the seer (the candidate
-    // signed up in test 2). Candidates can't vote for themselves
-    // (SheriffService.kt:385), so they abstain instead.
-    const seerBots = ctx.roleMap.SEER ?? []
-    const targetNick = seerBots[0]?.nick
-    expect(targetNick, 'kit must include a SEER candidate to vote for').toBeDefined()
+    // All non-host non-candidate bots vote for the bot that signed up via
+    // DOM in test 2 (recorded in test2BrowserCandidateNick). Candidates
+    // can't vote for themselves (SheriffService.kt:385), so they abstain
+    // instead.
+    const targetNick = test2BrowserCandidateNick
+    expect(
+      targetNick,
+      'test 2 must have recorded the DOM-signup candidate nick before test 4',
+    ).toBeTruthy()
     sheriff('vote', { target: targetNick!, room: ctx.roomCode })
     sheriff('abstain', { player: targetNick!, room: ctx.roomCode })
 


### PR DESCRIPTION
## Summary

Root-cause fix for the intermittent failure in `e2e/real/sheriff-flow.spec.ts` tests 4 + 5. **Not a flake, not a timing race** — a deterministic test-design bug that fires whenever the random role assignment puts the host into the SEER slot (~1/9 ≈ 11% of runs in the 9p kit).

## Root cause

Test 2 clicked \`sheriff-run\` on \`ctx.pages.get('SEER')\`. The harness (\`helpers/multi-browser.ts:469-470\`) deliberately maps the host's randomly-assigned role to its own page, so when host = SEER, **seerPage == hostPage** and that click signed the *host* up as a candidate.

Test 3 then recorded the signer's userId into \`test2CampaignerUserIds\` and deliberately skipped the host when driving remaining alive players to pass — so the host stayed in the candidate list. Test 4 then assumed \"host is never a candidate\" and tried to click \`sheriff-abstain\`, but \`SheriffElection.vue:286-305\` swaps that button for a disabled \"候选人不参与投票 / Candidates can't vote\" indicator for candidates, so the \`waitFor\` legitimately timed out. Test 5's \`sheriff-end-result\` failure was downstream — test 4 never clicked Reveal, so the game stayed in VOTING.

The failure-time page snapshot (recovered from the CI blob report) confirms it:

\`\`\`
- 4 candidates: Bot1, Bot3, Bot5, Host        ← host in candidate set
- button \"候选人不参与投票 / Candidates can't vote\" [disabled]
- 9/9 voted
- button \"揭晓结果 / Reveal Result\"          ← the actually-available action
\`\`\`

The product/backend are correct — candidates can't vote per game rules. The bug is purely the test's hidden precondition (\"host is never a candidate\") that the harness never enforced.

## The fix (structural, not a mitigation)

At the top of test 2, pick the first browser-page role that is **not** \`ctx.hostRole\`. That page is by construction a bot's page, so the DOM signup always registers a bot — the host can never be a candidate, regardless of which role the backend assigns. Test 4's vote target now follows from the recorded \`test2BrowserCandidateNick\` instead of guessing the seer.

The alternative \"add a conditional in test 4 to skip abstain when host is a candidate\" was rejected as a mitigation — it leaves the underlying precondition unenforced.

## Validation

- \`npx vue-tsc --noEmit\` → exit 0
- \`npx playwright test --config=playwright.real.config.ts e2e/real/sheriff-flow.spec.ts\` → **5 passed (55.6s)** locally on a fresh \`e2e\` profile backend
- Structural reasoning across host-role cases (SEER / WITCH / GUARD / WEREWOLF / VILLAGER): \`candidateRole\` selection rejects \`ctx.hostRole\` and walks the remaining browser kit, always producing a valid non-host candidate

## Test plan

- [ ] CI: \"E2E · Integration\" shard 3/6 passes (it runs game-flow + sheriff-flow). All 6 shards should remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)