### PR TITLE
fix(audio): stop pool priming leaking audible cues on iOS; surface tap-to-enable banner

### DIFF
--- a/frontend/e2e/real/audio-autoplay-unlock-firefox.spec.ts
+++ b/frontend/e2e/real/audio-autoplay-unlock-firefox.spec.ts
@@ -49,6 +49,9 @@ test('denied head is parked with the full sequence; a tap plays it in-gesture an
   )
   expect(parked.userInteracted).toBe(true)
   expect(parked.queueLen).toBe(NIGHT1_SEQUENCE.length)
+  // The player must be TOLD. Same banner as the Chromium half, but reached via
+  // a real browser NotAllowedError rather than our pre-interaction gate.
+  await expect(page.getByTestId('audio-unlock-banner')).toBeVisible({ timeout: 10_000 })
   expect(countIn(lines, 'Failed to play')).toBe(0)
   expect(parked.elements.every((e) => e.paused && e.currentTime === 0)).toBe(true)
 

--- a/frontend/e2e/real/audio-autoplay-unlock.spec.ts
+++ b/frontend/e2e/real/audio-autoplay-unlock.spec.ts
@@ -78,3 +78,24 @@ test('night sequence parks untouched, then plays through after one tap', async (
   expect(resumed.queueLen).toBe(NIGHT1_SEQUENCE.length - 1)
   expect(countIn(lines, 'narration file(s) during user gesture')).toBeGreaterThan(0)
 })
+
+/**
+ * The affordance half of the same bug. Parking a cue keeps it recoverable, but
+ * on a real iPhone (game 94) that was not enough: the host's tab reloaded, all
+ * eight cues of night 1 were blocked, and NOTHING on screen said a tap would
+ * fix it. A host narrating a night has no reason to tap, so the whole night
+ * passed in silence — and because a parked backlog is replaced rather than
+ * stacked, those cues were discarded, not merely delayed.
+ */
+test('parked narration surfaces the tap-to-enable banner until the first tap', async ({ page }) => {
+  await installTrigger(page, 'pristine')
+  await page.goto('/#unlock-repro')
+
+  const banner = page.getByTestId('audio-unlock-banner')
+  await expect(banner).toBeVisible({ timeout: 15_000 })
+
+  // Top-left, clear of the centred banner — any document-level gesture works.
+  await page.locator('body').click({ position: { x: 10, y: 10 }, force: true })
+
+  await expect(banner).toBeHidden({ timeout: 10_000 })
+})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,9 +1,18 @@
 <template>
   <RouterView />
   <VersionBadge />
+  <!--
+    Global on purpose: this is driven by audio-service state, not by route.
+    isAudioBlocked() only goes true once a cue has actually parked or a BGM
+    start has actually deferred, which cannot happen outside a game — so it
+    never shows spuriously in the lobby, and it survives the room -> game
+    transition without remounting.
+  -->
+  <AudioUnlockBanner />
 </template>
 
 <script lang="ts" setup>
 import { RouterView } from 'vue-router'
 import VersionBadge from '@/components/VersionBadge.vue'
+import AudioUnlockBanner from '@/components/AudioUnlockBanner.vue'
 </script>

--- a/frontend/src/__tests__/audioServiceAutoplayUnlock.test.ts
+++ b/frontend/src/__tests__/audioServiceAutoplayUnlock.test.ts
@@ -94,7 +94,14 @@ describe('audioService autoplay unlock', () => {
   beforeEach(async () => {
     localStorage.clear()
     mockAudioInstances = []
+    // mockClear() resets calls but NOT implementations, so a persistent
+    // mockImplementation from an earlier test (see "priming a rejected file
+    // retries") would otherwise leak into every test after it. Restore the
+    // default factory so each test is order-independent.
     ;(Audio as unknown as ReturnType<typeof vi.fn>).mockClear()
+    ;(Audio as unknown as ReturnType<typeof vi.fn>).mockImplementation(function (src: string) {
+      return createMockAudio(src ?? '')
+    })
     vi.resetModules()
     const mod = await import('@/services/audioService')
     audioService = mod.audioService
@@ -206,7 +213,7 @@ describe('audioService autoplay unlock', () => {
 
   // ── 3: gesture-time pool priming ─────────────────────────────────────────
 
-  it('primes the known narration pool muted on the first gesture and restores element state', async () => {
+  it('primes the known narration pool muted and leaves it muted so priming can never emit sound', async () => {
     fireGesture()
 
     expect(KNOWN_NARRATION_FILES.length).toBeGreaterThan(0)
@@ -221,7 +228,11 @@ describe('audioService autoplay unlock', () => {
     for (const file of KNOWN_NARRATION_FILES) {
       const el = instFor(file)!
       expect(el.pause).toHaveBeenCalled()
-      expect(el.muted).toBe(false)
+      // Regression (real iPhone, game 93): restoring muted=false straight after
+      // pause() let WebKit emit a fragment of every primed cue on each gesture —
+      // players heard guard_close_eyes in a game that had no Guard. Primed
+      // elements stay muted; playNextInQueue unmutes them for real playback.
+      expect(el.muted, `${file} must stay muted after priming`).toBe(true)
       expect(el.currentTime).toBe(0)
     }
   })
@@ -275,5 +286,59 @@ describe('audioService autoplay unlock', () => {
       (p: any) => (p.mock?.calls?.length ?? 0) === 0,
     )
     expect(audioService.isQueueActive()).toBe(false)
+  })
+
+  // ── 6: the blocked signal that drives AudioUnlockBanner ───────────────────
+  //
+  // Parked narration and a deferred BGM start are both silent AND invisible.
+  // On a real iPhone (game 94) a mid-game reload lost all 8 cues of night 1
+  // plus BGM, because a parked backlog is replaced by the next sequence rather
+  // than stacked — the cues were discarded, not merely delayed. The UI needs a
+  // subscribable signal so it can tell the player a single tap fixes it.
+
+  it('reports blocked while narration is parked and clears it on the resuming gesture', async () => {
+    const seen: boolean[] = []
+    const unsub = audioService.onAudioBlockedChange((b) => seen.push(b))
+
+    expect(audioService.isAudioBlocked()).toBe(false)
+
+    audioService.playSequential(['goes_dark_close_eyes.mp3'])
+    expect(audioService.isAudioBlocked()).toBe(true)
+
+    fireGesture()
+    await flush()
+    expect(audioService.isAudioBlocked()).toBe(false)
+
+    expect(seen).toEqual([true, false])
+    unsub()
+  })
+
+  it('reports blocked when a BGM start is deferred before the first gesture', () => {
+    expect(audioService.isAudioBlocked()).toBe(false)
+    audioService.startBgm('suspicion.mp3')
+    expect(audioService.isAudioBlocked()).toBe(true)
+  })
+
+  it('is edge-triggered — repeated parks do not re-notify', () => {
+    const seen: boolean[] = []
+    const unsub = audioService.onAudioBlockedChange((b) => seen.push(b))
+
+    audioService.playSequential(['a.mp3'])
+    audioService.playSequential(['b.mp3'])
+    audioService.playSequential(['c.mp3'])
+
+    expect(seen).toEqual([true])
+    unsub()
+  })
+
+  it('stops reporting blocked to an unsubscribed listener', () => {
+    const seen: boolean[] = []
+    const unsub = audioService.onAudioBlockedChange((b) => seen.push(b))
+    unsub()
+
+    audioService.playSequential(['a.mp3'])
+
+    expect(seen).toEqual([])
+    expect(audioService.isAudioBlocked()).toBe(true)
   })
 })

--- a/frontend/src/__tests__/audioUnlockBanner.test.ts
+++ b/frontend/src/__tests__/audioUnlockBanner.test.ts
@@ -1,0 +1,100 @@
+/**
+ * AudioUnlockBanner — the "silent night" affordance.
+ *
+ * Reproduced on a real iPhone (game 94, 2026-08-22): the host's tab was
+ * reloaded mid-game, so the fresh document had no user gesture. Every one of
+ * night 1's eight narration cues was blocked, and BGM never even attempted to
+ * start (`startBgm` bails on `!userInteracted` before calling play()). Nothing
+ * on screen said so. Worse than a delay: a parked backlog is REPLACED by the
+ * next sequence rather than stacked, so the night's cues were discarded — after
+ * finally tapping, the host heard only the daybreak pair.
+ *
+ * A host narrating a night has no reason to tap anything, which is precisely
+ * why the silence lasted a whole night and then "fixed itself" the next day.
+ * This banner is the missing signal that one tap is all it takes.
+ *
+ * Each test re-imports the service so `userInteracted` starts false — the
+ * singleton latches it to true for good on the first gesture.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import type { Component } from 'vue'
+
+const SEL = '[data-testid="audio-unlock-banner"]'
+
+let audioService: typeof import('@/services/audioService').audioService
+let AudioUnlockBanner: Component
+
+/** A real document-level click — the capture listener the service registers. */
+function gesture(): void {
+  document.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+}
+
+describe('AudioUnlockBanner', () => {
+  beforeEach(async () => {
+    localStorage.clear()
+    vi.resetModules()
+    audioService = (await import('@/services/audioService')).audioService
+    AudioUnlockBanner = (await import('@/components/AudioUnlockBanner.vue')).default
+  })
+
+  it('stays hidden while nothing is waiting on a gesture', () => {
+    const w = mount(AudioUnlockBanner)
+    expect(w.find(SEL).exists()).toBe(false)
+  })
+
+  it('appears when narration parks before the first gesture', async () => {
+    const w = mount(AudioUnlockBanner)
+    expect(w.find(SEL).exists()).toBe(false)
+
+    audioService.playSequential(['goes_dark_close_eyes.mp3', 'wolf_howl.mp3'])
+    await nextTick()
+
+    expect(w.find(SEL).exists()).toBe(true)
+  })
+
+  it('appears when a BGM start is deferred before the first gesture', async () => {
+    const w = mount(AudioUnlockBanner)
+
+    audioService.startBgm('suspicion.mp3')
+    await nextTick()
+
+    expect(w.find(SEL).exists()).toBe(true)
+  })
+
+  it('disappears once a user gesture releases the parked audio', async () => {
+    const w = mount(AudioUnlockBanner)
+    audioService.playSequential(['goes_dark_close_eyes.mp3'])
+    await nextTick()
+    expect(w.find(SEL).exists()).toBe(true)
+
+    gesture()
+    await nextTick()
+
+    expect(w.find(SEL).exists()).toBe(false)
+    expect(audioService.isAudioBlocked()).toBe(false)
+  })
+
+  it('mounts already-visible when audio was blocked before it rendered', async () => {
+    // Ordering guard: the banner is inside GameView, which mounts after the
+    // STOMP cue can already have arrived and parked.
+    audioService.playSequential(['wolf_howl.mp3'])
+    const w = mount(AudioUnlockBanner)
+    await nextTick()
+
+    expect(w.find(SEL).exists()).toBe(true)
+  })
+
+  it('unsubscribes on unmount so later state changes do not leak', async () => {
+    const w = mount(AudioUnlockBanner)
+    audioService.playSequential(['wolf_howl.mp3'])
+    await nextTick()
+    expect(w.find(SEL).exists()).toBe(true)
+
+    w.unmount()
+    gesture()
+
+    expect(audioService.isAudioBlocked()).toBe(false)
+  })
+})

--- a/frontend/src/components/AudioUnlockBanner.vue
+++ b/frontend/src/components/AudioUnlockBanner.vue
@@ -1,0 +1,103 @@
+<template>
+  <!--
+    Rendered as a real <button> for the 88px tap target and a11y, but it needs
+    no click handler: audioService's document-level capture listener runs on
+    click/touchstart/pointerdown before any component handler, primes the pool,
+    resumes the parked queue and fires the deferred BGM start. The banner then
+    unmounts itself when the subscription reports unblocked. Its whole job is
+    to tell the player that a tap is what's missing.
+  -->
+  <button v-if="blocked" type="button" class="aub-root" data-testid="audio-unlock-banner">
+    <span class="aub-icon" aria-hidden="true">🔇</span>
+    <span class="aub-text">点击任意处开启声音 / Tap anywhere to enable sound</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted, ref } from 'vue'
+import { audioService } from '@/services/audioService'
+
+/*
+ * "The night was silent and nobody knew why."
+ *
+ * Browsers refuse un-gestured playback, so on a document with no interaction
+ * yet — most commonly a mid-game reload, which iOS Safari does on its own to
+ * backgrounded tabs — narration parks and BGM defers. Neither is visible. Worse,
+ * a parked backlog is REPLACED by the next sequence rather than stacked, so the
+ * cues are not merely delayed, they are discarded: reproduced on a real iPhone
+ * (game 94), where a reloaded host lost all 8 cues of night 1 plus BGM and heard
+ * only the daybreak pair after finally tapping.
+ *
+ * A host narrating a night has no reason to tap anything, which is exactly why
+ * the silence persisted for a whole night and then "fixed itself" the next day.
+ */
+const blocked = ref(audioService.isAudioBlocked())
+
+const unsubscribeBlocked = audioService.onAudioBlockedChange((b) => {
+  blocked.value = b
+})
+
+onUnmounted(() => {
+  unsubscribeBlocked()
+})
+</script>
+
+<style scoped>
+/* Style C "Ink & Paper" — project tokens, readable over both the parchment
+   day background and the --ink night background. */
+.aub-root {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  top: calc(env(safe-area-inset-top, 0px) + 8px);
+  z-index: 60;
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  /* Touch target: >=88px wide, comfortable height per the UI guidelines. */
+  min-width: 88px;
+  min-height: 44px;
+  max-width: calc(100vw - 24px);
+  padding: 10px 16px;
+
+  background: var(--red);
+  color: #fff;
+  border: 1px solid var(--red);
+  border-radius: 999px;
+  box-shadow: 0 2px 10px rgb(0 0 0 / 25%);
+
+  font-size: 14px;
+  line-height: 1.2;
+  text-align: left;
+  cursor: pointer;
+
+  animation: aub-pulse 2s ease-in-out infinite;
+}
+
+.aub-icon {
+  font-size: 18px;
+  flex: 0 0 auto;
+}
+
+.aub-text {
+  flex: 1 1 auto;
+}
+
+@keyframes aub-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.72;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aub-root {
+    animation: none;
+  }
+}
+</style>

--- a/frontend/src/services/audioService.ts
+++ b/frontend/src/services/audioService.ts
@@ -75,7 +75,14 @@ class AudioService {
   private bgmBaseVolume = 0.5
   private bgmLevel: BgmLevel = 'LOW'
   private bgmNarrationActive = false
-  private bgmPendingStart: (() => void) | null = null
+  private _bgmPendingStart: (() => void) | null = null
+  private get bgmPendingStart(): (() => void) | null {
+    return this._bgmPendingStart
+  }
+  private set bgmPendingStart(v: (() => void) | null) {
+    this._bgmPendingStart = v
+    this.notifyAudioBlocked()
+  }
   private bgmTweenHandle: number | null = null
 
   constructor() {
@@ -99,7 +106,14 @@ class AudioService {
   private lastPlaybackStartTime = 0
   // Narration blocked by the autoplay policy waits here for a user gesture
   // (the narration counterpart of bgmPendingStart, PR #119).
-  private pendingGestureResume = false
+  private _pendingGestureResume = false
+  private get pendingGestureResume(): boolean {
+    return this._pendingGestureResume
+  }
+  private set pendingGestureResume(v: boolean) {
+    this._pendingGestureResume = v
+    this.notifyAudioBlocked()
+  }
   private primedFiles = new Set<string>()
   private currentAudio: HTMLAudioElement | null = null
 
@@ -391,10 +405,17 @@ class AudioService {
               el.pause()
               el.currentTime = 0
             }
-            el.muted = false
+            // Stay muted, deliberately. pause() does not guarantee WebKit has
+            // stopped emitting by the time the next statement runs, so
+            // restoring muted=false here leaked an audible fragment of every
+            // primed cue on each gesture — on a real iPhone (game 93) players
+            // heard guard_close_eyes in a game that had no Guard, and day cues
+            // in the middle of the night. A permanently muted element cannot
+            // make sound whichever way that race falls. Nothing audible
+            // depends on this: playNextInQueue unmutes before real playback,
+            // and it is the only path that plays a cached narration element.
           })
           .catch(() => {
-            el.muted = false
             this.primedFiles.delete(filename)
           })
       } catch {
@@ -585,6 +606,39 @@ class AudioService {
 
   private notifyMuteListeners(): void {
     for (const fn of this.muteListeners) fn(this.muted)
+  }
+
+  // Audio-blocked subscription. Narration parked by the autoplay policy and a
+  // deferred BGM start are both invisible to the player: cues queue up, get
+  // discarded by the next sequence, and the night passes in silence with no UI
+  // hint that one tap would fix it (reproduced on a real iPhone, game 94 — a
+  // reloaded tab lost every cue of night 1 plus BGM). Both flags are private
+  // accessors so every existing assignment funnels through notifyAudioBlocked
+  // and no mutation site can be missed.
+  private blockedListeners = new Set<(blocked: boolean) => void>()
+  private lastBlocked = false
+
+  /** True while any audio is waiting on a user gesture to start. */
+  isAudioBlocked(): boolean {
+    return this._pendingGestureResume || this._bgmPendingStart !== null
+  }
+
+  onAudioBlockedChange(listener: (blocked: boolean) => void): () => void {
+    this.blockedListeners.add(listener)
+    return () => {
+      this.blockedListeners.delete(listener)
+    }
+  }
+
+  /** Edge-triggered: fires only when the blocked state actually flips. */
+  private notifyAudioBlocked(): void {
+    // Guard construction-order: the accessors above can fire before the class
+    // fields down here are initialised.
+    if (!this.blockedListeners) return
+    const blocked = this.isAudioBlocked()
+    if (blocked === this.lastBlocked) return
+    this.lastBlocked = blocked
+    for (const fn of this.blockedListeners) fn(blocked)
   }
 
   /**
@@ -814,6 +868,37 @@ class AudioService {
       filename: this.bgmFilename,
       userInteracted: this.userInteracted,
       pendingStart: !!this.bgmPendingStart,
+    }
+  }
+
+  /**
+   * Diagnostics snapshot of the narration queue — the counterpart to
+   * [getBgmState]. Narration state lives in private fields, so a console or an
+   * e2e helper can otherwise only reach it through `as any`. These are exactly
+   * the fields that separate "muted" from "parked by the autoplay policy" from
+   * "the cue never arrived".
+   */
+  getNarrationState(): {
+    muted: boolean
+    userInteracted: boolean
+    isPlayingQueue: boolean
+    pendingGestureResume: boolean
+    queue: string[]
+    primed: string[]
+    cached: string[]
+    msSinceLastStart: number | null
+  } {
+    return {
+      muted: this.muted,
+      userInteracted: this.userInteracted,
+      isPlayingQueue: this.isPlayingQueue,
+      pendingGestureResume: this.pendingGestureResume,
+      queue: this.audioQueue.map((q) => q.filename),
+      primed: [...this.primedFiles],
+      cached: [...this.audioCache.keys()],
+      msSinceLastStart: this.lastPlaybackStartTime
+        ? Math.round(performance.now() - this.lastPlaybackStartTime)
+        : null,
     }
   }
 


### PR DESCRIPTION
Two client-side audio defects, both found by reproducing the "mobile night 1 is silent" report on a **real iPhone** against a LAN dev stack. Backend cue delivery was verified correct throughout — every cue was broadcast on schedule.

Worth stating up front: the original report that started this was **not a bug at all** — the iPhone was routing audio to a Bluetooth device. But chasing it surfaced these two.

## 1. `primeNarrationPool()` emitted audible narration on every gesture

PR #140's priming played each pooled element muted, then in `.then()` did `pause()` → `currentTime = 0` → **`muted = false`**. `pause()` does not guarantee WebKit has stopped emitting by the time the next statement runs, so unmuting there let all 13 elements leak a fragment simultaneously. It recurred on *every* gesture because `.catch()` un-primes rejected files, and iOS caps concurrent media so some always reject and retry.

Observed on device: a jumble on "Start Game" (`wolf_howl` + `rooster_crowing`), another on "run for sheriff" (`seer_close_eyes` + `guard_close_eyes`), another on "next speaker".

**The proof it was client-side:** `guard_close_eyes.mp3` played in a game with **no Guard** (roles `WEREWOLF/VILLAGER/SEER/WITCH/HUNTER`, `has_guard=false`). The server can never broadcast that cue, and the backend log confirmed zero such broadcasts. A cue that is in `KNOWN_NARRATION_FILES` but impossible for the current game config is a clean client-origin oracle.

This is worse than silence — it actively lies to players, announcing roles that aren't in the game and day cues in the middle of the night. It is shipping in **v0.8.3**.

**Fix — two deleted lines.** Drop both `muted = false` restores; primed elements stay muted. A permanently muted element cannot make sound however that race falls, so this removes the failure class rather than one instance of it. Safe because `playNextInQueue` already unmutes before real playback (`audioService.ts:289`) and is the only path that plays a cached narration element — BGM uses a separate `bgmAudioEl` under volume control.

The pre-existing unit test asserted the *bug* (`expect(el.muted).toBe(false)` after priming); flipping it to `toBe(true)` is the regression test.

## 2. A document with no user gesture loses an entire night, silently

Reproduced end to end with the iPhone as host and 8 bot seats driven over HTTP, so the phone never had to be touched: the tab was reloaded mid-game, and **all 8 night-1 cues plus BGM were silent for the whole night**, with nothing on screen to say why.

Worse than a delay — a parked backlog is **replaced** by the next sequence rather than stacked, so those cues were *discarded*. After finally tapping, the host heard only the daybreak pair (`rooster_crowing`, `day_time`), never the wolf/witch/seer cues.

This explains the original "night 1 silent, later nights partly work" report exactly: iOS Safari discards backgrounded tabs, a host narrating a night has no reason to tap anything, and the moment they tap on the next day `userInteracted` latches true for the life of the document.

**Fix:** `AudioUnlockBanner`, driven by a new `audioService.onAudioBlockedChange` subscription. Both blocking flags (`pendingGestureResume`, `bgmPendingStart`) become private getter/setter pairs, so **every existing assignment funnels through the notifier** and no mutation site can be missed — no call sites changed.

Mounted in `App.vue`, not `GameView`: it is driven by audio state rather than route, `isAudioBlocked()` can only be true once something has actually parked or deferred (so it never shows in the lobby), and it survives the room → game transition.

## Test coverage

| Layer | Runs in CI | Covers |
|---|---|---|
| `audioServiceAutoplayUnlock.test.ts` (+4) | ✅ | blocked signal on park/defer, cleared on gesture, edge-triggered, unsubscribe |
| `audioUnlockBanner.test.ts` (new, 6) | ✅ | banner shows/hides, mounts already-visible, unsubscribes on unmount |
| `audio-autoplay-unlock.spec.ts` (+1) | ❌ local-only | banner under headed Chromium `--autoplay-policy=user-gesture-required` |
| `audio-autoplay-unlock-firefox.spec.ts` (+1 assert) | ❌ local-only | banner under a real `NotAllowedError` (`media.autoplay.blocking_policy=2`) |

**Note on e2e:** both autoplay specs are `test.skip(!!process.env.CI)` — they need a headed browser with a real autoplay policy, because CI's headless-shell pre-activates every page (the exact condition that hid this bug from every e2e run). So the CI-enforcing gate here is the unit/component layer; the e2e specs are a local gate. Both were run locally and pass.

Also hardened the autoplay suite's `beforeEach`: `mockClear()` resets calls but **not** implementations, so a persistent `mockImplementation` from one test leaked into every test after it, making them order-dependent. Caught because it made a new test fail for the wrong reason.

## Verification

- 582 unit tests / 55 files pass (10 new)
- `vue-tsc -b --force` exit 0
- `eslint src` 0 errors, `prettier --check src` clean
- Both e2e specs run and pass locally (headed Chromium + headed Firefox)
- Priming fix **verified on the real iPhone**: cues now play sequentially with no jumble, where the previous build produced overlapping fragments on every single gesture

## Verified on the real iPhone

Confirmed end to end on device (game 95) — banner absent during role-reveal, appearing the instant the first cue was blocked, clearing on tap with audio and BGM resuming cleanly, and never returning for the rest of the night. Full protocol and results in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

