### PR TITLE
fix(audio): park blocked narration for gesture-resume + prime cue pool (mobile night-1 silence)

### DIFF
--- a/frontend/e2e/real/audio-autoplay-unlock-firefox.spec.ts
+++ b/frontend/e2e/real/audio-autoplay-unlock-firefox.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test'
+import { countIn, installTrigger, NIGHT1_SEQUENCE, snapshot } from './helpers/autoplay-unlock'
+
+/**
+ * Narration autoplay unlock — Firefox half (see
+ * audio-autoplay-unlock.spec.ts for the Chromium half and the full
+ * rationale). LOCAL-ONLY, skipped in CI.
+ *
+ * Firefox media.autoplay.blocking_policy=2 requires play() to run inside
+ * an input handler — the same shape as iOS Safari's per-element gesture
+ * rule, and immune to Playwright's activation grant (unlike Chromium's
+ * sticky-activation policy). It exercises the NotAllowedError
+ * park-and-retry path against a real browser denial end to end.
+ */
+
+test.skip(
+  !!process.env.CI,
+  'needs a headed browser with a real autoplay policy; headless-shell pages are pre-activated',
+)
+
+test.use({
+  browserName: 'firefox',
+  headless: false,
+  launchOptions: {
+    firefoxUserPrefs: {
+      'media.autoplay.default': 1,
+      'media.autoplay.blocking_policy': 2,
+    },
+  },
+})
+
+test('denied head is parked with the full sequence; a tap plays it in-gesture and the tail re-parks', async ({
+  page,
+}) => {
+  const lines: string[] = []
+  page.on('console', (msg) => lines.push(msg.text()))
+  await installTrigger(page, 'flagged')
+  await page.goto('/#unlock-repro')
+
+  // Head attempted (flag true), denied by the browser, and PARKED — the
+  // old code consumed all four files here ('Failed to play' ×4).
+  await expect
+    .poll(() => countIn(lines, 'Autoplay prevented by browser policy'), { timeout: 20_000 })
+    .toBeGreaterThan(0)
+  const parked = await snapshot(page)
+  console.log(
+    `[unlock:firefox] parked queueLen=${parked.queueLen} ` +
+      `failedLogs=${countIn(lines, 'Failed to play')}`,
+  )
+  expect(parked.userInteracted).toBe(true)
+  expect(parked.queueLen).toBe(NIGHT1_SEQUENCE.length)
+  expect(countIn(lines, 'Failed to play')).toBe(0)
+  expect(parked.elements.every((e) => e.paused && e.currentTime === 0)).toBe(true)
+
+  // A real tap resumes the head synchronously inside the input handler —
+  // the only context this policy (and iOS) accepts.
+  const marker = lines.length
+  await page.locator('body').click({ position: { x: 10, y: 10 }, force: true })
+  await expect
+    .poll(
+      async () => {
+        const s = await snapshot(page)
+        const head = s.elements.find((e) => e.file === 'goes_dark_close_eyes.mp3')
+        return head ? head.currentTime > 0 : false
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true)
+
+  // When the head ends, the tail's un-gestured play is denied again under
+  // blocking_policy=2 → it re-parks with the remaining cues instead of
+  // draining. (iOS differs here: pool priming blesses the elements, so the
+  // chain continues — covered by the unit suite.)
+  await expect
+    .poll(() => countIn(lines, 'Narration parked (autoplay blocked)', marker), {
+      timeout: 20_000,
+    })
+    .toBeGreaterThan(0)
+  const reparked = await snapshot(page)
+  console.log(`[unlock:firefox] re-parked queueLen=${reparked.queueLen}`)
+  expect(reparked.queueLen).toBe(NIGHT1_SEQUENCE.length - 1)
+  expect(countIn(lines, 'Failed to play')).toBe(0)
+})

--- a/frontend/e2e/real/audio-autoplay-unlock.spec.ts
+++ b/frontend/e2e/real/audio-autoplay-unlock.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test'
+import { countIn, installTrigger, NIGHT1_SEQUENCE, snapshot } from './helpers/autoplay-unlock'
+
+/**
+ * Narration autoplay unlock — browser-level regression net for the mobile
+ * "first night has no sound" bug, Chromium half (Firefox half:
+ * audio-autoplay-unlock-firefox.spec.ts; queue logic unit-pinned in
+ * src/__tests__/audioServiceAutoplayUnlock.test.ts).
+ *
+ * LOCAL-ONLY (skipped in CI): it needs a headed browser with a strict
+ * autoplay policy. CI shards run Playwright's headless-shell, which starts
+ * every page pre-activated (navigator.userActivation.hasBeenActive === true
+ * within ~500ms of commit, verified even on a plain JSON page) — the exact
+ * condition that masked this bug in every e2e run. Run locally:
+ *
+ *   npx playwright test --config=playwright.real.config.ts audio-autoplay-unlock
+ *
+ * This half exercises OUR pre-interaction gate under
+ * --autoplay-policy=user-gesture-required: cues queued before any
+ * interaction must be PARKED (not consumed) and must play after the first
+ * real tap. (page.evaluate grants Chromium sticky activation, so the
+ * browser-side NotAllowedError path can't be tested here — that's what the
+ * Firefox half is for.)
+ */
+
+test.skip(
+  !!process.env.CI,
+  'needs a headed browser with a real autoplay policy; headless-shell pages are pre-activated',
+)
+
+test.use({
+  headless: false,
+  launchOptions: { args: ['--autoplay-policy=user-gesture-required'] },
+})
+
+test('night sequence parks untouched, then plays through after one tap', async ({ page }) => {
+  const lines: string[] = []
+  page.on('console', (msg) => lines.push(msg.text()))
+  await installTrigger(page, 'pristine')
+  await page.goto('/#unlock-repro')
+
+  await expect.poll(() => countIn(lines, 'playSequential fired'), { timeout: 15_000 }).toBe(1)
+  await expect
+    .poll(() => countIn(lines, 'Narration parked (autoplay blocked)'), { timeout: 10_000 })
+    .toBeGreaterThan(0)
+
+  // Parked, not consumed: whole sequence still queued, nothing started.
+  const parked = await snapshot(page)
+  console.log(`[unlock:chromium] parked queueLen=${parked.queueLen}`)
+  expect(parked.queueLen).toBe(NIGHT1_SEQUENCE.length)
+  expect(parked.isPlayingQueue).toBe(false)
+  expect(countIn(lines, 'Starting playback')).toBe(0)
+  expect(parked.elements.every((e) => e.paused && e.currentTime === 0)).toBe(true)
+
+  // First real tap → pool primes + queue resumes audibly.
+  await page.locator('body').click({ position: { x: 10, y: 10 }, force: true })
+
+  await expect
+    .poll(() => countIn(lines, 'Starting playback: goes_dark_close_eyes.mp3'), {
+      timeout: 10_000,
+    })
+    .toBe(1)
+  await expect
+    .poll(
+      async () => {
+        const s = await snapshot(page)
+        const head = s.elements.find((e) => e.file === 'goes_dark_close_eyes.mp3')
+        return head ? head.currentTime > 0 : false
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true)
+  const resumed = await snapshot(page)
+  console.log(
+    `[unlock:chromium] resumed queueLen=${resumed.queueLen} ` +
+      `primedLog=${countIn(lines, 'narration file(s) during user gesture')}`,
+  )
+  expect(resumed.queueLen).toBe(NIGHT1_SEQUENCE.length - 1)
+  expect(countIn(lines, 'narration file(s) during user gesture')).toBeGreaterThan(0)
+})

--- a/frontend/e2e/real/helpers/autoplay-unlock.ts
+++ b/frontend/e2e/real/helpers/autoplay-unlock.ts
@@ -1,0 +1,75 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Shared pieces for the two audio-autoplay-unlock specs (Chromium +
+ * Firefox halves live in separate files because browserName/headless/
+ * launchOptions are worker-scoped and cannot vary per describe group).
+ */
+
+export const NIGHT1_SEQUENCE = [
+  'goes_dark_close_eyes.mp3',
+  'wolf_howl.mp3',
+  'wolf_open_eyes.mp3',
+  'wolf_close_eyes.mp3',
+]
+
+export interface SvcSnapshot {
+  userInteracted: boolean
+  queueLen: number
+  isPlayingQueue: boolean
+  elements: Array<{ file: string; paused: boolean; currentTime: number }>
+}
+
+export function snapshot(page: Page): Promise<SvcSnapshot> {
+  return page.evaluate(() => {
+    const svc: any = (window as any).__audioService
+    const cache: Map<string, HTMLAudioElement> = svc.audioCache
+    return {
+      userInteracted: !!svc.userInteracted,
+      queueLen: svc.audioQueue.length,
+      isPlayingQueue: !!svc.isPlayingQueue,
+      elements: [...cache.entries()].map(([file, el]) => ({
+        file,
+        paused: el.paused,
+        currentTime: el.currentTime,
+      })),
+    }
+  })
+}
+
+/**
+ * Trigger playback WITHOUT page.evaluate (evaluate carries a CDP/juggler
+ * user gesture that grants sticky activation): an init script fires
+ * playSequential a moment after load, exactly like a STOMP push landing on
+ * an untouched phone. mode=flagged additionally dispatches an untrusted
+ * click first so the service's userInteracted flag is true while the
+ * browser still has no gesture.
+ */
+export async function installTrigger(page: Page, mode: 'pristine' | 'flagged'): Promise<void> {
+  await page.addInitScript(
+    ({ files, m }: { files: string[]; m: string }) => {
+      const wantsRepro = location.hash.includes('unlock-repro')
+      const run = () => {
+        if (!wantsRepro) return
+        setTimeout(async () => {
+          try {
+            await import(/* @vite-ignore */ '/src/services/audioService.ts' as string)
+            if (m === 'flagged') {
+              document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+            }
+            ;(window as any).__audioService.playSequential(files)
+            console.log('[unlock-trigger] playSequential fired')
+          } catch (e) {
+            console.log(`[unlock-trigger] ERROR ${(e as Error).message}`)
+          }
+        }, 2_000)
+      }
+      if (document.readyState === 'complete') run()
+      else window.addEventListener('load', run)
+    },
+    { files: NIGHT1_SEQUENCE, m: mode },
+  )
+}
+
+export const countIn = (lines: string[], needle: string, from = 0) =>
+  lines.slice(from).filter((l) => l.includes(needle)).length

--- a/frontend/src/__tests__/audioServiceAutoplayUnlock.test.ts
+++ b/frontend/src/__tests__/audioServiceAutoplayUnlock.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Narration autoplay unlock — the mobile "first night has no sound" bug.
+ *
+ * Replicated (Firefox media.autoplay.blocking_policy=2 + Chromium
+ * user-gesture-required): cues arrive via STOMP with no qualifying user
+ * gesture; play() rejects with NotAllowedError (iOS: per fresh element,
+ * regardless of page interaction history). The old code CONSUMED each
+ * queue item on failure — an entire night of narration silently dropped,
+ * and the first cue to arrive after a tap (e.g. wolf_close_eyes right
+ * after the wolf picked a victim) suddenly played out loud.
+ *
+ * Contract under test:
+ *  1. blocked narration is PARKED, not dropped (both the pre-interaction
+ *     gate and NotAllowedError rejections)
+ *  2. the next user gesture resumes the parked queue synchronously
+ *  3. gestures prime (muted play/pause) the known cue pool + queued files
+ *     so later un-gestured plays are element-blessed on iOS
+ *  4. while parked, a newer sequence replaces the stale backlog
+ *  5. stopAll/clearQueue cancel any pending resume
+ */
+
+type MockAudio = {
+  play: ReturnType<typeof vi.fn>
+  pause: ReturnType<typeof vi.fn>
+  currentTime: number
+  volume: number
+  muted: boolean
+  mutedAtPlayCalls: boolean[]
+  loop: boolean
+  preload: string
+  src: string
+  onended: (() => void) | null
+}
+
+let mockAudioInstances: MockAudio[] = []
+
+function createMockAudio(src: string): MockAudio {
+  const inst: MockAudio = {
+    play: vi.fn(),
+    pause: vi.fn(),
+    currentTime: 0,
+    volume: 1,
+    muted: false,
+    mutedAtPlayCalls: [],
+    loop: false,
+    preload: '',
+    src,
+    onended: null,
+  }
+  inst.play.mockImplementation(() => {
+    inst.mutedAtPlayCalls.push(inst.muted)
+    return Promise.resolve()
+  })
+  mockAudioInstances.push(inst)
+  return inst
+}
+
+function instFor(filename: string): MockAudio | undefined {
+  return mockAudioInstances.find((i) => decodeURIComponent(i.src).includes(filename))
+}
+
+const notAllowed = () => Object.assign(new Error('play() blocked'), { name: 'NotAllowedError' })
+
+vi.stubGlobal('document', { ...globalThis.document, addEventListener: vi.fn() })
+vi.stubGlobal(
+  'Audio',
+  vi.fn().mockImplementation(function (src: string) {
+    return createMockAudio(src ?? '')
+  }),
+)
+vi.stubGlobal(
+  'AudioContext',
+  vi.fn().mockImplementation(function () {
+    return {}
+  }),
+)
+
+let audioService: typeof import('@/services/audioService').audioService
+let KNOWN_NARRATION_FILES: readonly string[]
+
+/** The capture-phase document 'click' listener registered by the service (latest registration wins after resetModules). */
+function fireGesture(): void {
+  const calls = (document.addEventListener as unknown as ReturnType<typeof vi.fn>).mock.calls
+  const clicks = calls.filter((c) => c[0] === 'click')
+  const handler = clicks[clicks.length - 1]![1] as () => void
+  handler()
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0))
+
+describe('audioService autoplay unlock', () => {
+  beforeEach(async () => {
+    localStorage.clear()
+    mockAudioInstances = []
+    ;(Audio as unknown as ReturnType<typeof vi.fn>).mockClear()
+    vi.resetModules()
+    const mod = await import('@/services/audioService')
+    audioService = mod.audioService
+    KNOWN_NARRATION_FILES = mod.KNOWN_NARRATION_FILES
+  })
+
+  // ── 1+2: pre-interaction parking ──────────────────────────────────────────
+
+  it('parks narration queued before the first interaction and plays it on the first gesture', async () => {
+    audioService.playSequential(['goes_dark_close_eyes.mp3', 'wolf_howl.mp3'])
+
+    // Parked, not dropped: nothing played, queue intact.
+    expect(instFor('goes_dark_close_eyes.mp3')?.play ?? { mock: { calls: [] } }).toSatisfy(
+      (p: any) => (p.mock?.calls?.length ?? 0) === 0,
+    )
+    expect(audioService.isQueueActive()).toBe(true)
+
+    fireGesture()
+    await flush()
+
+    const head = instFor('goes_dark_close_eyes.mp3')
+    expect(head?.play).toHaveBeenCalledTimes(1)
+    // The resumed head must be audible (not left muted by pool priming).
+    expect(head?.mutedAtPlayCalls[0]).toBe(false)
+
+    head?.onended?.()
+    await flush()
+    const tail = instFor('wolf_howl.mp3')
+    // wolf_howl was pool-primed muted during the gesture, then really played
+    // when its turn came — the real play must be unmuted.
+    expect(tail?.play).toHaveBeenCalled()
+    expect(tail?.mutedAtPlayCalls[tail.mutedAtPlayCalls.length - 1]).toBe(false)
+  })
+
+  // ── 1+2: NotAllowedError parking ─────────────────────────────────────────
+
+  it('parks the sequence when the browser rejects play() with NotAllowedError and retries on the next gesture', async () => {
+    audioService.toggleMute()
+    audioService.toggleMute() // sets userInteracted=true, ends unmuted
+    ;(Audio as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(function (src: string) {
+      const inst = createMockAudio(src ?? '')
+      inst.play
+        .mockImplementationOnce(() => {
+          inst.mutedAtPlayCalls.push(inst.muted)
+          return Promise.reject(notAllowed())
+        })
+        .mockImplementation(() => {
+          inst.mutedAtPlayCalls.push(inst.muted)
+          return Promise.resolve()
+        })
+      return inst
+    })
+
+    audioService.playSequential(['blocked_head.mp3', 'tail_cue.mp3'])
+    await flush()
+
+    // Old behavior: rejection consumed the item and advanced to tail_cue.
+    // New behavior: the whole sequence is parked awaiting a gesture.
+    expect(audioService.isQueueActive()).toBe(true)
+    expect(instFor('tail_cue.mp3')?.play ?? { mock: { calls: [] } }).toSatisfy(
+      (p: any) => (p.mock?.calls?.length ?? 0) === 0,
+    )
+
+    fireGesture()
+    await flush()
+    const head = instFor('blocked_head.mp3')
+    expect(head?.play).toHaveBeenCalledTimes(2) // rejected once, retried on gesture
+
+    head?.onended?.()
+    await flush()
+    expect(instFor('tail_cue.mp3')?.play).toHaveBeenCalled()
+  })
+
+  it('still skips to the next file on non-autoplay play() errors', async () => {
+    audioService.toggleMute()
+    audioService.toggleMute()
+    ;(Audio as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(function (src: string) {
+      const inst = createMockAudio(src ?? '')
+      inst.play.mockImplementation(() => Promise.reject(new Error('decode failure')))
+      return inst
+    })
+
+    audioService.playSequential(['broken.mp3', 'ok.mp3'])
+    await vi.waitFor(() => {
+      expect(instFor('ok.mp3')?.play).toHaveBeenCalled()
+    })
+  })
+
+  // ── 4: stale backlog replacement while parked ─────────────────────────────
+
+  it('replaces a parked backlog with the newest sequence instead of stacking stale cues', async () => {
+    audioService.playSequential(['stale_cue.mp3'])
+    expect(audioService.isQueueActive()).toBe(true)
+
+    audioService.playSequential(['fresh_a.mp3', 'fresh_b.mp3'])
+
+    fireGesture()
+    await flush()
+
+    expect(instFor('stale_cue.mp3')?.play ?? { mock: { calls: [] } }).toSatisfy(
+      (p: any) => (p.mock?.calls?.length ?? 0) === 0,
+    )
+    expect(instFor('fresh_a.mp3')?.play).toHaveBeenCalledTimes(1)
+
+    instFor('fresh_a.mp3')?.onended?.()
+    await flush()
+    expect(instFor('fresh_b.mp3')?.play).toHaveBeenCalled()
+  })
+
+  // ── 3: gesture-time pool priming ─────────────────────────────────────────
+
+  it('primes the known narration pool muted on the first gesture and restores element state', async () => {
+    fireGesture()
+
+    expect(KNOWN_NARRATION_FILES.length).toBeGreaterThan(0)
+    for (const file of KNOWN_NARRATION_FILES) {
+      const el = instFor(file)
+      expect(el, `${file} should be created by priming`).toBeTruthy()
+      expect(el!.play).toHaveBeenCalledTimes(1)
+      expect(el!.mutedAtPlayCalls[0], `${file} must be primed muted`).toBe(true)
+    }
+
+    await flush()
+    for (const file of KNOWN_NARRATION_FILES) {
+      const el = instFor(file)!
+      expect(el.pause).toHaveBeenCalled()
+      expect(el.muted).toBe(false)
+      expect(el.currentTime).toBe(0)
+    }
+  })
+
+  it('does not re-prime already primed files on later gestures', async () => {
+    fireGesture()
+    await flush()
+    fireGesture()
+    await flush()
+    for (const file of KNOWN_NARRATION_FILES) {
+      expect(instFor(file)!.play).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it('priming a rejected file retries on a later gesture', async () => {
+    const target = KNOWN_NARRATION_FILES[0]!
+    ;(Audio as unknown as ReturnType<typeof vi.fn>).mockImplementation(function (src: string) {
+      const inst = createMockAudio(src ?? '')
+      if (decodeURIComponent(src ?? '').includes(target)) {
+        inst.play
+          .mockImplementationOnce(() => {
+            inst.mutedAtPlayCalls.push(inst.muted)
+            return Promise.reject(notAllowed())
+          })
+          .mockImplementation(() => {
+            inst.mutedAtPlayCalls.push(inst.muted)
+            return Promise.resolve()
+          })
+      }
+      return inst
+    })
+
+    fireGesture()
+    await flush()
+    fireGesture()
+    await flush()
+    expect(instFor(target)!.play).toHaveBeenCalledTimes(2)
+  })
+
+  // ── 5: cancel pending resume ─────────────────────────────────────────────
+
+  it('stopAll cancels a pending gesture resume', async () => {
+    audioService.playSequential(['orphan.mp3'])
+    expect(audioService.isQueueActive()).toBe(true)
+
+    audioService.stopAll()
+    fireGesture()
+    await flush()
+
+    expect(instFor('orphan.mp3')?.play ?? { mock: { calls: [] } }).toSatisfy(
+      (p: any) => (p.mock?.calls?.length ?? 0) === 0,
+    )
+    expect(audioService.isQueueActive()).toBe(false)
+  })
+})

--- a/frontend/src/services/audioService.ts
+++ b/frontend/src/services/audioService.ts
@@ -32,6 +32,31 @@ const BGM_RAMP_SEC = 0.15
 // queue is never discarded.
 const STUCK_QUEUE_MS = 15_000
 
+/**
+ * Static narration pool, primed (muted play+pause) inside the first user
+ * gesture. iOS Safari removes its autoplay restriction PER ELEMENT on the
+ * element's first gestured play() — page-level interaction history is not
+ * enough — so cues pushed later over STOMP would otherwise be denied on
+ * every night. Mirrors backend/src/main/resources/static/audio/ minus the
+ * unreferenced crow_night.mp3; a cue missing from this list still works via
+ * the park-and-resume path, it just needs one extra tap on iOS.
+ */
+export const KNOWN_NARRATION_FILES: readonly string[] = [
+  'goes_dark_close_eyes.mp3',
+  'wolf_howl.mp3',
+  'wolf_open_eyes.mp3',
+  'wolf_close_eyes.mp3',
+  'witch_open_eyes.mp3',
+  'witch_close_eyes.mp3',
+  'seer_open_eyes.mp3',
+  'seer_close_eyes.mp3',
+  'guard_open_eyes.mp3',
+  'guard_close_eyes.mp3',
+  'rooster_crowing.mp3',
+  'day_time.mp3',
+  'countdown_warning.mp3',
+]
+
 class AudioService {
   private audioCache = new Map<string, HTMLAudioElement>()
   private globalVolume = 1.0
@@ -72,6 +97,11 @@ class AudioService {
   private audioQueue: Array<{ filename: string; options: AudioOptions }> = []
   private isPlayingQueue = false
   private lastPlaybackStartTime = 0
+  // Narration blocked by the autoplay policy waits here for a user gesture
+  // (the narration counterpart of bgmPendingStart, PR #119).
+  private pendingGestureResume = false
+  private primedFiles = new Set<string>()
+  private currentAudio: HTMLAudioElement | null = null
 
   /**
    * Setup tracking for user interaction to enable audio playback
@@ -89,6 +119,21 @@ class AudioService {
           } catch (error) {
             console.warn('[AudioService] Failed to initialize AudioContext:', error)
           }
+        }
+      }
+
+      // Bless the narration pool while we are inside a genuine input
+      // handler — the only context iOS accepts for a first play().
+      this.primeNarrationPool()
+
+      // Resume narration parked by the autoplay policy. playNextInQueue's
+      // play() runs synchronously inside this input handler, which is
+      // exactly the context iOS/Firefox require.
+      if (this.pendingGestureResume) {
+        this.pendingGestureResume = false
+        if (!this.muted && this.audioQueue.length > 0 && !this.isPlayingQueue) {
+          this.duckBgm()
+          this.playNextInQueue()
         }
       }
 
@@ -196,6 +241,16 @@ class AudioService {
       // does call unduckBgm because no new narration is guaranteed to follow.
     }
 
+    // A parked backlog is stale by definition (same philosophy as the
+    // tab-resume drain: never replay narration other players already
+    // heard). Keep only the newest sequence for the eventual gesture-resume.
+    if (this.pendingGestureResume && !this.isPlayingQueue && this.audioQueue.length > 0) {
+      console.warn('[AudioService] Replacing parked narration with a newer sequence', {
+        dropped: this.audioQueue.length,
+      })
+      this.audioQueue = []
+    }
+
     // Add to queue with options
     filenames.forEach((filename) => {
       this.audioQueue.push({ filename, options })
@@ -216,20 +271,22 @@ class AudioService {
   private playNextInQueue(): void {
     if (this.audioQueue.length === 0) {
       this.isPlayingQueue = false
+      this.currentAudio = null
       this.unduckBgm()
       console.log('[AudioService] Queue empty, playback complete')
       return
     }
 
     this.isPlayingQueue = true
-    const { filename, options } = this.audioQueue.shift()!
-    console.log(
-      `[AudioService] Starting playback: ${filename} (queue remaining: ${this.audioQueue.length})`,
-    )
+    const item = this.audioQueue.shift()!
+    const { filename, options } = item
 
     try {
       const audio = this.getAudio(filename)
       audio.currentTime = 0
+      // Pool priming leaves elements muted for a tick; real playback must
+      // always be audible.
+      audio.muted = false
 
       // Apply options
       if (options.loop !== undefined) {
@@ -250,32 +307,102 @@ class AudioService {
         this.playNextInQueue()
       }
 
-      // Check if user has interacted before playing
+      // No interaction yet: the browser would deny play() anyway. Park the
+      // sequence for the first gesture instead of consuming it.
       if (!this.userInteracted) {
         console.warn('[AudioService] Cannot play audio - user has not interacted with the page yet')
-        console.warn('[AudioService] Please click anywhere on the page to enable audio')
-        this.playNextInQueue() // Continue to next audio
+        this.parkQueue(item)
         return
       }
 
+      console.log(
+        `[AudioService] Starting playback: ${filename} (queue remaining: ${this.audioQueue.length})`,
+      )
+
       // Record start time for stuck-queue watchdog in playSequential.
       this.lastPlaybackStartTime = performance.now()
+      this.currentAudio = audio
 
-      // Handle play errors and continue to next
       audio.play().catch((error) => {
-        console.warn(`[AudioService] Failed to play ${filename} in queue:`, error)
-
-        // Check if it's an autoplay error
+        // Autoplay denial (iOS per-element gesture rule, Chrome/Firefox
+        // before first interaction): park and retry on the next gesture —
+        // dropping here is what made whole nights silently mute on phones.
         if (error instanceof Error && error.name === 'NotAllowedError') {
-          console.warn('[AudioService] Autoplay prevented by browser policy')
-          console.warn('[AudioService] Please click anywhere on the page to enable audio')
+          console.warn(
+            '[AudioService] Autoplay prevented by browser policy — parking narration for the next gesture',
+          )
+          this.parkQueue(item)
+          return
         }
 
+        // Anything else (decode error, missing file): skip this cue and
+        // keep the sequence moving.
+        console.warn(`[AudioService] Failed to play ${filename} in queue:`, error)
         this.playNextInQueue()
       })
     } catch (error) {
       console.warn(`[AudioService] Error playing ${filename} in queue:`, error)
       this.playNextInQueue()
+    }
+  }
+
+  /**
+   * Put a blocked item back at the queue head and wait for a user gesture
+   * (the interaction tracker resumes the queue inside its handler). The
+   * narration counterpart of bgmPendingStart: before this existed, blocked
+   * cues were consumed one by one — a whole night could drain silently, and
+   * the first cue to arrive after a stray tap played out of context (e.g.
+   * wolf_close_eyes blaring from the wolf's phone during 狼人闭眼).
+   */
+  private parkQueue(item: { filename: string; options: AudioOptions }): void {
+    this.audioQueue.unshift(item)
+    this.isPlayingQueue = false
+    this.currentAudio = null
+    this.pendingGestureResume = true
+    console.warn(
+      `[AudioService] Narration parked (autoplay blocked) — ${this.audioQueue.length} cue(s) awaiting a user gesture`,
+    )
+  }
+
+  /**
+   * Muted play()+pause() inside a user gesture removes the element-level
+   * autoplay restriction (iOS Safari blesses each HTMLAudioElement on its
+   * first gestured play; page-level interaction is not enough). Primes the
+   * static cue pool plus anything queued, except the queue head — the
+   * gesture-resume real-plays that one in the same handler. A rejected
+   * prime is retried on a later gesture.
+   */
+  private primeNarrationPool(): void {
+    const queued = this.audioQueue.map((q) => q.filename)
+    const head = queued[0]
+    let primed = 0
+    for (const filename of new Set([...KNOWN_NARRATION_FILES, ...queued])) {
+      if (this.primedFiles.has(filename) || filename === head) continue
+      try {
+        const el = this.getAudio(filename)
+        if (el === this.currentAudio) continue
+        el.muted = true
+        this.primedFiles.add(filename)
+        primed += 1
+        el.play()
+          .then(() => {
+            // Never yank an element that became the live cue meanwhile.
+            if (el !== this.currentAudio) {
+              el.pause()
+              el.currentTime = 0
+            }
+            el.muted = false
+          })
+          .catch(() => {
+            el.muted = false
+            this.primedFiles.delete(filename)
+          })
+      } catch {
+        /* priming is best-effort; the park-resume path still covers playback */
+      }
+    }
+    if (primed > 0) {
+      console.log(`[AudioService] Primed ${primed} narration file(s) during user gesture`)
     }
   }
 
@@ -333,6 +460,8 @@ class AudioService {
       }
       this.audioQueue = []
       this.isPlayingQueue = false
+      this.pendingGestureResume = false
+      this.currentAudio = null
     } catch (error) {
       console.warn('[AudioService] Error stopping all audio:', error)
     }
@@ -488,6 +617,8 @@ class AudioService {
     this.audioQueue = []
     this.stopAllNarration()
     this.isPlayingQueue = false
+    this.pendingGestureResume = false
+    this.currentAudio = null
     this.unduckBgm()
   }
 


### PR DESCRIPTION
## Player complaints (all replicated)

1. 苹果手机第一晚上还是没有声音。第二晚上有几个角色有声音
2. 第二局，安卓手机开的第一天，晚上也没有声音
3. 狼人闭眼的时候，狼人的手机发出了声音。苹果手机没有声音

## Root cause

Narration cues arrive via STOMP with **no qualifying user gesture**. Mobile autoplay policies (iOS Safari: per fresh `HTMLAudioElement`, regardless of page interaction history) reject the un-gestured `play()` with `NotAllowedError` — and `playNextInQueue` **consumed the queue item** on both failure paths (`!userInteracted` gate and the `play()` catch), so:

- an entire night of narration drained silently (complaint 1 night-1, complaint 2 after any reload/tab-discard) — `audioService.ts` old lines 254–275
- the first cue to arrive **after** a stray tap played out of context — e.g. `wolf_close_eyes` blaring from the wolf's phone right after they tapped to pick a victim (complaint 3); phones without a usable gesture (iPhones) stayed silent
- cues whose broadcast happened to land near a host tap played while the rest stayed blocked → "第二晚上有几个角色有声音"

BGM got exactly this retry-on-gesture fix in PR #119 (`bgmPendingStart`); narration never did.

## Why 5 audio-fix PRs and a heavy e2e audio suite never caught it

Two measured harness properties (see spec comments):
- Playwright pages are **pre-activated**: `navigator.userActivation.hasBeenActive === true` within ~500ms of commit — verified even on a plain backend JSON page, headed and headless.
- `page.evaluate` runs with CDP `userGesture: true`, granting sticky activation.

So every e2e run permanently satisfies Chromium's autoplay policy — the denied path was untestable by accident. The new Firefox spec uses `media.autoplay.blocking_policy=2` (play() must run inside an input handler — the same shape as iOS Safari's rule), which is immune to the activation grant.

## Replication evidence (pre-fix)

- Firefox strict policy: all 4 night-1 cues attempted → `NotAllowedError` ×4 → **queue drained to 0, elements never played, nothing pending**; one real tap later, the *next* cue (`wolf_close_eyes.mp3`) played while the dropped ones never returned — complaint 3's exact signature.
- Chromium (pristine page, no interaction): all 4 cues consumed by the `!userInteracted` gate; a later tap recovered nothing.

## Fix (all inside `audioService.ts`)

- **Park, don't drop**: blocked cues are un-shifted back and wait for a gesture (both failure paths). Non-autoplay errors (decode/missing file) still skip forward.
- **Gesture-resume**: the existing document interaction listener resumes the parked queue synchronously inside the input handler — the context iOS/Firefox require.
- **Pool priming**: gestures prime the 13 known narration files (muted `play()`+`pause()`), removing iOS's per-element restriction before cues ever arrive un-gestured. Every player taps 确认身份 before night 1, so all devices are blessed by the first cue. Best-effort; unknown files fall back to park-resume.
- **Stale-cue policy kept**: while parked, a newer sequence replaces the backlog (same never-replay-stale philosophy as the tab-resume drain); `stopAll`/`clearQueue` cancel pending resumes.

## Tests

- `src/__tests__/audioServiceAutoplayUnlock.test.ts` — 8 unit tests, written RED first (park/resume, NotAllowed retry, backlog replacement, muted priming + restore, no re-prime, prime retry, stopAll cancel).
- `e2e/real/audio-autoplay-unlock{,-firefox}.spec.ts` — browser-level regression net on both policy models. **Local-only (CI-skipped)**: needs headed browsers with real autoplay policies; CI's pre-activated headless-shell cannot exercise this class (reason documented in-spec).

## Verification

- `vitest`: 557/557 (incl. all pre-existing audioService/BGM suites unchanged)
- `vue-tsc -b --noEmit`: clean
- Real-E2E on a fresh e2e backend: `full-game-audio` (2-night chain, exact backend counts) and `guard-audio-sequence` green — the happy path is byte-identical because e2e pages always have `userInteracted=true` before night 1
- New unlock specs: Chromium parks 4/plays after tap; Firefox parks on real denial (0 `Failed to play` drops), gesture-plays the head, re-parks the tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)