### PR TITLE
fix(frontend): show the real version badge in prod (dynamic, not hardcoded)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags so `git describe` resolves the app version
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -56,6 +58,13 @@ jobs:
           owner_lc=$(echo "${IMAGE_OWNER}" | tr '[:upper:]' '[:lower:]')
           echo "ref=${REGISTRY}/${owner_lc}/werewolf-simple-${{ matrix.service.name }}" >> "$GITHUB_OUTPUT"
 
+      # Resolve the version dynamically from git (the frontend image build can't
+      # run `git describe` itself — no .git in its ./frontend context). A tag push
+      # resolves to that tag (e.g. v0.8.0); a main push resolves to the latest tag.
+      - name: Resolve app version
+        id: appver
+        run: echo "value=$(git describe --tags --abbrev=0 2>/dev/null || echo dev)" >> "$GITHUB_OUTPUT"
+
       - name: Extract image tags
         id: meta
         uses: docker/metadata-action@v5
@@ -71,6 +80,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.service.context }}
+          # Consumed by the frontend image (corner-badge version); ignored by backend.
+          build-args: |
+            APP_VERSION=${{ steps.appver.outputs.value }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,9 @@ services:
     image: ghcr.io/wangdaqian08/werewolf-simple-frontend:${WEREWOLF_VERSION:-latest}
     build:
       context: ./frontend
+      # Badge version for a local `--build`; CI passes the git tag instead.
+      args:
+        APP_VERSION: ${WEREWOLF_VERSION:-}
     restart: unless-stopped
     # Host Nginx proxies to this port; /api and /ws are handled by the host,
     # so the frontend container only needs to serve static assets.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,11 @@ RUN --mount=type=cache,target=/root/.npm \
 
 # Copy sources and build. `npm run build` = vue-tsc -b && vite build → dist/.
 COPY . .
+# Version for the corner badge. `git describe` can't run in this stage (no `.git`
+# in the ./frontend build context, no git binary in alpine), so the build pipeline
+# injects it and vite reads APP_VERSION. Empty default → vite falls back to 'dev'.
+ARG APP_VERSION=
+ENV APP_VERSION=$APP_VERSION
 RUN npm run build
 
 # ---- Stage 2: serve static assets via Nginx ------------------------------

--- a/frontend/src/__tests__/appVersion.test.ts
+++ b/frontend/src/__tests__/appVersion.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { pickAppVersion } from '@/utils/appVersion'
+
+// The badge version is resolved at build time with this precedence:
+//   1. an injected APP_VERSION (set by the build pipeline / Docker build-arg),
+//   2. otherwise the local `git describe` result (plain `npm` builds in a checkout),
+//   3. otherwise the literal 'dev'.
+// This keeps it dynamic everywhere: containers (which have no .git) get the
+// injected value; local dev reads git directly. Nothing is hardcoded.
+describe('pickAppVersion', () => {
+  it('prefers a non-empty injected APP_VERSION over git', () => {
+    expect(pickAppVersion('v9.9.9', 'v0.8.0')).toBe('v9.9.9')
+  })
+
+  it('falls back to the git value when APP_VERSION is unset or blank', () => {
+    expect(pickAppVersion(undefined, 'v0.8.0')).toBe('v0.8.0')
+    expect(pickAppVersion('   ', 'v0.8.0')).toBe('v0.8.0')
+  })
+
+  it("falls back to 'dev' when neither source is available", () => {
+    expect(pickAppVersion(undefined, undefined)).toBe('dev')
+    expect(pickAppVersion('', '')).toBe('dev')
+  })
+
+  it('trims surrounding whitespace from the resolved value', () => {
+    expect(pickAppVersion(' v1.2.3 ', undefined)).toBe('v1.2.3')
+    expect(pickAppVersion(undefined, '  v0.8.0\n')).toBe('v0.8.0')
+  })
+})

--- a/frontend/src/utils/appVersion.ts
+++ b/frontend/src/utils/appVersion.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolve the app version shown in the corner badge, with precedence:
+ *   1. an injected `APP_VERSION` (build pipeline / Docker build-arg) — used by
+ *      containerized builds, which have no `.git` to run `git describe` against;
+ *   2. otherwise the local `git describe` result — plain `npm` builds in a checkout;
+ *   3. otherwise the literal `'dev'`.
+ *
+ * Pure on purpose: `vite.config.ts` does the Node-side `git describe` and passes
+ * both candidate strings here, so the precedence is unit-testable without spawning git.
+ */
+export function pickAppVersion(
+  injected: string | undefined,
+  gitDescribe: string | undefined,
+): string {
+  const fromEnv = injected?.trim()
+  if (fromEnv) return fromEnv
+  const fromGit = gitDescribe?.trim()
+  if (fromGit) return fromGit
+  return 'dev'
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,15 +3,17 @@ import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 import {fileURLToPath, URL} from 'node:url'
 import {execSync} from 'node:child_process'
+import {pickAppVersion} from './src/utils/appVersion'
 
-function resolveAppVersion(): string {
+// Local `git describe`, or undefined when git/.git is unavailable (e.g. inside a
+// container build). Container builds get the version from APP_VERSION instead.
+function gitDescribe(): string | undefined {
     try {
-        const tag = execSync('git describe --tags --abbrev=0', {
+        return execSync('git describe --tags --abbrev=0', {
             stdio: ['ignore', 'pipe', 'ignore'],
         }).toString().trim()
-        return tag || 'dev'
     } catch {
-        return 'dev'
+        return undefined
     }
 }
 
@@ -26,7 +28,7 @@ export default defineConfig({
         },
     },
     define: {
-        __APP_VERSION__: JSON.stringify(resolveAppVersion()),
+        __APP_VERSION__: JSON.stringify(pickAppVersion(process.env.APP_VERSION, gitDescribe())),
         // Fix for SockJS: add global polyfill
         global: 'globalThis',
     },


### PR DESCRIPTION
## Problem

The corner version badge shows **`dev`** on every deployed build, while it shows the real version locally. That looked like \"v0.8.0 didn't deploy / the profile is still dev\" — it isn't (the backend runs `prod`, verified). It's a separate frontend build bug.

## Root cause (reproduced, not assumed)

`vite.config.ts` resolves the badge via `git describe --tags`. But the frontend image builds with `context: ./frontend` (no `.git` — it's at the repo root) inside `node:20-alpine` (no git binary). So `git describe` throws and `resolveAppVersion()` falls back to the literal `'dev'`. Proven:

```
git -C frontend describe --tags  → v0.8.0     (local works → local badge correct)
frontend/.git                    → ABSENT     (not in the ./frontend build context)
docker run node:20-alpine git    → NO GIT BINARY
```

So it's been `dev` on every Docker build (v0.7.0 too), unrelated to the Spring profile.

## Fix — keep it dynamic, don't hardcode, don't ship 120 MB of `.git`

Resolve the version from git **where `.git` is cheap** (the build host/CI) and hand it to Vite; keep the local `git describe` fallback so local stays git-dynamic.

- **`pickAppVersion(injected, gitDescribe)`** — new pure helper, precedence: injected `APP_VERSION` → local `git describe` → `'dev'`. Unit-tested.
- **`vite.config.ts`** — reads `process.env.APP_VERSION` first, else `git describe`.
- **`frontend/Dockerfile`** — `ARG APP_VERSION` → `ENV APP_VERSION` before `npm run build`.
- **`publish-images.yml`** — `fetch-depth: 0` + `--build-arg APP_VERSION=$(git describe --tags --abbrev=0)`. Tag push bakes that tag; main bakes the latest tag.
- **`docker-compose.yml`** — `APP_VERSION=${WEREWOLF_VERSION}` for local `--build`.

Nothing is hardcoded — the version flows from the git tag through the pipeline. `release.sh` needs no change: it pulls the image already built with the tag's version.

## Verification

- Unit: 4 cases for `pickAppVersion` (RED→GREEN), full suite 487/487 green.
- **End-to-end in the real build env**: `docker build --build-arg APP_VERSION=v0.8.0` (alpine, no git) → bundle bakes **`v0.8.0`**; without the arg → falls back to `dev`.
- prettier/eslint(0 errors)/vue-tsc all clean.

> Note: this reaches prod only on a **fresh release built after merge** — the existing `:v0.8.0` image was built before this fix, so it still shows `dev`. Cut e.g. `v0.8.1` after merging and the badge will read the real version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)