### PR TITLE
chore: remove unused CSS and dead sheriffResultAutoAdvanceMs config

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/config/GameTimingProperties.kt
+++ b/backend/src/main/kotlin/com/werewolf/config/GameTimingProperties.kt
@@ -26,10 +26,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *                               begins, so goes_dark + wolf_howl play fully.
  *   waitingDelayMs            — how long WAITING sub-phase idles for sheriff-
  *                               election games before the first real role.
- *   sheriffResultAutoAdvanceMs — Variant B: how long the sheriff RESULT screen
- *                               is shown before the game auto-advances back
- *                               to DAY_DISCUSSION/RESULT_REVEALED. Defaults to
- *                               60_000ms in production; tests/e2e shrink it.
  *   sheriffMorningCueDelayMs  — Variant B Day 1: silence pause after
  *                               guard_close_eyes (night ended) before
  *                               rooster_crowing + day_time (campaign begins)
@@ -45,7 +41,6 @@ data class GameTimingProperties(
     val interRoleGapMs: Long? = null,
     val nightInitAudioDelayMs: Long? = null,
     val waitingDelayMs: Long? = null,
-    val sheriffResultAutoAdvanceMs: Long? = null,
     val sheriffMorningCueDelayMs: Long? = null,
 ) {
     /**

--- a/backend/src/main/resources/application-e2e.yml
+++ b/backend/src/main/resources/application-e2e.yml
@@ -42,5 +42,4 @@ werewolf:
     inter-role-gap-ms: 500
     night-init-audio-delay-ms: 1000
     waiting-delay-ms: 500
-    sheriff-result-auto-advance-ms: 2000
     sheriff-morning-cue-delay-ms: 500

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -53,5 +53,4 @@ werewolf:
     inter-role-gap-ms: 300
     night-init-audio-delay-ms: 500
     waiting-delay-ms: 200
-    sheriff-result-auto-advance-ms: 1000
     sheriff-morning-cue-delay-ms: 100

--- a/frontend/src/components/DayPhase.vue
+++ b/frontend/src/components/DayPhase.vue
@@ -487,13 +487,6 @@ function onTap(player: GamePlayer) {
   font-weight: 600;
 }
 
-.footer-hint-sm {
-  text-align: center;
-  color: var(--muted);
-  font-size: 0.6875rem;
-  margin: 0;
-}
-
 .player-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(85px, 47%), 1fr));

--- a/frontend/src/components/NightPhase.vue
+++ b/frontend/src/components/NightPhase.vue
@@ -1041,16 +1041,6 @@ const isPoisonTargetFn = (p: GamePlayer) => isPoisonTarget(p, props.myUserId)
   margin-top: 0.375rem;
 }
 
-.ss-countdown {
-  font-family: 'Noto Serif SC', serif;
-  font-size: 3.5rem;
-  font-weight: 700;
-  color: var(--paper);
-  line-height: 1;
-  margin: 0.25rem 0;
-  opacity: 0.9;
-}
-
 /* ── Button overrides for night mode ─────────────────────────────────────── */
 /* Size/shape use global .btn; only color overrides needed here */
 .btn:disabled {
@@ -1060,11 +1050,6 @@ const isPoisonTargetFn = (p: GamePlayer) => isPoisonTarget(p, props.myUserId)
 
 .btn-danger {
   background: var(--red);
-  color: #fff;
-}
-
-.btn-success {
-  background: var(--green);
   color: #fff;
 }
 

--- a/frontend/src/components/SheriffElection.vue
+++ b/frontend/src/components/SheriffElection.vue
@@ -809,11 +809,6 @@ function speakerLabel(uid: string, idx: number) {
   color: var(--gold);
 }
 
-.timer-result {
-  font-size: 0.6875rem;
-  color: var(--muted);
-}
-
 /* Info banner */
 .info-banner {
   background: rgba(160, 120, 48, 0.08);
@@ -873,12 +868,6 @@ function speakerLabel(uid: string, idx: number) {
   color: var(--text);
 }
 
-.running-badge {
-  font-size: 0.625rem;
-  letter-spacing: 0.1em;
-  color: var(--gold);
-}
-
 /* SIGNUP stats — count + decision progress, no per-candidate rows */
 .signup-stats {
   background: var(--paper);
@@ -907,15 +896,6 @@ function speakerLabel(uid: string, idx: number) {
   font-size: 1.5rem;
   font-weight: 700;
   color: var(--text);
-}
-
-.stat-hint {
-  margin-top: 0.25rem;
-  font-size: 0.6875rem;
-  line-height: 1.5;
-  text-align: center;
-  border-top: 1px dashed var(--border-l);
-  padding-top: 0.5rem;
 }
 
 /* Action footer */

--- a/frontend/src/components/VotingPhase.vue
+++ b/frontend/src/components/VotingPhase.vue
@@ -1072,32 +1072,6 @@ function onBadgeTap(player: GamePlayer) {
   border: 1px solid currentColor;
 }
 
-.my-role-wolf {
-  color: var(--red);
-  background: rgba(181, 37, 26, 0.08);
-}
-
-.my-role-special {
-  color: var(--gold);
-  background: rgba(160, 120, 48, 0.08);
-}
-
-.my-role-guard {
-  color: #3b82f6;
-  background: rgba(59, 130, 246, 0.08);
-}
-
-.my-role-hunter {
-  color: #7c5c3a;
-  background: rgba(124, 92, 58, 0.08);
-}
-
-.my-role-default {
-  color: var(--muted);
-  background: var(--paper);
-  border-color: var(--border-l);
-}
-
 .my-role-locked {
   color: var(--muted);
   background: var(--paper);
@@ -1195,12 +1169,6 @@ function onBadgeTap(player: GamePlayer) {
   font-size: 0.875rem;
   font-weight: 700;
   color: var(--text);
-}
-
-.history-elim {
-  font-size: 0.75rem;
-  color: var(--red);
-  padding: 0.25rem 0;
 }
 
 .history-columns {

--- a/frontend/src/views/DemoView.vue
+++ b/frontend/src/views/DemoView.vue
@@ -772,8 +772,7 @@ const endPlayers = computed<GamePlayer[]>(() =>
 .demo-phone :deep(.day-wrap),
 .demo-phone :deep(.voting-wrap),
 .demo-phone :deep(.sheriff-wrap),
-.demo-phone :deep(.reveal-wrap),
-.demo-phone :deep(.hunter-wrap) {
+.demo-phone :deep(.reveal-wrap) {
   min-height: auto;
 }
 /* Reveal-wrap has 5.5rem top padding for status-bar room — trim in demo */

--- a/frontend/src/views/LobbyView.vue
+++ b/frontend/src/views/LobbyView.vue
@@ -415,15 +415,6 @@ function signInWithWechat() {
   letter-spacing: 0.05em;
 }
 
-.identity-name {
-  font-family: 'Noto Serif SC', serif;
-  font-size: 1rem;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .identity-name-input {
   font-family: 'Noto Serif SC', serif;
   font-size: 1rem;


### PR DESCRIPTION
## Summary

Evidence-driven cleanup of dead declarations across backend and frontend. No behavioral change.

- **Backend** (commit `1f0d93d`) — Remove `GameTimingProperties.sheriffResultAutoAdvanceMs` and its two orphan YAML keys. The Variant B sheriff RESULT auto-advance timer was replaced by the host-driven `SHERIFF_END_RESULT` action; `SheriffService.cancelScheduledJob()` is an intentional no-op (per its docstring) and the property had zero consumers in main or test code.
- **Frontend** (commit `030dae0`) — Remove 14 unused CSS selectors across 6 Vue files, validated by extracting every `.foo` selector and confirming zero static matches, zero `:class` bindings, zero dynamic prefix patterns, and zero literal-string hits anywhere in `src/`, `e2e/`, or `backend/`. The documented global `.btn-success` in `style.css` is intentionally kept; only the scoped duplicate in `NightPhase.vue` was removed.

## Test plan

- [x] `cd backend && ./gradlew compileKotlin compileTestKotlin` — clean compile
- [x] `cd backend && ./gradlew test --tests "*Sheriff*" --tests "ProdConfigPlaceholderTest"` — pass
- [x] `cd frontend && npm run format` — prettier clean
- [x] `cd frontend && npm run lint` — 0 errors (22 pre-existing warnings unchanged)
- [x] `cd frontend && npm run test` — 451/451 pass
- [x] `rg "sheriffResultAutoAdvance|sheriff-result-auto-advance" backend/` → 0 hits
- [x] `rg` for each removed CSS class in `frontend/src` → 0 hits
- [ ] CI green on this PR

## Risk

Very low. Lines deleted only; no signatures or behavior changed. The backend YAML keys were bound to a field that no production code path read. The frontend CSS rules had no consumers (templates, bindings, dynamic generation, or full-text grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)