### PR TITLE
feat: sheriff night-death handover + witch self-save toggle + BGM duck to 10%

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/dto/RoomDtos.kt
+++ b/backend/src/main/kotlin/com/werewolf/dto/RoomDtos.kt
@@ -10,6 +10,7 @@ data class RoomConfigRequest(
     val hasSheriff: Boolean = true,
     val winCondition: WinConditionMode = WinConditionMode.CLASSIC,
     val bgmTrack: String? = null,
+    val witchSelfSaveAllowed: Boolean = true,
 )
 
 data class CreateRoomRequest(
@@ -44,7 +45,7 @@ data class RoomPlayerDto(
     val isHost: Boolean,
 )
 
-data class RoomConfigDto(val totalPlayers: Int, val roles: List<PlayerRole>, val hasSheriff: Boolean = true, val winCondition: WinConditionMode = WinConditionMode.CLASSIC, val bgmTrack: String? = null)
+data class RoomConfigDto(val totalPlayers: Int, val roles: List<PlayerRole>, val hasSheriff: Boolean = true, val winCondition: WinConditionMode = WinConditionMode.CLASSIC, val bgmTrack: String? = null, val witchSelfSaveAllowed: Boolean = true)
 
 data class RoomDto(
     val roomId: String,

--- a/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/phase/GamePhasePipeline.kt
@@ -68,10 +68,18 @@ class GamePhasePipeline(
             actionLogService.recordNightDeaths(context.gameId, context.game.dayNumber, pendingKills)
         }
 
-        context.game.subPhase = DaySubPhase.RESULT_REVEALED.name
+        // If the sheriff is among the night kills, transition into the new
+        // BADGE_HANDOVER sub-phase so the dying sheriff can pass on or destroy
+        // the badge before discussion begins. Otherwise land on RESULT_REVEALED
+        // and let the host advance to voting as usual.
+        val sheriffKilledAtNight =
+            context.game.sheriffUserId != null && context.game.sheriffUserId in pendingKills
+        val nextSubPhase =
+            if (sheriffKilledAtNight) DaySubPhase.BADGE_HANDOVER else DaySubPhase.RESULT_REVEALED
+        context.game.subPhase = nextSubPhase.name
         gameRepository.save(context.game)
 
-        log.info("[revealNightResult] Successfully revealed night result; applied kills=$pendingKills")
+        log.info("[revealNightResult] Successfully revealed night result; applied kills=$pendingKills nextSubPhase=$nextSubPhase")
         if (pendingKills.isNotEmpty()) {
             stompPublisher.broadcastGameAfterCommit(
                 context.gameId,
@@ -80,7 +88,7 @@ class GamePhasePipeline(
         }
         stompPublisher.broadcastGameAfterCommit(
             context.gameId,
-            DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_DISCUSSION, DaySubPhase.RESULT_REVEALED.name)
+            DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_DISCUSSION, nextSubPhase.name)
         )
 
         return GameActionResult.Success()

--- a/backend/src/main/kotlin/com/werewolf/game/role/WitchHandler.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/role/WitchHandler.kt
@@ -66,6 +66,13 @@ class WitchHandler(private val nightPhaseRepository: NightPhaseRepository) : Rol
         if (poisonTarget != null && context.alivePlayerById(poisonTarget) == null)
             return GameActionResult.Rejected("Poison target not found or dead")
 
+        // Self-save gate: when the room has disabled self-save and the wolves'
+        // victim tonight is the witch herself, reject the antidote.
+        val selfSaveAllowed = context.room.config?.witchSelfSaveAllowed ?: true
+        if (useAntidote && !selfSaveAllowed && nightPhase.wolfTargetUserId == actor.userId) {
+            return GameActionResult.Rejected("Witch cannot self-save in this game")
+        }
+
         if (useAntidote) {
             nightPhase.witchAntidoteUsed = true
             log.info("[WitchHandler] Antidote used")

--- a/backend/src/main/kotlin/com/werewolf/game/voting/VotingPipeline.kt
+++ b/backend/src/main/kotlin/com/werewolf/game/voting/VotingPipeline.kt
@@ -273,10 +273,22 @@ class VotingPipeline(
 
     @Transactional
     fun handleBadge(request: GameActionRequest, context: GameContext): GameActionResult {
-        if (context.game.phase != GamePhase.DAY_VOTING)
-            return GameActionResult.Rejected("Not in voting phase")
-        if (context.game.subPhase != VotingSubPhase.BADGE_HANDOVER.name)
+        // Two entry points share this handler:
+        //   (A) Voting elimination: DAY_VOTING + VotingSubPhase.BADGE_HANDOVER
+        //       — sheriff voted out → after handover, continue elimination via
+        //         afterElimination() and land on VotingSubPhase.VOTE_RESULT.
+        //   (B) Night kill reveal:  DAY_DISCUSSION + DaySubPhase.BADGE_HANDOVER
+        //       — sheriff killed at night → after handover, land back on
+        //         DaySubPhase.RESULT_REVEALED so host can advance to voting.
+        val fromVoting = context.game.phase == GamePhase.DAY_VOTING &&
+            context.game.subPhase == VotingSubPhase.BADGE_HANDOVER.name
+        val fromNightReveal = context.game.phase == GamePhase.DAY_DISCUSSION &&
+            context.game.subPhase == DaySubPhase.BADGE_HANDOVER.name
+        if (!fromVoting && !fromNightReveal)
             return GameActionResult.Rejected("Not in BADGE_HANDOVER sub-phase")
+
+        val postPhase = if (fromVoting) GamePhase.DAY_VOTING else GamePhase.DAY_DISCUSSION
+        val postSubPhase = if (fromVoting) VotingSubPhase.VOTE_RESULT.name else DaySubPhase.RESULT_REVEALED.name
 
         val actor = context.playerById(request.actorUserId)
             ?: return GameActionResult.Rejected("Actor not found")
@@ -292,10 +304,10 @@ class VotingPipeline(
 
                 // Update sheriff
                 context.game.sheriffUserId = targetPlayer.userId
-                context.game.subPhase = VotingSubPhase.VOTE_RESULT.name
+                context.game.subPhase = postSubPhase
                 gameRepository.save(context.game)
 
-                commitDeferredHunterShotIfAny(context, actor.userId)
+                if (fromVoting) commitDeferredHunterShotIfAny(context, actor.userId)
 
                 // Update sheriff flags
                 gamePlayerRepository.findByGameIdAndUserId(context.gameId, actor.userId).ifPresent {
@@ -310,16 +322,16 @@ class VotingPipeline(
                 )
                 stompPublisher.broadcastGameAfterCommit(
                     context.gameId,
-                    DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_VOTING, VotingSubPhase.VOTE_RESULT.name)
+                    DomainEvent.PhaseChanged(context.gameId, postPhase, postSubPhase)
                 )
             }
 
             ActionType.BADGE_DESTROY -> {
                 // Update sheriff
                 context.game.sheriffUserId = null
-                context.game.subPhase = VotingSubPhase.VOTE_RESULT.name
+                context.game.subPhase = postSubPhase
                 gameRepository.save(context.game)
-                commitDeferredHunterShotIfAny(context, actor.userId)
+                if (fromVoting) commitDeferredHunterShotIfAny(context, actor.userId)
                 gamePlayerRepository.findByGameIdAndUserId(context.gameId, actor.userId).ifPresent {
                     it.sheriff = false; gamePlayerRepository.save(it)
                 }
@@ -329,23 +341,16 @@ class VotingPipeline(
                 )
                 stompPublisher.broadcastGameAfterCommit(
                     context.gameId,
-                    DomainEvent.PhaseChanged(context.gameId, GamePhase.DAY_VOTING, VotingSubPhase.VOTE_RESULT.name)
+                    DomainEvent.PhaseChanged(context.gameId, postPhase, postSubPhase)
                 )
             }
 
             else -> return GameActionResult.Rejected("Unknown action: ${request.actionType}")
+        }
 
-            
-
-                    }
-
-            
-
-                    afterElimination(context)
-
-                    return GameActionResult.Success()
-
-                }
+        if (fromVoting) afterElimination(context)
+        return GameActionResult.Success()
+    }
 
     /**
      * Commit the deferred hunter-shot kill on the dying sheriff, if there is

--- a/backend/src/main/kotlin/com/werewolf/model/Enums.kt
+++ b/backend/src/main/kotlin/com/werewolf/model/Enums.kt
@@ -27,7 +27,7 @@ enum class VoteContext { SHERIFF_ELECTION, ELIMINATION }
 
 enum class WinnerSide { WEREWOLF, VILLAGER }
 
-enum class DaySubPhase { RESULT_HIDDEN, RESULT_REVEALED }
+enum class DaySubPhase { RESULT_HIDDEN, RESULT_REVEALED, BADGE_HANDOVER }
 
 enum class VotingSubPhase { VOTING, RE_VOTING, VOTE_RESULT, HUNTER_SHOOT, BADGE_HANDOVER }
 

--- a/backend/src/main/kotlin/com/werewolf/model/RoleDelayConfig.kt
+++ b/backend/src/main/kotlin/com/werewolf/model/RoleDelayConfig.kt
@@ -92,6 +92,12 @@ data class GameConfig(
      * 选定的夜晚背景音乐文件名（在 /audio/bgm/ 下），未选则为 null。
      */
     val bgmTrack: String? = null,
+
+    /**
+     * Whether the witch may use her antidote to save herself when the wolves'
+     * target is the witch. Default true preserves the historical behavior.
+     */
+    val witchSelfSaveAllowed: Boolean = true,
 ) {
     /**
      * 获取指定角色的延迟配置

--- a/backend/src/main/kotlin/com/werewolf/service/GameService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/GameService.kt
@@ -330,6 +330,7 @@ class GameService(
             // after a refresh — the existing per-phase startBgm watcher reads
             // it from gameStore as a fallback when roomStore is empty.
             "bgmTrack" to room?.config?.bgmTrack,
+            "witchSelfSaveAllowed" to (room?.config?.witchSelfSaveAllowed ?: true),
             "winner" to game.winner?.name,
             "myRole" to myPlayer?.role?.name,
             "roleReveal" to roleReveal,

--- a/backend/src/main/kotlin/com/werewolf/service/RoomService.kt
+++ b/backend/src/main/kotlin/com/werewolf/service/RoomService.kt
@@ -52,7 +52,7 @@ class RoomService(
                 hasIdiot = PlayerRole.IDIOT in cfg.roles,
                 hasSheriff = cfg.hasSheriff,
                 winCondition = cfg.winCondition,
-                config = buildGameConfig(cfg.bgmTrack),
+                config = buildGameConfig(cfg.bgmTrack, cfg.witchSelfSaveAllowed),
             )
         )
         val roomId = room.roomId ?: error("Failed to persist room")
@@ -231,7 +231,7 @@ class RoomService(
             hostId = room.hostUserId,
             status = room.status.name,
             players = playerDtos,
-            config = RoomConfigDto(totalPlayers = room.totalPlayers, roles = roles, hasSheriff = room.hasSheriff, winCondition = room.winCondition, bgmTrack = room.config?.bgmTrack),
+            config = RoomConfigDto(totalPlayers = room.totalPlayers, roles = roles, hasSheriff = room.hasSheriff, winCondition = room.winCondition, bgmTrack = room.config?.bgmTrack, witchSelfSaveAllowed = room.config?.witchSelfSaveAllowed ?: true),
             activeGameId = activeGameId,
         )
     }
@@ -246,7 +246,7 @@ class RoomService(
      * overrides. Production leaves the properties unset and gets the compile-time
      * role defaults; the test profile sets small values so CI completes quickly.
      */
-    private fun buildGameConfig(bgmTrack: String?): GameConfig = GameConfig(
+    private fun buildGameConfig(bgmTrack: String?, witchSelfSaveAllowed: Boolean): GameConfig = GameConfig(
         roleDelays = mapOf(
             PlayerRole.WEREWOLF to timing.applyTo(PlayerRole.WEREWOLF),
             PlayerRole.SEER to timing.applyTo(PlayerRole.SEER),
@@ -254,6 +254,7 @@ class RoomService(
             PlayerRole.GUARD to timing.applyTo(PlayerRole.GUARD),
         ),
         bgmTrack = bgmTrack,
+        witchSelfSaveAllowed = witchSelfSaveAllowed,
     )
 }
 

--- a/backend/src/main/resources/db/migration/V14__add_witch_self_save_config.sql
+++ b/backend/src/main/resources/db/migration/V14__add_witch_self_save_config.sql
@@ -1,0 +1,14 @@
+-- Backfill the new `witchSelfSaveAllowed` key into the `rooms.config` JSONB
+-- for every pre-existing row. Default is `true` to preserve the historical
+-- behavior (witch could always self-save before this feature shipped).
+--
+-- Idempotent: the guard `NOT (config ? 'witchSelfSaveAllowed')` makes
+-- re-running this migration a no-op on already-backfilled rows.
+UPDATE rooms
+SET config = jsonb_set(
+        COALESCE(config, '{}'::jsonb),
+        '{witchSelfSaveAllowed}',
+        'true'::jsonb,
+        true
+    )
+WHERE config IS NULL OR NOT (config ? 'witchSelfSaveAllowed');

--- a/backend/src/test/kotlin/com/werewolf/integration/SheriffNightDeathHandoverIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/integration/SheriffNightDeathHandoverIntegrationTest.kt
@@ -1,0 +1,319 @@
+package com.werewolf.integration
+
+import com.werewolf.integration.TestConstants.CREATE_ROOM_URL
+import com.werewolf.integration.TestConstants.FIELD_CONFIG
+import com.werewolf.integration.TestConstants.FIELD_ROOM_CODE
+import com.werewolf.integration.TestConstants.FIELD_ROOM_ID
+import com.werewolf.integration.TestConstants.FIELD_TOKEN
+import com.werewolf.integration.TestConstants.FIELD_TOTAL_PLAYERS
+import com.werewolf.integration.TestConstants.JOIN_ROOM_URL
+import com.werewolf.integration.TestConstants.LOGIN_URL
+import com.werewolf.model.DaySubPhase
+import com.werewolf.model.GamePhase
+import com.werewolf.model.NightPhase
+import com.werewolf.model.NightSubPhase
+import com.werewolf.repository.GamePlayerRepository
+import com.werewolf.repository.GameRepository
+import com.werewolf.repository.NightPhaseRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Integration coverage for the new "sheriff killed at night gets one last
+ * action" contract. Setup mirrors SheriffElectionIntegrationTest's shortcut
+ * style — the night flow isn't under test, so we manipulate the NightPhase
+ * row directly to set wolfTargetUserId, then hit REVEAL_NIGHT_RESULT through
+ * the real HTTP endpoint and verify:
+ *
+ *   1. revealNightResult lands on DAY_DISCUSSION/BADGE_HANDOVER when the
+ *      sheriff is the wolves' victim (and stays on RESULT_REVEALED when
+ *      they're not).
+ *   2. BADGE_PASS during the night-reveal handover transitions back to
+ *      DAY_DISCUSSION/RESULT_REVEALED with the heir flagged.
+ *   3. BADGE_DESTROY during the night-reveal handover clears sheriffUserId
+ *      and lands on RESULT_REVEALED.
+ *   4. After handover, the existing dayAdvance path still works (host can
+ *      proceed to voting).
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class SheriffNightDeathHandoverIntegrationTest {
+
+    @Autowired lateinit var restTemplate: TestRestTemplate
+    @Autowired lateinit var gameRepository: GameRepository
+    @Autowired lateinit var gamePlayerRepository: GamePlayerRepository
+    @Autowired lateinit var nightPhaseRepository: NightPhaseRepository
+
+    companion object {
+        const val START_URL = "/api/game/start"
+        const val SEAT_URL = "/api/room/seat"
+        const val READY_URL = "/api/room/ready"
+        const val ACTION_URL = "/api/game/action"
+    }
+
+    private data class TestPlayer(val token: String, val userId: String)
+
+    private fun login(nickname: String): TestPlayer {
+        @Suppress("UNCHECKED_CAST")
+        val body = restTemplate.postForEntity(LOGIN_URL, mapOf("nickname" to nickname), Map::class.java).body!!
+        val token = body[FIELD_TOKEN] as String
+        val userId = (body["user"] as Map<*, *>)["userId"] as String
+        return TestPlayer(token, userId)
+    }
+
+    private fun headers(token: String) = HttpHeaders().also {
+        it.setBearerAuth(token)
+        it.contentType = MediaType.APPLICATION_JSON
+    }
+
+    private fun action(token: String, gameId: Int, actionType: String, targetUserId: String? = null) =
+        restTemplate.postForEntity(
+            ACTION_URL,
+            HttpEntity(
+                mapOf("gameId" to gameId, "actionType" to actionType, "targetUserId" to targetUserId),
+                headers(token)
+            ),
+            Map::class.java
+        )
+
+    private data class Sextuple(
+        val host: TestPlayer,
+        val g1: TestPlayer,
+        val g2: TestPlayer,
+        val g3: TestPlayer,
+        val g4: TestPlayer,
+        val g5: TestPlayer,
+        val roomId: Int,
+    )
+
+    private fun setupSheriffRoom(prefix: String): Sextuple {
+        val host = login("${prefix}H")
+        val g1 = login("${prefix}G1")
+        val g2 = login("${prefix}G2")
+        val g3 = login("${prefix}G3")
+        val g4 = login("${prefix}G4")
+        val g5 = login("${prefix}G5")
+
+        @Suppress("UNCHECKED_CAST")
+        val roomBody = restTemplate.postForEntity(
+            CREATE_ROOM_URL,
+            HttpEntity(
+                mapOf(
+                    FIELD_CONFIG to mapOf(
+                        FIELD_TOTAL_PLAYERS to 6,
+                        "roles" to listOf("WEREWOLF", "SEER", "WITCH", "VILLAGER", "VILLAGER"),
+                        "hasSheriff" to true,
+                    ),
+                ),
+                headers(host.token),
+            ),
+            Map::class.java,
+        ).body!! as Map<String, Any?>
+
+        val roomId = (roomBody[FIELD_ROOM_ID] as String).toInt()
+        val roomCode = roomBody[FIELD_ROOM_CODE] as String
+
+        restTemplate.postForEntity(
+            SEAT_URL,
+            HttpEntity(mapOf("seatIndex" to 0, "roomId" to roomId), headers(host.token)),
+            Map::class.java,
+        )
+
+        listOf(g1, g2, g3, g4, g5).forEachIndexed { idx, player ->
+            restTemplate.postForEntity(
+                JOIN_ROOM_URL,
+                HttpEntity(mapOf("roomCode" to roomCode), headers(player.token)),
+                Map::class.java,
+            )
+            restTemplate.postForEntity(
+                SEAT_URL,
+                HttpEntity(mapOf("seatIndex" to idx + 1, "roomId" to roomId), headers(player.token)),
+                Map::class.java,
+            )
+            restTemplate.postForEntity(
+                READY_URL,
+                HttpEntity(mapOf("ready" to true, "roomId" to roomId), headers(player.token)),
+                Map::class.java,
+            )
+        }
+
+        return Sextuple(host, g1, g2, g3, g4, g5, roomId)
+    }
+
+    /**
+     * Drive the room from creation → DAY_DISCUSSION/RESULT_HIDDEN with the
+     * given user already flagged as sheriff and a populated Day-2 NightPhase
+     * where the wolves chose `wolfTargetUserId` as their victim.
+     *
+     * Bypasses the actual night flow — this test is about the day-reveal
+     * branch, not about night orchestration.
+     */
+    private fun openDay2RevealWithSheriffAndWolfTarget(
+        host: TestPlayer,
+        players: List<TestPlayer>,
+        roomId: Int,
+        sheriffUserId: String,
+        wolfTargetUserId: String,
+    ): Int {
+        val startResp = restTemplate.postForEntity(
+            START_URL, HttpEntity(mapOf("roomId" to roomId), headers(host.token)), Map::class.java
+        )
+        assertThat(startResp.statusCode).isEqualTo(HttpStatus.OK)
+
+        val game = gameRepository.findAll().first { it.roomId == roomId }
+        val gameId = game.gameId!!
+
+        players.forEach { player ->
+            assertThat(action(player.token, gameId, "CONFIRM_ROLE").statusCode).isEqualTo(HttpStatus.OK)
+        }
+
+        // Park the game at "Day 2 morning, ready to reveal" with the sheriff
+        // already in place. Real games reach this state via N1 → election →
+        // D1 vote → N2 night actions; we skip ahead because that path is
+        // already covered by SheriffElectionIntegrationTest + the unit suite.
+        game.phase = GamePhase.DAY_DISCUSSION
+        game.subPhase = DaySubPhase.RESULT_HIDDEN.name
+        game.dayNumber = 2
+        game.sheriffUserId = sheriffUserId
+        gameRepository.save(game)
+
+        // Flag the sheriff player as sheriff (matches what handleBadge
+        // checks alongside game.sheriffUserId).
+        gamePlayerRepository.findByGameIdAndUserId(gameId, sheriffUserId).ifPresent {
+            it.sheriff = true
+            gamePlayerRepository.save(it)
+        }
+
+        // The night that just ended: wolves targeted the given player. No
+        // antidote, no guard save → computePendingKills returns [target].
+        nightPhaseRepository.save(NightPhase(gameId = gameId, dayNumber = 2).also {
+            it.subPhase = NightSubPhase.COMPLETE
+            it.wolfTargetUserId = wolfTargetUserId
+        })
+
+        return gameId
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `revealNightResult lands on BADGE_HANDOVER when sheriff is the wolves victim`() {
+        val (host, g1, g2, g3, g4, g5, roomId) = setupSheriffRoom("SNDH1")
+        val players = listOf(host, g1, g2, g3, g4, g5)
+        val gameId = openDay2RevealWithSheriffAndWolfTarget(
+            host, players, roomId,
+            sheriffUserId = g1.userId,
+            wolfTargetUserId = g1.userId,
+        )
+
+        val resp = action(host.token, gameId, "REVEAL_NIGHT_RESULT")
+        assertThat(resp.statusCode).isEqualTo(HttpStatus.OK)
+
+        val game = gameRepository.findById(gameId).orElseThrow()
+        assertThat(game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(game.subPhase).isEqualTo(DaySubPhase.BADGE_HANDOVER.name)
+        // Sheriff identity is intact during handover; the dying player is
+        // still authorized to dispatch BADGE_PASS / BADGE_DESTROY.
+        assertThat(game.sheriffUserId).isEqualTo(g1.userId)
+        // Sheriff is dead in DB after applyNightKills, but the handover doesn't
+        // care about aliveness for the actor check.
+        val g1Player = gamePlayerRepository.findByGameIdAndUserId(gameId, g1.userId).orElseThrow()
+        assertThat(g1Player.alive).isFalse()
+    }
+
+    @Test
+    fun `revealNightResult lands on RESULT_REVEALED when a non-sheriff is killed`() {
+        val (host, g1, g2, g3, g4, g5, roomId) = setupSheriffRoom("SNDH2")
+        val players = listOf(host, g1, g2, g3, g4, g5)
+        val gameId = openDay2RevealWithSheriffAndWolfTarget(
+            host, players, roomId,
+            sheriffUserId = g1.userId,
+            wolfTargetUserId = g2.userId, // not the sheriff
+        )
+
+        val resp = action(host.token, gameId, "REVEAL_NIGHT_RESULT")
+        assertThat(resp.statusCode).isEqualTo(HttpStatus.OK)
+
+        val game = gameRepository.findById(gameId).orElseThrow()
+        assertThat(game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        assertThat(game.sheriffUserId).isEqualTo(g1.userId)
+    }
+
+    @Test
+    fun `night-reveal BADGE_PASS hands the badge to the heir and lands back on RESULT_REVEALED`() {
+        val (host, g1, g2, g3, g4, g5, roomId) = setupSheriffRoom("SNDH3")
+        val players = listOf(host, g1, g2, g3, g4, g5)
+        val gameId = openDay2RevealWithSheriffAndWolfTarget(
+            host, players, roomId,
+            sheriffUserId = g1.userId,
+            wolfTargetUserId = g1.userId,
+        )
+        // Land in BADGE_HANDOVER first.
+        assertThat(action(host.token, gameId, "REVEAL_NIGHT_RESULT").statusCode).isEqualTo(HttpStatus.OK)
+
+        // Sheriff hands the badge to g3 (alive).
+        val passResp = action(g1.token, gameId, "BADGE_PASS", g3.userId)
+        assertThat(passResp.statusCode).isEqualTo(HttpStatus.OK)
+
+        val game = gameRepository.findById(gameId).orElseThrow()
+        assertThat(game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        assertThat(game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        assertThat(game.sheriffUserId).isEqualTo(g3.userId)
+
+        val oldSheriff = gamePlayerRepository.findByGameIdAndUserId(gameId, g1.userId).orElseThrow()
+        val newSheriff = gamePlayerRepository.findByGameIdAndUserId(gameId, g3.userId).orElseThrow()
+        assertThat(oldSheriff.sheriff).isFalse()
+        assertThat(newSheriff.sheriff).isTrue()
+    }
+
+    @Test
+    fun `night-reveal BADGE_DESTROY clears sheriffUserId and lands back on RESULT_REVEALED`() {
+        val (host, g1, g2, g3, g4, g5, roomId) = setupSheriffRoom("SNDH4")
+        val players = listOf(host, g1, g2, g3, g4, g5)
+        val gameId = openDay2RevealWithSheriffAndWolfTarget(
+            host, players, roomId,
+            sheriffUserId = g1.userId,
+            wolfTargetUserId = g1.userId,
+        )
+        assertThat(action(host.token, gameId, "REVEAL_NIGHT_RESULT").statusCode).isEqualTo(HttpStatus.OK)
+
+        val destroyResp = action(g1.token, gameId, "BADGE_DESTROY")
+        assertThat(destroyResp.statusCode).isEqualTo(HttpStatus.OK)
+
+        val game = gameRepository.findById(gameId).orElseThrow()
+        assertThat(game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        assertThat(game.sheriffUserId).isNull()
+
+        val oldSheriff = gamePlayerRepository.findByGameIdAndUserId(gameId, g1.userId).orElseThrow()
+        assertThat(oldSheriff.sheriff).isFalse()
+    }
+
+    @Test
+    fun `after night-reveal handover, host can dayAdvance to voting`() {
+        val (host, g1, g2, g3, g4, g5, roomId) = setupSheriffRoom("SNDH5")
+        val players = listOf(host, g1, g2, g3, g4, g5)
+        val gameId = openDay2RevealWithSheriffAndWolfTarget(
+            host, players, roomId,
+            sheriffUserId = g1.userId,
+            wolfTargetUserId = g1.userId,
+        )
+        assertThat(action(host.token, gameId, "REVEAL_NIGHT_RESULT").statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(action(g1.token, gameId, "BADGE_PASS", g3.userId).statusCode).isEqualTo(HttpStatus.OK)
+
+        // Now the host can advance into voting via the existing DAY_ADVANCE.
+        val advanceResp = action(host.token, gameId, "DAY_ADVANCE")
+        assertThat(advanceResp.statusCode).isEqualTo(HttpStatus.OK)
+
+        val game = gameRepository.findById(gameId).orElseThrow()
+        assertThat(game.phase).isEqualTo(GamePhase.DAY_VOTING)
+    }
+}

--- a/backend/src/test/kotlin/com/werewolf/unit/role/WitchHandlerTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/role/WitchHandlerTest.kt
@@ -239,4 +239,57 @@ class WitchHandlerTest {
         assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
         assertThat((result as GameActionResult.Rejected).reason).contains("Poison target not found or dead")
     }
+
+    // ── Witch self-save config gate ─────────────────────────────────────────
+
+    private fun roomWithSelfSave(allowed: Boolean) = Room(
+        roomCode = "ABCD",
+        hostUserId = hostId,
+        totalPlayers = 6,
+        config = GameConfig(witchSelfSaveAllowed = allowed),
+    )
+
+    private fun ctxWithRoom(room: Room, vararg players: GamePlayer, nightPhase: NightPhase = nightPhase()) =
+        GameContext(game(), room, players.toList(), nightPhase = nightPhase, allNightPhases = emptyList())
+
+    @Test
+    fun `Self-save allowed (default) - witch antidoting herself succeeds when wolves attacked her`() {
+        val witch = player(witchId, 1, PlayerRole.WITCH)
+        val np = nightPhase().also { it.wolfTargetUserId = witchId }
+        val context = ctxWithRoom(roomWithSelfSave(allowed = true), witch, nightPhase = np)
+        whenever(nightPhaseRepository.save(any<NightPhase>())).thenAnswer { it.arguments[0] }
+
+        val result = witchHandler.handle(req(payload = mapOf("useAntidote" to true)), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(np.witchAntidoteUsed).isTrue()
+    }
+
+    @Test
+    fun `Self-save disabled - witch antidoting herself rejected when wolves attacked her`() {
+        val witch = player(witchId, 1, PlayerRole.WITCH)
+        val np = nightPhase().also { it.wolfTargetUserId = witchId }
+        val context = ctxWithRoom(roomWithSelfSave(allowed = false), witch, nightPhase = np)
+
+        val result = witchHandler.handle(req(payload = mapOf("useAntidote" to true)), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+        assertThat((result as GameActionResult.Rejected).reason).contains("Witch cannot self-save")
+        assertThat(np.witchAntidoteUsed).isFalse()
+    }
+
+    @Test
+    fun `Self-save disabled - witch antidoting someone else still succeeds`() {
+        val witch = player(witchId, 1, PlayerRole.WITCH)
+        val attacked = player(targetId, 2)
+        // Wolves attacked the OTHER player, not the witch.
+        val np = nightPhase().also { it.wolfTargetUserId = targetId }
+        val context = ctxWithRoom(roomWithSelfSave(allowed = false), witch, attacked, nightPhase = np)
+        whenever(nightPhaseRepository.save(any<NightPhase>())).thenAnswer { it.arguments[0] }
+
+        val result = witchHandler.handle(req(payload = mapOf("useAntidote" to true)), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(np.witchAntidoteUsed).isTrue()
+    }
 }

--- a/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/GamePipelineSheriffTest.kt
@@ -249,13 +249,16 @@ class GamePipelineSheriffTest {
     // ── Night-kill = no last action contract (regression guard for Phase B) ──
 
     @Test
-    fun `revealNightResult with sheriff among the killed lands on RESULT_REVEALED, NOT BADGE_HANDOVER`() {
-        // Contract: a sheriff killed at night silently loses the badge — no
-        // BADGE_HANDOVER sub-phase fires. Last actions only happen on vote-out
-        // (国标 rule: only voted-out players retain agency at the moment of
-        // elimination). An earlier Phase B prototype routed night-killed
-        // sheriffs to DAY_DISCUSSION/BADGE_HANDOVER; that was reverted because
-        // it ships the wrong rule. This test guards against re-introducing it.
+    fun `revealNightResult with sheriff among the killed lands on BADGE_HANDOVER`() {
+        // Contract (updated): a sheriff killed at night gets one last action —
+        // pass the badge to an heir or destroy it. revealNightResult lands the
+        // game on DAY_DISCUSSION/BADGE_HANDOVER (new DaySubPhase value); the
+        // dying sheriff then dispatches BADGE_PASS / BADGE_DESTROY through
+        // VotingPipeline.handleBadge, which transitions back to RESULT_REVEALED
+        // so the host can advance to voting. Earlier prototype: night-killed
+        // sheriffs silently lost the badge — that contract was reversed at the
+        // product owner's request because losing the badge with no farewell
+        // was unsatisfying gameplay.
         val np = NightPhase(gameId = gameId, dayNumber = 2).also {
             it.subPhase = NightSubPhase.COMPLETE
             it.wolfTargetUserId = "sheriff_victim"
@@ -271,10 +274,31 @@ class GamePipelineSheriffTest {
         val result = pipeline.revealNightResult(req, ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.BADGE_HANDOVER.name)
+        assertThat(ctx.game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+    }
+
+    @Test
+    fun `revealNightResult with non-sheriff among the killed lands on RESULT_REVEALED`() {
+        // Counterpart to the above: the BADGE_HANDOVER branch must trigger only
+        // when the dying player IS the sheriff. A non-sheriff night death lands
+        // on RESULT_REVEALED as before.
+        val np = NightPhase(gameId = gameId, dayNumber = 2).also {
+            it.subPhase = NightSubPhase.COMPLETE
+            it.wolfTargetUserId = "non_sheriff_victim"
+        }
+        whenever(nightPhaseRepository.findByGameIdAndDayNumber(gameId, 2)).thenReturn(Optional.of(np))
+        whenever(nightOrchestrator.computePendingKills(np)).thenReturn(listOf("non_sheriff_victim"))
+
+        val game = game(phase = GamePhase.DAY_DISCUSSION, dayNumber = 2, subPhase = DaySubPhase.RESULT_HIDDEN.name)
+        game.sheriffUserId = "different_sheriff"
+        val ctx = GameContext(game, room(hasSheriff = true), emptyList())
+
+        val req = GameActionRequest(gameId, hostId, ActionType.REVEAL_NIGHT_RESULT)
+        val result = pipeline.revealNightResult(req, ctx)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
         assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
-        // Crucially: NOT BADGE_HANDOVER — the contract says the badge
-        // silently disappears when the sheriff dies at night.
-        assertThat(ctx.game.subPhase).isNotEqualTo("BADGE_HANDOVER")
     }
 
     @Test
@@ -307,12 +331,11 @@ class GamePipelineSheriffTest {
     }
 
     @Test
-    fun `revealNightResult with sheriff AND hunter killed lands on RESULT_REVEALED, NOT BADGE_HANDOVER nor HUNTER_SHOOT`() {
-        // The doubly-special-role night-kill: both sheriff and hunter are
-        // among the killed (e.g. wolves' WOLF_KILL targets the sheriff; witch
-        // poisons the hunter). Neither last-action sub-phase fires — both
-        // players just die. The contract's symmetry: "killed at night = no
-        // last action" applies regardless of which / how many specials died.
+    fun `revealNightResult with sheriff AND hunter killed lands on BADGE_HANDOVER but skips HUNTER_SHOOT`() {
+        // Asymmetric mixed case: sheriff gets a last action (badge handover);
+        // hunter night-death still does NOT trigger HUNTER_SHOOT — that
+        // privilege remains a day-voting exclusive. Sheriff-handover takes
+        // precedence and is the only last-action that fires at reveal.
         val np = NightPhase(gameId = gameId, dayNumber = 2).also {
             it.subPhase = NightSubPhase.COMPLETE
             it.wolfTargetUserId = "sheriff_victim"
@@ -330,6 +353,7 @@ class GamePipelineSheriffTest {
         val result = pipeline.revealNightResult(req, ctx)
 
         assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
-        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        assertThat(ctx.game.subPhase).isEqualTo(DaySubPhase.BADGE_HANDOVER.name)
+        assertThat(ctx.game.subPhase).isNotEqualTo("HUNTER_SHOOT")
     }
 }

--- a/backend/src/test/kotlin/com/werewolf/unit/service/VotingPipelineTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/service/VotingPipelineTest.kt
@@ -368,6 +368,81 @@ class VotingPipelineTest {
         }
     }
 
+    // ── Night-reveal badge handover path ──────────────────────────────────────
+
+    /**
+     * Game state for the night-reveal handover branch: phase=DAY_DISCUSSION,
+     * subPhase=DaySubPhase.BADGE_HANDOVER (set by GamePhasePipeline.revealNightResult
+     * when sheriff is among pending kills).
+     */
+    private fun nightRevealGame(sheriff: String) = Game(roomId = 1, hostUserId = hostId).also {
+        val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
+        it.phase = GamePhase.DAY_DISCUSSION
+        it.subPhase = DaySubPhase.BADGE_HANDOVER.name
+        it.dayNumber = 2
+        it.sheriffUserId = sheriff
+    }
+
+    @Test
+    fun `handleBadge BADGE_PASS from night-reveal transitions to RESULT_REVEALED and does NOT run afterElimination`() {
+        // Night-killed sheriff hands the badge to an heir. Post-handover the
+        // game must land on DAY_DISCUSSION/RESULT_REVEALED so the host can run
+        // dayAdvance into voting. No elimination happened, so afterElimination
+        // (and its win-condition check via contextLoader) must NOT fire.
+        val dyingSheriff = player("u2", 2, alive = false).also { it.sheriff = true }
+        val heir = player("u3", 3)
+        val game = nightRevealGame(sheriff = "u2")
+        val context = GameContext(game, room(), listOf(dyingSheriff, heir))
+
+        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, "u2")).thenReturn(Optional.of(dyingSheriff))
+        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, "u3")).thenReturn(Optional.of(heir))
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+
+        val result = votingPipeline.handleBadge(req("u2", ActionType.BADGE_PASS, "u3"), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(game.sheriffUserId).isEqualTo("u3")
+        assertThat(game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        assertThat(game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        // No afterElimination — contextLoader.load must NOT be called.
+        verify(contextLoader, never()).load(any())
+        verify(winConditionChecker, never()).check(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `handleBadge BADGE_DESTROY from night-reveal transitions to RESULT_REVEALED with sheriff cleared`() {
+        val dyingSheriff = player("u2", 2, alive = false).also { it.sheriff = true }
+        val game = nightRevealGame(sheriff = "u2")
+        val context = GameContext(game, room(), listOf(dyingSheriff))
+
+        whenever(gamePlayerRepository.findByGameIdAndUserId(gameId, "u2")).thenReturn(Optional.of(dyingSheriff))
+        whenever(gameRepository.save(any<Game>())).thenAnswer { it.arguments[0] }
+
+        val result = votingPipeline.handleBadge(req("u2", ActionType.BADGE_DESTROY), context)
+
+        assertThat(result).isInstanceOf(GameActionResult.Success::class.java)
+        assertThat(game.sheriffUserId).isNull()
+        assertThat(game.subPhase).isEqualTo(DaySubPhase.RESULT_REVEALED.name)
+        assertThat(game.phase).isEqualTo(GamePhase.DAY_DISCUSSION)
+        verify(contextLoader, never()).load(any())
+    }
+
+    @Test
+    fun `handleBadge rejected when not in any BADGE_HANDOVER sub-phase`() {
+        val sheriff = player("u2", 2)
+        val game = Game(roomId = 1, hostUserId = hostId).also {
+            val f = Game::class.java.getDeclaredField("gameId"); f.isAccessible = true; f.set(it, gameId)
+            it.phase = GamePhase.DAY_DISCUSSION
+            it.subPhase = DaySubPhase.RESULT_REVEALED.name
+            it.sheriffUserId = "u2"
+        }
+        val context = GameContext(game, room(), listOf(sheriff))
+
+        val result = votingPipeline.handleBadge(req("u2", ActionType.BADGE_PASS, "u3"), context)
+        assertThat(result).isInstanceOf(GameActionResult.Rejected::class.java)
+        assertThat((result as GameActionResult.Rejected).reason).contains("BADGE_HANDOVER")
+    }
+
     @Test
     fun `handleHunterShoot - hunter shoots last wolf, game ends with VILLAGER win`() {
         val hunter = player(hostId, 0, PlayerRole.HUNTER)

--- a/frontend/e2e/real/flow-12p-sheriff.spec.ts
+++ b/frontend/e2e/real/flow-12p-sheriff.spec.ts
@@ -13,20 +13,18 @@
  * the Playwright report so the evidence is viewable at:
  *   docs/e2e-evidence/<run>/index.html  (after npx playwright show-report)
  */
-import {expect, type Page, test} from '@playwright/test'
-import {type GameContext, setupGame} from './helpers/multi-browser'
-import {act, actName, type RoleName, sheriff} from './helpers/shell-runner'
-import {
-  driveMinimalNight1ViaDom,
-  waitForDayDiscussionAfterSheriff,
-} from './helpers/night-driver'
-import {verifyAllBrowsersPhase} from './helpers/assertions'
-import {attachCompositeOnFailure, captureSnapshot} from './helpers/composite-screenshot'
+import { expect, type Page, test } from '@playwright/test'
+import { type GameContext, setupGame } from './helpers/multi-browser'
+import { act, actName, type RoleName, sheriff } from './helpers/shell-runner'
+import { driveMinimalNight1ViaDom, waitForDayDiscussionAfterSheriff } from './helpers/night-driver'
+import { verifyAllBrowsersPhase } from './helpers/assertions'
+import { attachCompositeOnFailure, captureSnapshot } from './helpers/composite-screenshot'
 import {
   readAlivePlayerIds,
   readHostSeat,
   readHostUserId,
   readUnvotedAlivePlayerIds,
+  waitForCondition,
   waitForVotingSubPhase,
 } from './helpers/state-polling'
 
@@ -53,10 +51,7 @@ function assertNonNull<T>(value: T | null | undefined, msg: string): asserts val
  * Resolve `role` to its bot OR to the host (whoever holds it). Returns null
  * only if neither holds the role (impossible if the role is in the kit).
  */
-async function resolveRolePlayer(
-  ctx: GameContext,
-  role: RoleName,
-): Promise<RolePlayer | null> {
+async function resolveRolePlayer(ctx: GameContext, role: RoleName): Promise<RolePlayer | null> {
   if (ctx.isHostRole(role)) {
     const hostSeat = await readHostSeat(ctx.hostPage, ctx.gameId)
     const hostUserId = await readHostUserId(ctx.hostPage)
@@ -255,7 +250,9 @@ async function runSheriffElection(ctx: GameContext, pickNickCampaign: string[]):
     }
   }
   // eslint-disable-next-line no-console
-  console.warn(`[sheriff] after campaign scripts — subPhase=${await readSheriffSubPhase(hostPage, gameId)}`)
+  console.warn(
+    `[sheriff] after campaign scripts — subPhase=${await readSheriffSubPhase(hostPage, gameId)}`,
+  )
 
   // 2026-05-11: SIGNUP→SPEECH is now backend-auto-triggered when every alive
   // player has decided. The host's `sheriff-start-campaign` button is gone.
@@ -292,10 +289,14 @@ async function runSheriffElection(ctx: GameContext, pickNickCampaign: string[]):
   // Wait for backend to auto-transition SIGNUP → SPEECH.
   const reachedSpeech = await waitForSheriffSubPhase(hostPage, gameId, 'SPEECH', 15_000)
   // eslint-disable-next-line no-console
-  console.warn(`[sheriff] reachedSpeech=${reachedSpeech} current=${await readSheriffSubPhase(hostPage, gameId)}`)
+  console.warn(
+    `[sheriff] reachedSpeech=${reachedSpeech} current=${await readSheriffSubPhase(hostPage, gameId)}`,
+  )
   await advanceAllSheriffSpeeches(hostPage, gameId)
   // eslint-disable-next-line no-console
-  console.warn(`[sheriff] advanceAllSpeeches done — subPhase=${await readSheriffSubPhase(hostPage, gameId)}`)
+  console.warn(
+    `[sheriff] advanceAllSpeeches done — subPhase=${await readSheriffSubPhase(hostPage, gameId)}`,
+  )
 
   const reachedVoting = await waitForSheriffSubPhase(hostPage, gameId, 'VOTING', 15_000)
   // eslint-disable-next-line no-console
@@ -393,7 +394,9 @@ async function runSheriffElection(ctx: GameContext, pickNickCampaign: string[]):
   }
   await hostPage.waitForTimeout(1_500)
   // eslint-disable-next-line no-console
-  console.warn(`[sheriff] leaving runSheriffElection — subPhase=${await readSheriffSubPhase(hostPage, gameId)}`)
+  console.warn(
+    `[sheriff] leaving runSheriffElection — subPhase=${await readSheriffSubPhase(hostPage, gameId)}`,
+  )
 }
 
 /**
@@ -401,7 +404,11 @@ async function runSheriffElection(ctx: GameContext, pickNickCampaign: string[]):
  * seerCheckSeat = optional target for seer's check. Returns silently; rejected
  * actions are ignored (roles may be dead / skipped).
  */
-async function completeNight(ctx: GameContext, targetSeat: number, seerCheckSeat?: number): Promise<void> {
+async function completeNight(
+  ctx: GameContext,
+  targetSeat: number,
+  seerCheckSeat?: number,
+): Promise<void> {
   const wolfBots = ctx.roleMap.WEREWOLF ?? []
   const seerBots = ctx.roleMap.SEER ?? []
   const witchBots = ctx.roleMap.WITCH ?? []
@@ -439,7 +446,9 @@ async function completeNight(ctx: GameContext, targetSeat: number, seerCheckSeat
   const seatToUserId = await hostPage.evaluate(async (id: string) => {
     const token = localStorage.getItem('jwt')
     if (!token) return {} as Record<string, string>
-    const res = await fetch(`/api/game/${id}/state`, { headers: { Authorization: `Bearer ${token}` } })
+    const res = await fetch(`/api/game/${id}/state`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
     if (!res.ok) return {} as Record<string, string>
     const state = await res.json()
     return Object.fromEntries(
@@ -455,7 +464,8 @@ async function completeNight(ctx: GameContext, targetSeat: number, seerCheckSeat
     : (Object.entries(seatToUserId).find(
         ([s, uid]) => !wolfSeats.has(Number(s)) && isAlive(uid),
       )?.[0] ?? targetSeat)
-  const resolvedTargetSeatNum = typeof resolvedTargetSeat === 'string' ? Number(resolvedTargetSeat) : resolvedTargetSeat
+  const resolvedTargetSeatNum =
+    typeof resolvedTargetSeat === 'string' ? Number(resolvedTargetSeat) : resolvedTargetSeat
 
   // ── WEREWOLF_PICK ──
   // Only fire the kill if the backend actually reached the WEREWOLF_PICK
@@ -467,11 +477,21 @@ async function completeNight(ctx: GameContext, targetSeat: number, seerCheckSeat
   const reachedWolfPick = await waitForSubPhase(hostPage, gameId, 'WEREWOLF_PICK', 20_000)
   if (!reachedWolfPick) return
   if (wolfBot) {
-    tryAct('WOLF_KILL', actName(wolfBot), { target: String(resolvedTargetSeatNum), room: ctx.roomCode })
+    tryAct('WOLF_KILL', actName(wolfBot), {
+      target: String(resolvedTargetSeatNum),
+      room: ctx.roomCode,
+    })
   } else {
     // host is the sole alive wolf — drive via host UI
-    await hostPage.locator('.player-grid .slot-alive').first().click().catch(() => {})
-    await hostPage.getByTestId('wolf-confirm-kill').click().catch(() => {})
+    await hostPage
+      .locator('.player-grid .slot-alive')
+      .first()
+      .click()
+      .catch(() => {})
+    await hostPage
+      .getByTestId('wolf-confirm-kill')
+      .click()
+      .catch(() => {})
   }
 
   // ── WITCH_ACT ──
@@ -494,9 +514,12 @@ async function completeNight(ctx: GameContext, targetSeat: number, seerCheckSeat
       // the self-check prohibition (game-rules memory).
       const candidateSeat = seerCheckSeat ?? 1
       const candidateBot = ctx.allBots.find((b) => b.seat === candidateSeat && isAlive(b.userId))
-      const checkSeat = candidateBot && candidateBot.userId !== seerBot.userId
-        ? candidateSeat
-        : ctx.allBots.find((b) => b.userId !== seerBot.userId && b.nick !== 'Host' && isAlive(b.userId))?.seat ?? candidateSeat
+      const checkSeat =
+        candidateBot && candidateBot.userId !== seerBot.userId
+          ? candidateSeat
+          : (ctx.allBots.find(
+              (b) => b.userId !== seerBot.userId && b.nick !== 'Host' && isAlive(b.userId),
+            )?.seat ?? candidateSeat)
       tryAct('SEER_CHECK', actName(seerBot), { target: String(checkSeat), room: ctx.roomCode })
       // SEER_RESULT next
       await waitForSubPhase(hostPage, gameId, 'SEER_RESULT', 10_000)
@@ -564,24 +587,29 @@ async function completeDay(
   // would otherwise resolve to undefined and the fan-out would silently
   // abstain instead of voting.
   const aliveIds = await readAlivePlayerIds(hostPage, gameId)
-  const targetUserId = targetSeat >= 0
-    ? await hostPage.evaluate(
-        async ({ id, seat }) => {
-          const token = localStorage.getItem('jwt')
-          if (!token) return null as string | null
-          const res = await fetch(`/api/game/${id}/state`, {
-            headers: { Authorization: `Bearer ${token}` },
-          })
-          if (!res.ok) return null as string | null
-          const state = await res.json()
-          const match = ((state?.players ?? []) as Array<{ seatIndex: number; userId: string }>)
-            .find((p) => p.seatIndex === seat)
-          return match?.userId ?? null
-        },
-        { id: gameId, seat: targetSeat },
-      )
-    : null
-  const targetBot = targetUserId && aliveIds.has(targetUserId) ? { seat: targetSeat, userId: targetUserId } : undefined
+  const targetUserId =
+    targetSeat >= 0
+      ? await hostPage.evaluate(
+          async ({ id, seat }) => {
+            const token = localStorage.getItem('jwt')
+            if (!token) return null as string | null
+            const res = await fetch(`/api/game/${id}/state`, {
+              headers: { Authorization: `Bearer ${token}` },
+            })
+            if (!res.ok) return null as string | null
+            const state = await res.json()
+            const match = (
+              (state?.players ?? []) as Array<{ seatIndex: number; userId: string }>
+            ).find((p) => p.seatIndex === seat)
+            return match?.userId ?? null
+          },
+          { id: gameId, seat: targetSeat },
+        )
+      : null
+  const targetBot =
+    targetUserId && aliveIds.has(targetUserId)
+      ? { seat: targetSeat, userId: targetUserId }
+      : undefined
   // eslint-disable-next-line no-console
   console.warn(
     `[completeDay] targetSeat=${targetSeat} → targetUserId=${targetUserId ?? 'null'} alive=${targetUserId ? aliveIds.has(targetUserId) : false}`,
@@ -627,7 +655,9 @@ async function completeDay(
 
     const revealTallyBtn = hostPage.getByTestId('voting-reveal')
     await revealTallyBtn.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {})
-    await expect(revealTallyBtn).toBeEnabled({ timeout: 15_000 }).catch(() => {})
+    await expect(revealTallyBtn)
+      .toBeEnabled({ timeout: 15_000 })
+      .catch(() => {})
     if (await revealTallyBtn.isVisible().catch(() => false)) {
       await revealTallyBtn.click()
       await hostPage.waitForTimeout(1_500)
@@ -635,7 +665,11 @@ async function completeDay(
       tryAct('VOTING_REVEAL_TALLY', 'Host', { room: ctx.roomCode })
       await hostPage.waitForTimeout(1_500)
     }
-    await captureSnapshot(ctx.pages, testInfo, `${evidenceLabel}-day-tally-revealed-r${attempt + 1}`)
+    await captureSnapshot(
+      ctx.pages,
+      testInfo,
+      `${evidenceLabel}-day-tally-revealed-r${attempt + 1}`,
+    )
 
     // If the backend has left voting (VOTE_RESULT / BADGE_HANDOVER /
     // HUNTER_SHOOT) or the top-level phase changed (e.g. GAME_OVER), stop.
@@ -719,9 +753,12 @@ async function completeDay(
       // keeps it sticky for the remainder of the test. Otherwise pick the
       // first alive slot. Click is on the page where `isEliminatedSheriff`
       // is true (resolvedSheriffPage) — only that page renders the buttons.
-      const slot = resolvedRecipientSeat !== undefined
-        ? resolvedSheriffPage.locator(`.player-grid [data-seat="${resolvedRecipientSeat}"].slot-alive`)
-        : resolvedSheriffPage.locator('.player-grid .slot-alive').first()
+      const slot =
+        resolvedRecipientSeat !== undefined
+          ? resolvedSheriffPage.locator(
+              `.player-grid [data-seat="${resolvedRecipientSeat}"].slot-alive`,
+            )
+          : resolvedSheriffPage.locator('.player-grid .slot-alive').first()
       await slot.waitFor({ state: 'visible', timeout: 10_000 })
       await slot.click()
       await resolvedSheriffPage.waitForTimeout(300)
@@ -986,7 +1023,8 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     // Park the guard's protect on a wolf — wolves don't kill each other,
     // so the protection is wasted but doesn't block the planned death.
     const wolfBots = ctx.roleMap.WEREWOLF ?? []
-    const wolfSeatForGuardProtect = wolfBots.find((b) => b.nick !== 'Host')?.seat ?? wolfBots[0]?.seat
+    const wolfSeatForGuardProtect =
+      wolfBots.find((b) => b.nick !== 'Host')?.seat ?? wolfBots[0]?.seat
     expect(
       wolfSeatForGuardProtect,
       'HARD_MODE kit needs at least one wolf so guard can protect a non-target seat',
@@ -1037,14 +1075,7 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
       badgeWolfBot,
       'a non-host wolf is needed as the badge recipient so the badge stays put for the rest of the test',
     )
-    await completeDay(
-      ctx,
-      testInfo,
-      seer.seat,
-      'hard-05-day-1',
-      seerPage,
-      badgeWolfBot.seat,
-    )
+    await completeDay(ctx, testInfo, seer.seat, 'hard-05-day-1', seerPage, badgeWolfBot.seat)
     await ctx.hostPage.waitForTimeout(2_000)
 
     // Plan needs 2 nights: D1 vote-out fires BADGE_HANDOVER + post-vote win
@@ -1116,5 +1147,178 @@ test.describe('12p sheriff — HARD_MODE wolf win with badge passover', () => {
     await expect(ctx.hostPage.locator('.outcome-title')).toBeVisible({ timeout: 10_000 })
     const winner = (await ctx.hostPage.locator('.outcome-title').textContent()) ?? ''
     expect(winner).toMatch(/狼人|Werewolf|WOLF/i)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────────
+// Scenario 3 — 12 players, sheriff killed AT NIGHT on N2.
+// New contract (2026-05-22): night-killed sheriff gets one last action — pass
+// the badge to an heir OR destroy it — landed in the new
+// DaySubPhase.BADGE_HANDOVER value at day reveal, BEFORE discussion. This
+// exercises the new flow end-to-end: real STOMP broadcasts, REST endpoints,
+// DAY_DISCUSSION-side badge UI in DayPhase.vue (separate from VotingPhase's
+// badge UI which covers vote-out elimination).
+// ───────────────────────────────────────────────────────────────────────────────
+test.describe('12p sheriff — night-killed sheriff hands over badge at day reveal', () => {
+  test.setTimeout(600_000)
+
+  let ctx: GameContext
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(process.env.CI ? 360_000 : 180_000)
+    ctx = await setupGame(browser, {
+      totalPlayers: 12,
+      hasSheriff: true,
+      roles: ['WEREWOLF', 'VILLAGER', 'SEER', 'WITCH', 'GUARD'] as RoleName[],
+      browserRoles: BROWSER_ROLES,
+    })
+  })
+
+  test.afterAll(async () => {
+    await ctx?.cleanup()
+  })
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'failed' && ctx?.pages) {
+      await attachCompositeOnFailure(ctx.pages, testInfo)
+    }
+  })
+
+  test('N1 normal → sheriff elected → D1 vote-out wolf → N2 wolves kill sheriff → BADGE_HANDOVER at reveal → pass to heir', async ({}, testInfo) => {
+    // Resolve roles. Seer becomes sheriff (matches HARD_MODE pattern).
+    const seer = await resolveRolePlayer(ctx, 'SEER')
+    const guard = await resolveRolePlayer(ctx, 'GUARD')
+    assertNonNull(seer, `kit must have a SEER (bot or host=${ctx.hostRole})`)
+    assertNonNull(guard, `kit must have a GUARD (bot or host=${ctx.hostRole})`)
+
+    const wolfSeats = new Set((ctx.roleMap.WEREWOLF ?? []).map((b) => b.seat))
+    const villagerSeats = (ctx.roleMap.VILLAGER ?? [])
+      .filter((b) => b.nick !== 'Host')
+      .map((b) => b.seat)
+      .filter((s) => !wolfSeats.has(s))
+    expect(
+      villagerSeats.length,
+      'plan needs a non-host non-wolf villager seat for N1 kill + D1 wolf vote-out target',
+    ).toBeGreaterThanOrEqual(1)
+
+    // ── N1: wolves kill a villager (not the seer — seer needs to become sheriff)
+    const wolfBots = ctx.roleMap.WEREWOLF ?? []
+    const guardSafeWolfSeat = wolfBots.find((b) => b.nick !== 'Host')?.seat ?? wolfBots[0]?.seat
+    expect(
+      guardSafeWolfSeat,
+      'need a wolf seat so guard can protect a wolf without blocking the planned kill',
+    ).toBeDefined()
+
+    await driveMinimalNight1ViaDom(ctx, {
+      wolfTargetSeat: villagerSeats[0],
+      seerCheckSeat: guardSafeWolfSeat,
+      guardTargetSeat: guardSafeWolfSeat!,
+    })
+    await captureSnapshot(ctx.pages, testInfo, 'sndh-01-n1-done')
+
+    // ── Sheriff election: seer campaigns and wins
+    await runSheriffElection(ctx, [seer.nick])
+    await captureSnapshot(ctx.pages, testInfo, 'sndh-02-sheriff-elected-is-seer')
+    await waitForDayDiscussionAfterSheriff(ctx)
+
+    // Confirm: seer is now sheriffUserId.
+    const sheriffAfterElection = await ctx.hostPage.evaluate(async (id: string) => {
+      const token = localStorage.getItem('jwt')
+      const res = await fetch(`/api/game/${id}/state`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return res.ok ? (await res.json())?.sheriffUserId : null
+    }, ctx.gameId)
+    expect(sheriffAfterElection, 'seer should hold the badge after election').toBe(seer.userId)
+
+    // ── D1: vote out any non-sheriff wolf (keep sheriff alive for the N2 plan)
+    const wolfToKill = wolfBots.find((b) => b.nick !== 'Host') ?? wolfBots[0]
+    assertNonNull(wolfToKill, 'need a wolf to vote out on D1')
+    await completeDay(ctx, testInfo, wolfToKill.seat, 'sndh-03-d1')
+    await ctx.hostPage.waitForTimeout(2_000)
+
+    // ── N2: wolves target the SHERIFF (the seer). Witch+guard pass via
+    //         completeNight defaults (witch declines antidote → kill stands;
+    //         guard skips).
+    await completeNight(ctx, seer.seat)
+    await captureSnapshot(ctx.pages, testInfo, 'sndh-04-n2-done')
+
+    // ── Day 2 reveal: backend should transition to DAY_DISCUSSION/BADGE_HANDOVER
+    //         because the sheriff died at night.
+    const revealBtn = ctx.hostPage.getByTestId('day-reveal-result')
+    await revealBtn.waitFor({ state: 'visible', timeout: 30_000 })
+    await revealBtn.click()
+
+    // Authoritative subPhase check via API (not DOM): the backend should be
+    // in BADGE_HANDOVER, not RESULT_REVEALED.
+    await waitForCondition(
+      async () => {
+        const state = await ctx.hostPage.evaluate(async (id: string) => {
+          const token = localStorage.getItem('jwt')
+          const res = await fetch(`/api/game/${id}/state`, {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          return res.ok ? await res.json() : null
+        }, ctx.gameId)
+        return state?.phase === 'DAY_DISCUSSION' && state?.subPhase === 'BADGE_HANDOVER'
+      },
+      'BADGE_HANDOVER at day-2 reveal (night-killed sheriff)',
+      15_000,
+    )
+    await captureSnapshot(ctx.pages, testInfo, 'sndh-05-badge-handover-fired')
+
+    // ── Sheriff's browser must render the dying-sheriff banner + pass button.
+    //         When host is the seer, ctx.pages.get('SEER') === hostPage by
+    //         setupGame's mapping — host's own page renders the badge UI.
+    const seerPage = ctx.pages.get('SEER')
+    assertNonNull(
+      seerPage,
+      'badge-handover needs the SEER browser page — only the night-killed sheriff sees the pass-badge UI',
+    )
+    await expect(seerPage.getByTestId('day-badge-eliminated-banner')).toBeVisible({
+      timeout: 10_000,
+    })
+    const passBtn = seerPage.getByTestId('day-badge-pass')
+    await expect(passBtn).toBeVisible({ timeout: 5_000 })
+    // Disabled until an heir is selected.
+    await expect(passBtn).toBeDisabled()
+
+    // ── Non-sheriff browsers see the waiting banner, not the pass UI.
+    const witchPage = ctx.pages.get('WITCH')
+    if (witchPage) {
+      await expect(witchPage.getByTestId('day-badge-wait-banner')).toBeVisible({ timeout: 10_000 })
+      expect(await witchPage.getByTestId('day-badge-pass').count()).toBe(0)
+    }
+
+    // ── Pass the badge to an alive non-host non-wolf villager. The sheriff
+    //         page's player grid is tap-to-select; click the heir then click pass.
+    const heirSeat = villagerSeats.find((s) => s !== seer.seat) ?? villagerSeats[0]
+    const heirSlot = seerPage.locator(`.player-grid [data-seat="${heirSeat}"]`)
+    await heirSlot.click()
+    await expect(passBtn).toBeEnabled({ timeout: 5_000 })
+    await passBtn.click()
+
+    // ── Backend transitions to DAY_DISCUSSION/RESULT_REVEALED with the new
+    //         sheriff in place.
+    await waitForCondition(
+      async () => {
+        const state = await ctx.hostPage.evaluate(async (id: string) => {
+          const token = localStorage.getItem('jwt')
+          const res = await fetch(`/api/game/${id}/state`, {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          return res.ok ? await res.json() : null
+        }, ctx.gameId)
+        return (
+          state?.phase === 'DAY_DISCUSSION' &&
+          state?.subPhase === 'RESULT_REVEALED' &&
+          state?.sheriffUserId !== seer.userId &&
+          state?.sheriffUserId != null
+        )
+      },
+      'badge transferred → DAY_DISCUSSION/RESULT_REVEALED with new sheriff',
+      15_000,
+    )
+    await captureSnapshot(ctx.pages, testInfo, 'sndh-06-badge-passed-result-revealed')
   })
 })

--- a/frontend/src/__tests__/audioServiceBgm.test.ts
+++ b/frontend/src/__tests__/audioServiceBgm.test.ts
@@ -270,18 +270,33 @@ describe('audioService BGM lifecycle (real implementation)', () => {
     expect(bgm.volume).toBeCloseTo(lowVol, 5)
   })
 
-  it('duckBgm reduces element.volume; unduckBgm restores it', () => {
+  it('duckBgm targets absolute 0.10 (user at default 0.5/HIGH); unduckBgm restores', () => {
     unlockUserGesture()
+    audioService.setBgmVolume(0.5)
     audioService.startBgm('suspicion.mp3')
     audioService.setBgmLevel('HIGH')
     const bgm = getBgmInstance()!
     const highVol = bgm.volume
 
     audioService.duckBgm()
-    expect(bgm.volume).toBeLessThan(highVol)
+    expect(bgm.volume).toBeCloseTo(0.1, 5)
 
     audioService.unduckBgm()
     expect(bgm.volume).toBeCloseTo(highVol, 5)
+  })
+
+  it('duckBgm never loudens — caps at unducked volume when user is below 10%', () => {
+    unlockUserGesture()
+    audioService.setBgmVolume(0.05)
+    audioService.startBgm('suspicion.mp3')
+    audioService.setBgmLevel('HIGH')
+    const bgm = getBgmInstance()!
+    const unduckedVol = bgm.volume
+    expect(unduckedVol).toBeLessThan(0.1)
+
+    audioService.duckBgm()
+    // No loudening: stay at (or below) the already-quiet unducked level.
+    expect(bgm.volume).toBeLessThanOrEqual(unduckedVol + 1e-6)
   })
 
   // ── Mute integration ─────────────────────────────────────────────────────
@@ -330,7 +345,7 @@ describe('audioService BGM lifecycle (real implementation)', () => {
 //   #1 a rejected play() re-arms bgmPendingStart so the next gesture retries
 //   #2 a paused BGM resumes on visibilitychange→visible (lock-screen recovery)
 //   #3 the stuck-queue watchdog and the visibility-resume drain both call
-//      unduckBgm so BGM is not left clamped at BGM_GAIN_DUCKED forever
+//      unduckBgm so BGM is not left clamped at the duck level forever
 describe('audioService BGM defensive recovery (mobile Chrome)', () => {
   beforeEach(async () => {
     localStorage.clear()

--- a/frontend/src/__tests__/dayPhase.test.ts
+++ b/frontend/src/__tests__/dayPhase.test.ts
@@ -15,7 +15,7 @@ const PLAYERS: GamePlayer[] = [
   { userId: 'u2', nickname: 'Bob', seatIndex: 2, isAlive: false, isSheriff: false },
 ]
 
-function makeDay(subPhase: 'RESULT_HIDDEN' | 'RESULT_REVEALED'): DayPhaseState {
+function makeDay(subPhase: 'RESULT_HIDDEN' | 'RESULT_REVEALED' | 'BADGE_HANDOVER'): DayPhaseState {
   return {
     subPhase,
     dayNumber: 2,
@@ -200,5 +200,97 @@ describe('DayPhase — below-arch layout (my-role-chip left, log-fab + ActionMen
     expect(wrapper.find('[data-testid="action-menu-btn"]').exists()).toBe(true)
     // log-fab is hidden in RESULT_HIDDEN to prevent spoilers, ActionMenu is not
     expect(wrapper.find('.log-fab').exists()).toBe(false)
+  })
+})
+
+describe('DayPhase — sheriff night-death badge handover', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  // The dying sheriff is alive=false (kills applied in revealNightResult),
+  // but still owns the badge identity until they pass or destroy it.
+  const SHERIFF_PLAYERS: GamePlayer[] = [
+    { userId: 'sheriff', nickname: 'Sheriff', seatIndex: 1, isAlive: false, isSheriff: true },
+    { userId: 'alice', nickname: 'Alice', seatIndex: 2, isAlive: true, isSheriff: false },
+    { userId: 'bob', nickname: 'Bob', seatIndex: 3, isAlive: true, isSheriff: false },
+  ]
+
+  function mountAs(myUserId: string, sheriffUserId: string | null = 'sheriff') {
+    return mount(DayPhase, {
+      props: {
+        ...BASE_PROPS,
+        myUserId,
+        sheriffUserId,
+        players: SHERIFF_PLAYERS,
+        dayPhase: makeDay('BADGE_HANDOVER'),
+      },
+    })
+  }
+
+  it('dying sheriff sees the heir-prompt banner + pass/destroy buttons', () => {
+    const wrapper = mountAs('sheriff')
+    expect(wrapper.find('[data-testid="day-badge-eliminated-banner"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="day-badge-wait-banner"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="day-badge-pass"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="day-badge-destroy"]').exists()).toBe(true)
+  })
+
+  it('non-sheriff players see only the waiting banner — no pass/destroy buttons', () => {
+    const wrapper = mountAs('alice')
+    expect(wrapper.find('[data-testid="day-badge-wait-banner"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="day-badge-eliminated-banner"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="day-badge-pass"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="day-badge-destroy"]').exists()).toBe(false)
+  })
+
+  it('pass button is disabled until the sheriff taps a live heir', async () => {
+    const wrapper = mountAs('sheriff')
+    const passBtn = wrapper.get('[data-testid="day-badge-pass"]')
+    expect(passBtn.attributes('disabled')).toBeDefined()
+
+    // Tap an alive non-self player → button enables.
+    await wrapper.find('[data-seat="2"]').trigger('click')
+    expect(passBtn.attributes('disabled')).toBeUndefined()
+  })
+
+  it('passBadge emits with the selected heir userId', async () => {
+    const wrapper = mountAs('sheriff')
+    await wrapper.find('[data-seat="2"]').trigger('click')
+    await wrapper.get('[data-testid="day-badge-pass"]').trigger('click')
+    expect(wrapper.emitted('passBadge')).toEqual([['alice']])
+  })
+
+  it('destroyBadge emits without arguments and works without a selection', async () => {
+    const wrapper = mountAs('sheriff')
+    await wrapper.get('[data-testid="day-badge-destroy"]').trigger('click')
+    expect(wrapper.emitted('destroyBadge')).toHaveLength(1)
+  })
+
+  it('host who is NOT the sheriff sees the waiting hint, not the host start-vote footer', () => {
+    // Sheriff death takes precedence over the regular host footer template.
+    const wrapper = mount(DayPhase, {
+      props: {
+        ...BASE_PROPS,
+        myUserId: 'alice',
+        isHost: true,
+        sheriffUserId: 'sheriff',
+        players: SHERIFF_PLAYERS,
+        dayPhase: makeDay('BADGE_HANDOVER'),
+      },
+    })
+    expect(wrapper.find('[data-testid="day-start-vote"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="day-reveal-result"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="day-badge-wait-banner"]').exists()).toBe(true)
+  })
+
+  it('tapping a dead player or self does NOT select them as heir', async () => {
+    const wrapper = mountAs('sheriff')
+    // Tap self (dead sheriff) — should not become selected.
+    await wrapper.find('[data-seat="1"]').trigger('click')
+    expect(wrapper.get('[data-testid="day-badge-pass"]').attributes('disabled')).toBeDefined()
+    // Tap an alive player — that should work.
+    await wrapper.find('[data-seat="2"]').trigger('click')
+    expect(wrapper.get('[data-testid="day-badge-pass"]').attributes('disabled')).toBeUndefined()
   })
 })

--- a/frontend/src/__tests__/nightPhase.test.ts
+++ b/frontend/src/__tests__/nightPhase.test.ts
@@ -78,6 +78,84 @@ describe('NightPhase - eliminated banner gating', () => {
     expect(wrapper.find('[data-testid="guard-confirm-protect"]').exists()).toBe(false)
   })
 
+  it('witch sees the self-save-blocked note + the antidote button is HIDDEN when self-save is off and she is the wolves victim', () => {
+    const witch = mkPlayer({ userId: 'witch1', nickname: 'Witch', seatIndex: 1, isAlive: true })
+    const wolf = mkPlayer({ userId: 'w1', nickname: 'Wolf', seatIndex: 2 })
+
+    const wrapper = mountNight({
+      // hasAntidote=true so the antidote section actually renders. The
+      // wolves' target is the witch herself.
+      nightPhase: mkNight({
+        subPhase: 'WITCH_ACT',
+        dayNumber: 1,
+        hasAntidote: true,
+        attackedPlayerId: 'witch1',
+        attackedNickname: 'Witch',
+        attackedSeatIndex: 1,
+      }),
+      players: [witch, wolf],
+      myUserId: 'witch1',
+      myRole: 'WITCH',
+      // @ts-expect-error — extra prop accepted by the component
+      witchSelfSaveAllowed: false,
+    })
+
+    // "使用解药" button must NOT render.
+    expect(wrapper.find('[data-testid="witch-antidote"]').exists()).toBe(false)
+    // Explanatory note shown in its place.
+    expect(wrapper.find('[data-testid="witch-self-save-blocked"]').exists()).toBe(true)
+    // "放弃" button still available so the witch can advance.
+    expect(wrapper.find('[data-testid="switch-pass-antidote"]').exists()).toBe(true)
+  })
+
+  it('witch sees the antidote button when self-save is off but wolves attacked someone else', () => {
+    const witch = mkPlayer({ userId: 'witch1', nickname: 'Witch', seatIndex: 1, isAlive: true })
+    const other = mkPlayer({ userId: 'other1', nickname: 'Other', seatIndex: 2, isAlive: true })
+
+    const wrapper = mountNight({
+      nightPhase: mkNight({
+        subPhase: 'WITCH_ACT',
+        dayNumber: 1,
+        hasAntidote: true,
+        attackedPlayerId: 'other1',
+        attackedNickname: 'Other',
+        attackedSeatIndex: 2,
+      }),
+      players: [witch, other],
+      myUserId: 'witch1',
+      myRole: 'WITCH',
+      // @ts-expect-error — extra prop accepted by the component
+      witchSelfSaveAllowed: false,
+    })
+
+    expect(wrapper.find('[data-testid="witch-antidote"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="witch-self-save-blocked"]').exists()).toBe(false)
+  })
+
+  it('witch sees the antidote button when self-save is allowed (default), even when wolves attacked her', () => {
+    const witch = mkPlayer({ userId: 'witch1', nickname: 'Witch', seatIndex: 1, isAlive: true })
+    const filler = mkPlayer({ userId: 'v1', nickname: 'V1', seatIndex: 2, isAlive: true })
+
+    const wrapper = mountNight({
+      nightPhase: mkNight({
+        subPhase: 'WITCH_ACT',
+        dayNumber: 1,
+        hasAntidote: true,
+        attackedPlayerId: 'witch1',
+        attackedNickname: 'Witch',
+        attackedSeatIndex: 1,
+      }),
+      players: [witch, filler],
+      myUserId: 'witch1',
+      myRole: 'WITCH',
+      // No witchSelfSaveAllowed prop → undefined → defaults to allow (existing
+      // behavior preserved).
+    })
+
+    expect(wrapper.find('[data-testid="witch-antidote"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="witch-self-save-blocked"]').exists()).toBe(false)
+  })
+
   it('alive non-actor (villager during WEREWOLF_PICK) does NOT see the eliminated banner', () => {
     const villager = mkPlayer({ userId: 'v1', isAlive: true })
     const wolf = mkPlayer({ userId: 'w1', seatIndex: 2 })

--- a/frontend/src/components/DayPhase.vue
+++ b/frontend/src/components/DayPhase.vue
@@ -149,9 +149,7 @@
           <div class="sheriff-badge">⭐</div>
         </template>
         <template
-          v-if="
-            !player.isAlive && (dayPhase.subPhase === 'RESULT_REVEALED' || isBadgeHandover)
-          "
+          v-if="!player.isAlive && (dayPhase.subPhase === 'RESULT_REVEALED' || isBadgeHandover)"
           #overlay
         >
           <div class="slot-overlay dead-overlay">✕</div>

--- a/frontend/src/components/DayPhase.vue
+++ b/frontend/src/components/DayPhase.vue
@@ -46,7 +46,31 @@
 
     <!-- Fixed-height banner area — always rendered so grid position stays consistent -->
     <div class="banner-area">
-      <template v-if="viewRole === 'DEAD'">
+      <!-- Badge handover (sheriff killed at night): show this on top of the
+           normal reveal banners. The dying sheriff sees the heir prompt; all
+           other viewers see a "waiting for sheriff" hint. -->
+      <template v-if="isBadgeHandover">
+        <div
+          v-if="isDyingSheriff"
+          class="banner banner-gold"
+          data-testid="day-badge-eliminated-banner"
+        >
+          <span class="banner-avatar">⭐</span>
+          <div>
+            <div class="banner-title">你已出局 · Eliminated</div>
+            <div class="banner-sub">选择警徽继承人 / Choose badge heir</div>
+          </div>
+        </div>
+        <div v-else class="banner banner-info" data-testid="day-badge-wait-banner">
+          <span class="banner-avatar">⭐</span>
+          <div>
+            <div class="banner-title">警长正在移交警徽</div>
+            <div class="banner-sub">Sheriff is choosing an heir…</div>
+          </div>
+        </div>
+      </template>
+
+      <template v-else-if="viewRole === 'DEAD'">
         <div class="banner banner-info" data-testid="day-banner-self-eliminated">
           <span class="banner-icon">☑</span>
           <div>
@@ -124,7 +148,12 @@
         <template v-if="player.isSheriff" #badge>
           <div class="sheriff-badge">⭐</div>
         </template>
-        <template v-if="!player.isAlive && dayPhase.subPhase === 'RESULT_REVEALED'" #overlay>
+        <template
+          v-if="
+            !player.isAlive && (dayPhase.subPhase === 'RESULT_REVEALED' || isBadgeHandover)
+          "
+          #overlay
+        >
           <div class="slot-overlay dead-overlay">✕</div>
         </template>
       </PlayerSlot>
@@ -135,7 +164,39 @@
 
     <!-- Footer -->
     <footer class="day-footer">
-      <template v-if="viewRole === 'HOST'">
+      <!-- BADGE_HANDOVER (sheriff killed at night): dying sheriff sees
+           pass/destroy; everyone else (including host) waits. Takes precedence
+           over the regular host/dead/alive footer templates because the dying
+           sheriff may also be the host. -->
+      <template v-if="isBadgeHandover">
+        <template v-if="isDyingSheriff">
+          <div class="vote-actions">
+            <button
+              class="btn btn-gold vote-btn"
+              data-testid="day-badge-pass"
+              :class="{ 'is-loading': actionPending }"
+              :disabled="!badgeSelectedId || actionPending"
+              @click="badgeSelectedId && emit('passBadge', badgeSelectedId)"
+            >
+              移交警徽 · Pass Badge
+            </button>
+            <button
+              class="btn btn-secondary skip-btn"
+              data-testid="day-badge-destroy"
+              :class="{ 'is-loading': actionPending }"
+              :disabled="actionPending"
+              @click="emit('destroyBadge')"
+            >
+              销毁
+            </button>
+          </div>
+        </template>
+        <template v-else>
+          <p class="footer-hint">等待警长移交警徽 · Waiting for sheriff to pass badge…</p>
+        </template>
+      </template>
+
+      <template v-else-if="viewRole === 'HOST'">
         <div v-if="dayPhase.subPhase === 'RESULT_HIDDEN'" class="vote-actions">
           <button
             class="btn btn-primary vote-btn"
@@ -231,8 +292,21 @@ const props = defineProps<{
   myRole?: PlayerRole
   isAlive?: boolean
   daySkipVoting?: boolean
+  sheriffUserId?: string | null
   actionPending?: boolean
 }>()
+
+const isBadgeHandover = computed(() => props.dayPhase.subPhase === 'BADGE_HANDOVER')
+const isDyingSheriff = computed(
+  () => isBadgeHandover.value && !!props.sheriffUserId && props.sheriffUserId === props.myUserId,
+)
+const badgeSelectedId = ref<string | null>(null)
+function onBadgeTap(player: GamePlayer) {
+  if (!isDyingSheriff.value) return
+  if (!player.isAlive) return
+  if (player.userId === props.myUserId) return
+  badgeSelectedId.value = player.userId
+}
 
 const showLog = ref(false)
 const showRoleCard = ref(false)
@@ -304,6 +378,8 @@ const emit = defineEmits<{
   selectPlayer: [userId: string]
   'self-destruct': []
   continueToNight: []
+  passBadge: [userId: string]
+  destroyBadge: []
   'start-timer': [seconds: number]
   'stop-timer': []
 }>()
@@ -340,6 +416,11 @@ function isKilledAndVisible(player: GamePlayer) {
 }
 
 function slotVariant(player: GamePlayer) {
+  if (isBadgeHandover.value) {
+    if (!player.isAlive) return 'dead' as const
+    if (player.userId === badgeSelectedId.value) return 'selected' as const
+    return 'alive' as const
+  }
   if (props.dayPhase.subPhase === 'RESULT_REVEALED') {
     if (isKilledAndVisible(player)) return 'killed' as const
     if (!player.isAlive) return 'dead' as const
@@ -355,6 +436,10 @@ function slotVariant(player: GamePlayer) {
 }
 
 function onTap(player: GamePlayer) {
+  if (isBadgeHandover.value) {
+    onBadgeTap(player)
+    return
+  }
   if (viewRole.value !== 'ALIVE') return
   if (!props.dayPhase.canVote) return
   if (!player.isAlive) return

--- a/frontend/src/components/NightPhase.vue
+++ b/frontend/src/components/NightPhase.vue
@@ -194,8 +194,16 @@
           </span>
           被狼人袭击，是否使用解药？
         </p>
+        <p
+          v-if="witchSelfSaveBlocked"
+          class="ws-desc ws-blocked-note"
+          data-testid="witch-self-save-blocked"
+        >
+          本局禁止自救 / Self-save disabled this game
+        </p>
         <div class="ws-row">
           <button
+            v-if="!witchSelfSaveBlocked"
             class="btn btn-primary ws-btn"
             data-testid="witch-antidote"
             :class="{ 'is-loading': actionPending }"
@@ -407,7 +415,14 @@ const props = defineProps<{
   myUserId: string
   myRole?: PlayerRole
   actionPending?: boolean
+  witchSelfSaveAllowed?: boolean
 }>()
+
+const witchSelfSaveBlocked = computed(
+  () =>
+    props.witchSelfSaveAllowed === false &&
+    props.nightPhase.attackedPlayerId === props.myUserId,
+)
 
 const emit = defineEmits<{
   selectPlayer: [userId: string]

--- a/frontend/src/components/NightPhase.vue
+++ b/frontend/src/components/NightPhase.vue
@@ -409,18 +409,27 @@ import {
   wolfVariant,
 } from '@/utils/nightPhaseHelpers'
 
-const props = defineProps<{
-  nightPhase: NightPhaseState
-  players: GamePlayer[]
-  myUserId: string
-  myRole?: PlayerRole
-  actionPending?: boolean
-  witchSelfSaveAllowed?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    nightPhase: NightPhaseState
+    players: GamePlayer[]
+    myUserId: string
+    myRole?: PlayerRole
+    actionPending?: boolean
+    witchSelfSaveAllowed?: boolean
+  }>(),
+  {
+    // Vue 3 coerces a missing boolean prop to `false`, but the safe default
+    // here is `true` — self-save was the historical behavior; only the new
+    // room-config opt-in disables it. Pin the default so callers that omit
+    // the prop (older mocks, tests, demo data) don't accidentally block
+    // self-save for every witch.
+    witchSelfSaveAllowed: true,
+  },
+)
 
 const witchSelfSaveBlocked = computed(
-  () =>
-    props.witchSelfSaveAllowed === false && props.nightPhase.attackedPlayerId === props.myUserId,
+  () => !props.witchSelfSaveAllowed && props.nightPhase.attackedPlayerId === props.myUserId,
 )
 
 const emit = defineEmits<{

--- a/frontend/src/components/NightPhase.vue
+++ b/frontend/src/components/NightPhase.vue
@@ -420,8 +420,7 @@ const props = defineProps<{
 
 const witchSelfSaveBlocked = computed(
   () =>
-    props.witchSelfSaveAllowed === false &&
-    props.nightPhase.attackedPlayerId === props.myUserId,
+    props.witchSelfSaveAllowed === false && props.nightPhase.attackedPlayerId === props.myUserId,
 )
 
 const emit = defineEmits<{

--- a/frontend/src/services/audioService.ts
+++ b/frontend/src/services/audioService.ts
@@ -21,7 +21,9 @@ const BGM_VOLUME_STORAGE_KEY = 'bgm-volume'
 
 const BGM_GAIN_HIGH = 1.0
 const BGM_GAIN_LOW = 0.45
-const BGM_GAIN_DUCKED = 0.15
+// Absolute BGM volume during narration cues. Capped at the unducked target so
+// users listening at < 10% never get loudened mid-cue.
+const BGM_DUCK_ABSOLUTE = 0.1
 const BGM_RAMP_SEC = 0.15
 
 class AudioService {
@@ -122,7 +124,7 @@ class AudioService {
         this.isPlayingQueue = false
         // The queue drained mid-narration without firing the unduck path in
         // playNextInQueue's "queue empty" branch. Restore BGM gain so the
-        // music isn't left clamped at BGM_GAIN_DUCKED forever.
+        // music isn't left clamped at the duck level forever.
         this.unduckBgm()
       }
       // Mobile Chrome / iOS pause the BGM <audio> element implicitly when the
@@ -674,14 +676,16 @@ class AudioService {
 
   /** Compute the target HTMLAudioElement.volume from current state. */
   private computeBgmTargetVolume(): number {
-    const multiplier = this.muted
-      ? 0
-      : this.bgmNarrationActive
-        ? BGM_GAIN_DUCKED
-        : this.bgmLevel === 'HIGH'
-          ? BGM_GAIN_HIGH
-          : BGM_GAIN_LOW
-    return Math.max(0, Math.min(1, this.bgmBaseVolume * multiplier))
+    if (this.muted) return 0
+    const levelMult = this.bgmLevel === 'HIGH' ? BGM_GAIN_HIGH : BGM_GAIN_LOW
+    const unducked = this.bgmBaseVolume * levelMult
+    if (this.bgmNarrationActive) {
+      // Absolute target during cue narration; never louder than what the
+      // user picked unducked (otherwise a 5%-listener would hear the BGM
+      // jump UP to 10% during cues).
+      return Math.max(0, Math.min(unducked, BGM_DUCK_ABSOLUTE))
+    }
+    return Math.max(0, Math.min(1, unducked))
   }
 
   /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -289,7 +289,7 @@ export interface SheriffElectionState {
 
 // ── Day Phase ─────────────────────────────────────────────────────────────────
 
-export type DaySubPhase = 'RESULT_HIDDEN' | 'RESULT_REVEALED'
+export type DaySubPhase = 'RESULT_HIDDEN' | 'RESULT_REVEALED' | 'BADGE_HANDOVER'
 
 export interface KilledPlayer {
   killedPlayerId: string

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -49,6 +49,7 @@ export interface RoomConfig {
   hasSheriff?: boolean
   winCondition?: WinConditionMode
   bgmTrack?: string | null
+  witchSelfSaveAllowed?: boolean
 }
 
 export interface Room {
@@ -161,6 +162,8 @@ export interface GameState {
   // roomStore is empty). Source of truth lives in roomStore for the lobby
   // flow; mirror here for the game flow.
   bgmTrack?: string | null
+  /** Whether the witch may use her antidote to save herself (room config). */
+  witchSelfSaveAllowed?: boolean
   winner?: 'WEREWOLF' | 'VILLAGER' // set by backend when phase is GAME_OVER
   /** True when a wolf self-destructed this day — host sees "进入夜晚" instead of voting. */
   daySkipVoting?: boolean

--- a/frontend/src/views/CreateRoomView.vue
+++ b/frontend/src/views/CreateRoomView.vue
@@ -90,6 +90,28 @@
             <span class="toggle-thumb" />
           </button>
         </div>
+        <div class="role-row" :class="witchSelfSaveAllowed ? 'row-on' : 'row-off'">
+          <span class="role-emoji">🧙‍♀️</span>
+          <div class="role-names">
+            <span class="role-name">女巫自救 Witch Self-Save</span>
+            <span class="win-cond-desc">
+              {{
+                witchSelfSaveAllowed
+                  ? '允许女巫使用解药救自己 (Allowed)'
+                  : '禁止女巫使用解药救自己 (Disallowed)'
+              }}
+            </span>
+          </div>
+          <button
+            :class="witchSelfSaveAllowed ? 'toggle-on' : 'toggle-off'"
+            class="toggle"
+            data-testid="witchSelfSave-toggle"
+            :data-witch-self-save="witchSelfSaveAllowed"
+            @click="witchSelfSaveAllowed = !witchSelfSaveAllowed"
+          >
+            <span class="toggle-thumb" />
+          </button>
+        </div>
         <div class="role-row" :class="winCondition === 'HARD_MODE' ? 'row-wolf' : 'row-on'">
           <span class="role-emoji">⚔️</span>
           <div class="role-names">
@@ -192,6 +214,7 @@ const totalPlayers = ref(9)
 // Optional roles enabled by default
 const enabledOptional = ref(new Set(['SEER', 'WITCH', 'HUNTER']))
 const hasSheriff = ref(true)
+const witchSelfSaveAllowed = ref(true)
 const winCondition = ref<WinConditionMode>('CLASSIC')
 
 const bgmTracks = ref<AudioTrack[]>([{ id: null, filename: null, displayName: '无 (None)' }])
@@ -276,6 +299,7 @@ async function handleCreate() {
         hasSheriff: hasSheriff.value,
         winCondition: winCondition.value,
         bgmTrack: bgmTrack.value,
+        witchSelfSaveAllowed: witchSelfSaveAllowed.value,
       },
     }
     // Carry the per-room display-name override that the lobby may have set.

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -100,6 +100,7 @@
         :my-user-id="userStore.userId ?? ''"
         :my-role="gameStore.state.myRole"
         :action-pending="actionPending"
+        :witch-self-save-allowed="gameStore.state.witchSelfSaveAllowed"
         @select-player="handleNightSelect"
         @confirm="handleNightConfirm"
         @witch-antidote="handleWitchAntidote"

--- a/frontend/src/views/GameView.vue
+++ b/frontend/src/views/GameView.vue
@@ -156,6 +156,7 @@
           gameStore.state?.players.find((p) => p.userId === userStore.userId)?.isAlive ?? false
         "
         :day-skip-voting="gameStore.state?.daySkipVoting ?? false"
+        :sheriff-user-id="gameStore.state?.sheriffUserId ?? null"
         :action-pending="actionPending"
         @reveal-result="handleRevealResult"
         @start-vote="handleStartVote"
@@ -164,6 +165,8 @@
         @select-player="handleDaySelectPlayer"
         @self-destruct="handleSelfDestruct"
         @continue-to-night="handleVotingContinue"
+        @pass-badge="handlePassBadge"
+        @destroy-badge="handleDestroyBadge"
         @start-timer="(s) => handleTimerStart(Number(route.params.gameId), s)"
         @stop-timer="() => handleTimerStop(Number(route.params.gameId))"
       />


### PR DESCRIPTION
## Summary

Three independent gameplay/UX features:

- **Sheriff night-death badge handover.** When the sheriff is killed at night, the dying sheriff now picks an heir (or destroys the badge) at day reveal — before discussion. Reverses the older "silent loss" contract guarded by `GamePipelineSheriffTest`. Reuses the existing `BADGE_PASS` / `BADGE_DESTROY` actions via a new `DaySubPhase.BADGE_HANDOVER` value; `VotingPipeline.handleBadge` accepts both the voting and night-reveal entry points. Hunter night-deaths still die silently (HUNTER_SHOOT remains day-voting only).
- **Witch self-save game-config toggle.** New `witchSelfSaveAllowed` config bit on `RoomConfig` (default `true`). When `false`, backend rejects `useAntidote=true` if the wolves' victim is the witch; frontend hides the "use antidote" button with an explanatory note. V14 Flyway migration backfills the JSONB key on existing rooms so old configs query honestly.
- **BGM ducking → absolute 10%.** `BGM_GAIN_DUCKED = 0.15` (multiplier) becomes `BGM_DUCK_ABSOLUTE = 0.10` (absolute target). Capped at the unducked volume so users listening below 10% never get loudened mid-cue. Duck/unduck lifecycle around `playSequential` is unchanged.

## Test plan
- [x] Backend unit suite green (`./gradlew test`) — including the **updated** `GamePipelineSheriffTest` assertions and new `WitchHandlerTest` / `VotingPipelineTest` cases.
- [x] Frontend unit suite green (`npx vitest run`) — including the updated `audioServiceBgm` duck test + new "never louden" test.
- [x] `npx vue-tsc --noEmit` clean.
- [ ] Manual: 12p room, wolves kill the sheriff → at reveal the dying sheriff sees pass/destroy buttons → after action, host can advance to voting.
- [x] Manual: room with `witchSelfSaveAllowed=false` → witch attacked by wolves → "使用解药" button hidden + explanation shown → backend rejects forced antidote.
- [x] Manual: BGM at slider 80% → enter night cue → BGM drops to ~10% → cue ends → BGM back to ~80%. Repeat with slider 5% → no loudening on duck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)