### PR TITLE
fix(security): dev auth bypass can never activate under prod profile

### DIFF
--- a/backend/src/main/kotlin/com/werewolf/auth/DevAuthController.kt
+++ b/backend/src/main/kotlin/com/werewolf/auth/DevAuthController.kt
@@ -13,13 +13,14 @@ data class DevLoginRequest(
 )
 
 /**
- * Dev-only auth bypass — not compiled into production builds.
- * Active only when spring.profiles.active=dev.
+ * Dev-only auth bypass — an unauthenticated JWT mint for local/bot testing.
+ * Active only when the `dev` profile is on AND `prod` is NOT — so a stray
+ * `SPRING_PROFILES_ACTIVE=dev,prod` on a production box can never expose it.
  *
  * POST /api/auth/dev  { "nickname": "Alice" }
  *                     { "nickname": "Bob", "userId": "dev:bob-fixed-id" }
  */
-@Profile("dev")
+@Profile("dev & !prod")
 @RestController
 @RequestMapping("/api/auth")
 class DevAuthController(private val authService: AuthService) {

--- a/backend/src/test/kotlin/com/werewolf/unit/auth/DevAuthControllerProfileTest.kt
+++ b/backend/src/test/kotlin/com/werewolf/unit/auth/DevAuthControllerProfileTest.kt
@@ -1,0 +1,52 @@
+package com.werewolf.unit.auth
+
+import com.werewolf.auth.AuthService
+import com.werewolf.auth.DevAuthController
+import java.util.function.Supplier
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+
+/**
+ * Guards the security invariant: the dev-only auth bypass (`POST /api/auth/dev`,
+ * an unauthenticated JWT mint) must NEVER be registered when the `prod` profile
+ * is active — even if someone also lists `dev` (e.g. `SPRING_PROFILES_ACTIVE=dev,prod`
+ * on the VM). Profile-gating is evaluated at bean-registration time, so we assert
+ * on the presence of the [DevAuthController] bean under each profile combination
+ * rather than booting a full web context.
+ */
+class DevAuthControllerProfileTest {
+
+    /** Build a bare context with the given active profiles and the controller registered. */
+    private fun contextWith(vararg profiles: String): AnnotationConfigApplicationContext {
+        val ctx = AnnotationConfigApplicationContext()
+        ctx.environment.setActiveProfiles(*profiles)
+        // The controller needs an AuthService to instantiate when its @Profile matches.
+        ctx.registerBean(AuthService::class.java, Supplier { mock<AuthService>() })
+        ctx.register(DevAuthController::class.java)
+        ctx.refresh()
+        return ctx
+    }
+
+    @Test
+    fun `dev auth bypass is registered when only dev is active`() {
+        contextWith("dev").use { ctx ->
+            assertThat(ctx.getBeanNamesForType(DevAuthController::class.java)).isNotEmpty()
+        }
+    }
+
+    @Test
+    fun `dev auth bypass is NOT registered when prod is active alongside dev`() {
+        contextWith("dev", "prod").use { ctx ->
+            assertThat(ctx.getBeanNamesForType(DevAuthController::class.java)).isEmpty()
+        }
+    }
+
+    @Test
+    fun `dev auth bypass is NOT registered under prod alone`() {
+        contextWith("prod").use { ctx ->
+            assertThat(ctx.getBeanNamesForType(DevAuthController::class.java)).isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
## What & why

While investigating why the prod VM was *"running dev"*, I found the live `.env.prod` had `SPRING_PROFILES_ACTIVE=dev,prod` — **both** profiles active (startup log: `The following 2 profiles are active: "dev", "prod"`).

Because Spring uses last-wins for overlapping properties, `prod` already won on CORS/logging/etc., so the box behaved like prod **except** for one thing: `@Profile("dev")` beans were still registered. That includes `DevAuthController`, which exposes:

> ⚠️ `POST /api/auth/dev` — an **unauthenticated JWT mint**. With `dev` active, anyone on the public internet could forge a token for any `userId`/nickname and impersonate any player, with no OAuth.

`SPRING_PROFILES_ACTIVE` is injected **only** from the untracked `.env.prod` (no Dockerfile/compose default), and `deploy/release.sh` only manages `WEREWOLF_VERSION` — so a hand-edited `dev,` prefix (added to make the `dev-login.sh`/bot scripts work on the VM) persisted silently across every deploy.

## Fix

`@Profile("dev")` → `@Profile("dev & !prod")`. Any active profile set containing `prod` now excludes the bean, regardless of whether `dev` is also listed.

Behaviour is unchanged for every real profile:

| Profile(s) | `/api/auth/dev` before | after |
|---|---|---|
| `dev` (local) | available | available |
| `e2e` (real-E2E; bots use `/api/user/login`) | absent | absent |
| `test` (integration) | absent | absent |
| `prod` | absent | absent |
| **`dev,prod` (the bug)** | **available** ⚠️ | **absent** ✅ |

The human guest login (`POST /api/user/login`, `UserController`) is `permitAll` and ungated — unaffected in every profile.

## Tests (TDD)

`DevAuthControllerProfileTest` asserts the controller bean is registered under `dev`, **absent** under `dev,prod`, and absent under `prod`. The `dev,prod` case **failed before** the one-line change and passes after. Full backend suite green.

## Live prod already mitigated

The running VM was separately corrected ahead of this PR by flipping its `.env.prod` to `SPRING_PROFILES_ACTIVE=prod` and recreating the backend — verified: profile `prod` only, `/api/health` UP, `/api/auth/dev` → 404, `/api/user/login` → 200. This PR is the durable, defense-in-depth guard so it can't recur on the next box or a future hand-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)